### PR TITLE
Feature/#22 Member 테이블에 선호 지역을 추가한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/FoodbowlApplication.java
+++ b/src/main/java/org/dinosaur/foodbowl/FoodbowlApplication.java
@@ -2,7 +2,9 @@ package org.dinosaur.foodbowl;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class FoodbowlApplication {
 

--- a/src/main/java/org/dinosaur/foodbowl/FoodbowlApplication.java
+++ b/src/main/java/org/dinosaur/foodbowl/FoodbowlApplication.java
@@ -2,9 +2,7 @@ package org.dinosaur.foodbowl;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class FoodbowlApplication {
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/entity/Blame.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/entity/Blame.java
@@ -1,16 +1,7 @@
 package org.dinosaur.foodbowl.domain.blame.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -27,18 +18,21 @@ public class Blame extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, updatable = false)
+    @Column(name = "id", updatable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    @NotNull
+    @JoinColumn(name = "member_id", updatable = false)
     private Member member;
 
-    @Column(name = "target_id", nullable = false, updatable = false)
+    @NotNull
+    @Column(name = "target_id", updatable = false)
     private Long targetId;
 
     @Enumerated(value = EnumType.ORDINAL)
-    @Column(name = "target_type", nullable = false, updatable = false)
+    @NotNull
+    @Column(name = "target_type", updatable = false)
     private BlameTarget blameTarget;
 
     public enum BlameTarget {

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
@@ -70,6 +70,6 @@ public class Member extends BaseEntity {
 
     public enum SocialType {
 
-        APPLE;
+        APPLE
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
@@ -1,21 +1,7 @@
 package org.dinosaur.foodbowl.domain.member.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
 import org.dinosaur.foodbowl.global.entity.BaseEntity;
 
@@ -51,6 +37,12 @@ public class Member extends BaseEntity {
     @Column(name = "introduction", length = 255)
     private String introduction;
 
+    @Column(name = "region_1depth_name", length = 45)
+    private String region1depthName;
+
+    @Column(name = "region_2depth_name", length = 45)
+    private String region2depthName;
+
     @Builder
     private Member(
             Thumbnail thumbnail,
@@ -58,7 +50,9 @@ public class Member extends BaseEntity {
             String socialId,
             String email,
             String nickname,
-            String introduction
+            String introduction,
+            String region1depthName,
+            String region2depthName
     ) {
         this.thumbnail = thumbnail;
         this.socialType = socialType;
@@ -66,6 +60,8 @@ public class Member extends BaseEntity {
         this.email = email;
         this.nickname = nickname;
         this.introduction = introduction;
+        this.region1depthName = region1depthName;
+        this.region2depthName = region2depthName;
     }
 
     public enum SocialType {

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package org.dinosaur.foodbowl.domain.member.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
 import org.dinosaur.foodbowl.global.entity.BaseEntity;
@@ -14,7 +15,7 @@ public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, updatable = false)
+    @Column(name = "id", updatable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -22,16 +23,19 @@ public class Member extends BaseEntity {
     private Thumbnail thumbnail;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "social_type", nullable = false, updatable = false, length = 45)
+    @NotNull
+    @Column(name = "social_type", updatable = false, length = 45)
     private SocialType socialType;
 
-    @Column(name = "social_id", nullable = false, updatable = false, length = 512)
+    @NotNull
+    @Column(name = "social_id", updatable = false, length = 512)
     private String socialId;
 
     @Column(name = "email", length = 255)
     private String email;
 
-    @Column(name = "nickname", nullable = false, length = 45)
+    @NotNull
+    @Column(name = "nickname", length = 45)
     private String nickname;
 
     @Column(name = "introduction", length = 255)

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/MemberRole.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/MemberRole.java
@@ -1,19 +1,8 @@
 package org.dinosaur.foodbowl.domain.member.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 import org.dinosaur.foodbowl.global.entity.BaseEntity;
 
 @Getter
@@ -25,15 +14,17 @@ public class MemberRole extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, updatable = false)
+    @Column(name = "id", updatable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @NotNull
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "role_id", nullable = false)
+    @NotNull
+    @JoinColumn(name = "role_id")
     private Role role;
 
     @Builder

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Role.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Role.java
@@ -36,8 +36,7 @@ public class Role {
     public enum RoleType {
 
         ROLE_회원(1L),
-        ROLE_관리자(2L),
-        ;
+        ROLE_관리자(2L);
 
         private final Long id;
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Role.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Role.java
@@ -1,13 +1,7 @@
 package org.dinosaur.foodbowl.domain.member.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -22,11 +16,12 @@ public class Role {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, updatable = false)
+    @Column(name = "id", updatable = false)
     private Long id;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "name", nullable = false, updatable = false, unique = true, length = 45)
+    @NotNull
+    @Column(name = "name", updatable = false, unique = true, length = 45)
     private RoleType roleType;
 
     private Role(Long id, RoleType roleType) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Photo.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Photo.java
@@ -1,19 +1,8 @@
 package org.dinosaur.foodbowl.domain.photo.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.dinosaur.foodbowl.global.entity.BaseEntity;
 
@@ -26,14 +15,16 @@ public class Photo extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, updatable = false)
+    @Column(name = "id", updatable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
+    @NotNull
+    @JoinColumn(name = "post_id")
     private Post post;
 
-    @Column(name = "path", nullable = false, length = 512)
+    @NotNull
+    @Column(name = "path", length = 512)
     private String path;
 
     @Builder

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Thumbnail.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Thumbnail.java
@@ -1,16 +1,8 @@
 package org.dinosaur.foodbowl.domain.photo.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 import org.dinosaur.foodbowl.global.entity.BaseEntity;
 
 @Getter
@@ -22,16 +14,19 @@ public class Thumbnail extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, updatable = false)
+    @Column(name = "id", updatable = false)
     private Long id;
 
-    @Column(name = "path", nullable = false, length = 512)
+    @NotNull
+    @Column(name = "path", length = 512)
     private String path;
 
-    @Column(name = "width", nullable = false)
+    @NotNull
+    @Column(name = "width")
     private Integer width;
 
-    @Column(name = "height", nullable = false)
+    @NotNull
+    @Column(name = "height")
     private Integer height;
 
     @Builder

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -1,11 +1,6 @@
 package org.dinosaur.foodbowl.domain.post.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -21,6 +16,6 @@ public class Post extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, updatable = false)
+    @Column(name = "id", updatable = false)
     private Long id;
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/entity/BaseEntity.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/entity/BaseEntity.java
@@ -3,15 +3,16 @@ package org.dinosaur.foodbowl.global.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
+
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)


### PR DESCRIPTION
## 🔥 연관 이슈

close: #22

## 📝 작업 요약

멤버 테이블 선호 지역 추가로 인해 엔티티를 수정하였습니다.

## 🔎 작업 상세 설명

- 멤버 테이블 선호 지역을 엔티티에 추가하였습니다.
- `BaseEntity`를 추상 클래스로 수정하였습니다.
- `@Id`, `@NotNull` 어노테이션을 활용하도록 수정하였습니다.

## 🌟 리뷰 요구 사항

> 5분
