### PR TITLE
Feature/#8 Bookmark 테이블을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/entity/Bookmark.java
@@ -42,7 +42,7 @@ public class Bookmark extends BaseEntity {
     private Post post;
 
     @Builder
-    public Bookmark(Member member, Post post) {
+    private Bookmark(Member member, Post post) {
         this.member = member;
         this.post = post;
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/entity/Bookmark.java
@@ -1,0 +1,49 @@
+package org.dinosaur.foodbowl.domain.bookmark.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.member.entity.Member;
+import org.dinosaur.foodbowl.domain.post.entity.Post;
+import org.dinosaur.foodbowl.global.entity.BaseEntity;
+
+@Getter
+@Entity
+@Table(name = "bookmark")
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bookmark extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Builder
+    public Bookmark(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package org.dinosaur.foodbowl.domain.bookmark.repository;
+
+import org.dinosaur.foodbowl.domain.bookmark.entity.Bookmark;
+import org.springframework.data.repository.Repository;
+
+public interface BookmarkRepository extends Repository<Bookmark, Long> {
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #8 

## 📝 작업 요약

Bookmark(북마크) 테이블 설계

## 🔎 작업 상세 설명

- 멤버가 포스트에 북마크 설정을 위한 Bookmark 엔티티를 구현하였습니다.
- 멤버와 포스트의 `N:N` 관계를 `N:1`로 풀기위해 중간 테이블인 Bookmark 테이블을 설계하였습니다.
- `@ManyToOne` 연관관계의 페치 타입을 Lazy로 설정하였습니다.

## 🌟 리뷰 요구 사항

> 5분
