### PR TITLE
Feature/#2 Follow 테이블을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/entity/Follow.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/entity/Follow.java
@@ -1,0 +1,49 @@
+package org.dinosaur.foodbowl.domain.follow.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.member.entity.Member;
+import org.dinosaur.foodbowl.global.entity.BaseEntity;
+
+@Getter
+@Entity
+@Table(name = "follow")
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "following_id")
+    private Member following;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "follower_id")
+    private Member follower;
+
+    @Builder
+    private Follow(Member following, Member follower) {
+        this.following = following;
+        this.follower = follower;
+    }
+}
+

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,7 @@
+package org.dinosaur.foodbowl.domain.follow.repository;
+
+import org.dinosaur.foodbowl.domain.follow.entity.Follow;
+import org.springframework.data.repository.Repository;
+
+public interface FollowRepository extends Repository<Follow, Long> {
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #2

## 📝 작업 요약

Follow(팔로우) 테이블 설계.

## 🔎 작업 상세 설명

- 팔로우 관계를 위한 `Follow` 엔티티를 구현하였습니다.
- follow 관계를 표현하기 위해 follower following을 `@ManyToOne` 연관관계로 설정하였습니다.
- `@ManyToOne` 연관관계의 페치 타입을 Lazy로 설정하였습니다.

## 🌟 리뷰 요구 사항

> 10분
