### PR TITLE
Feature/#5 Photo 테이블을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
@@ -16,13 +16,13 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
+import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
 import org.dinosaur.foodbowl.global.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "member")
-@EqualsAndHashCode(of = {"id"})
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/MemberRole.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/MemberRole.java
@@ -19,7 +19,7 @@ import org.dinosaur.foodbowl.global.entity.BaseEntity;
 @Getter
 @Entity
 @Table(name = "member_role")
-@EqualsAndHashCode(of = {"id"})
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberRole extends BaseEntity {
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Photo.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Photo.java
@@ -33,7 +33,7 @@ public class Photo extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @Column(name = "path", nullable = false)
+    @Column(name = "path", nullable = false, length = 512)
     private String path;
 
     @Builder

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Photo.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Photo.java
@@ -1,0 +1,44 @@
+package org.dinosaur.foodbowl.domain.photo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.post.entity.Post;
+import org.dinosaur.foodbowl.global.entity.BaseEntity;
+
+@Getter
+@Entity
+@Table(name = "photo")
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Photo extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(name = "path", nullable = false)
+    private String path;
+
+    @Builder
+    private Photo(Post post, String path) {
+        this.post = post;
+        this.path = path;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Thumbnail.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Thumbnail.java
@@ -1,0 +1,20 @@
+package org.dinosaur.foodbowl.domain.photo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "thumbnail")
+public class Thumbnail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Thumbnail.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Thumbnail.java
@@ -6,15 +6,38 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.global.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "thumbnail")
-public class Thumbnail {
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Thumbnail extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Long id;
+
+    @Column(name = "path", nullable = false, length = 512)
+    private String path;
+
+    @Column(name = "width", nullable = false)
+    private Integer width;
+
+    @Column(name = "height", nullable = false)
+    private Integer height;
+
+    @Builder
+    private Thumbnail(String path, Integer width, Integer height) {
+        this.path = path;
+        this.width = width;
+        this.height = height;
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/repository/PhotoRepository.java
@@ -1,0 +1,7 @@
+package org.dinosaur.foodbowl.domain.photo.repository;
+
+import org.dinosaur.foodbowl.domain.photo.entity.Photo;
+import org.springframework.data.repository.Repository;
+
+public interface PhotoRepository extends Repository<Photo, Long> {
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/repository/ThumbnailRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/repository/ThumbnailRepository.java
@@ -1,0 +1,7 @@
+package org.dinosaur.foodbowl.domain.photo.repository;
+
+import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
+import org.springframework.data.repository.Repository;
+
+public interface ThumbnailRepository extends Repository<Thumbnail, Long> {
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -1,4 +1,4 @@
-package org.dinosaur.foodbowl.domain.thumbnail.entity;
+package org.dinosaur.foodbowl.domain.post.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -6,12 +6,18 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.global.entity.BaseEntity;
 
 @Getter
 @Entity
-@Table(name = "thumbnail")
-public class Thumbnail {
+@Table(name = "post")
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 🔥 연관 이슈

close: #5

## 📝 작업 요약

사진과 썸네일의 엔티티와 레포지토리를 구현하였습니다.

## 🔎 작업 상세 설명

- 이전과 동일하게 엔티티와 레포지토리를 구현하였습니다.
- 연관관계를 위해 임시로 `Post` 엔티티를 구현하였습니다.

## 🌟 리뷰 요구 사항

> 10분
