### PR TITLE
Feature/#3 Post 테이블을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Category.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Category.java
@@ -4,8 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -22,13 +20,12 @@ import lombok.NoArgsConstructor;
 public class Category {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", updatable = false)
     private Long id;
 
     @Enumerated(EnumType.STRING)
     @NotNull
-    @Column(name = "name", length = 45)
+    @Column(name = "name", unique = true, length = 45)
     private CategoryType categoryType;
 
     private Category(Long id, CategoryType categoryType) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Category.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Category.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -20,6 +22,7 @@ import lombok.NoArgsConstructor;
 public class Category {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", updatable = false)
     private Long id;
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Category.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Category.java
@@ -1,0 +1,66 @@
+package org.dinosaur.foodbowl.domain.post.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "category")
+@EqualsAndHashCode(of = {"id", "categoryType"}, callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(name = "name", length = 45)
+    private CategoryType categoryType;
+
+    private Category(Long id, CategoryType categoryType) {
+        this.id = id;
+        this.categoryType = categoryType;
+    }
+
+    public static Category from(CategoryType categoryType) {
+        return new Category(categoryType.id, categoryType);
+    }
+
+    public enum CategoryType {
+
+        전체(1L),
+        카페(2L),
+        한식(3L),
+        양식(4L),
+        일식(5L),
+        중식(6L),
+        치킨(7L),
+        분식(8L),
+        해산물(9L),
+        샐러드(10L);
+
+        private final Long id;
+
+        CategoryType(final Long id) {
+            this.id = id;
+        }
+
+        public Long getId() {
+            return id;
+        }
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -52,11 +52,11 @@ public class Post extends BaseEntity {
     private Store store;
 
     @NotNull
-    @Column(name = "content", length = 4000)
+    @Column(name = "content", length = 2000)
     private String content;
 
-    @NotNull
     @LastModifiedDate
+    @NotNull
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -35,7 +36,7 @@ public class Post extends BaseEntity {
     @Column(name = "id", updatable = false)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @NotNull
     @JoinColumn(name = "member_id")
     private Member member;
@@ -45,7 +46,7 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "thumbnail_id")
     private Thumbnail thumbnail;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @NotNull
     @JoinColumn(name = "store_id")
     private Store store;

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -2,14 +2,24 @@ package org.dinosaur.foodbowl.domain.post.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.member.entity.Member;
+import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
+import org.dinosaur.foodbowl.domain.store.entity.Store;
 import org.dinosaur.foodbowl.global.entity.BaseEntity;
 
 @Getter
@@ -21,6 +31,39 @@ public class Post extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, updatable = false)
+    @Column(name = "id", updatable = false)
     private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "thumbnail_id")
+    private Thumbnail thumbnail;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @NotNull
+    @Lob
+    @Column(name = "content")
+    private String content;
+
+    @NotNull
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private Post(Member member, Thumbnail thumbnail, Store store, String content) {
+        this.member = member;
+        this.thumbnail = thumbnail;
+        this.store = store;
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -23,6 +22,7 @@ import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
 import org.dinosaur.foodbowl.domain.store.entity.Store;
 import org.dinosaur.foodbowl.global.entity.BaseEntity;
+import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Entity
@@ -52,11 +52,11 @@ public class Post extends BaseEntity {
     private Store store;
 
     @NotNull
-    @Lob
-    @Column(name = "content")
+    @Column(name = "content", length = 2000)
     private String content;
 
     @NotNull
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
@@ -66,6 +66,5 @@ public class Post extends BaseEntity {
         this.thumbnail = thumbnail;
         this.store = store;
         this.content = content;
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -1,5 +1,6 @@
 package org.dinosaur.foodbowl.domain.post.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -39,7 +40,7 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @NotNull
     @JoinColumn(name = "thumbnail_id")
     private Thumbnail thumbnail;

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -52,7 +52,7 @@ public class Post extends BaseEntity {
     private Store store;
 
     @NotNull
-    @Column(name = "content", length = 2000)
+    @Column(name = "content", length = 4000)
     private String content;
 
     @NotNull

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/PostCategory.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/PostCategory.java
@@ -1,5 +1,6 @@
 package org.dinosaur.foodbowl.domain.post.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -25,6 +26,7 @@ public class PostCategory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/PostCategory.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/PostCategory.java
@@ -1,0 +1,45 @@
+package org.dinosaur.foodbowl.domain.post.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.global.entity.BaseEntity;
+
+@Getter
+@Entity
+@Table(name = "post_category")
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Builder
+    private PostCategory(Post post, Category category) {
+        this.post = post;
+        this.category = category;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/repository/CategoryRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/repository/CategoryRepository.java
@@ -2,11 +2,9 @@ package org.dinosaur.foodbowl.domain.post.repository;
 
 import java.util.List;
 import org.dinosaur.foodbowl.domain.post.entity.Category;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface CategoryRepository extends Repository<Category, Long> {
 
-    @Query(value = "select * from Category ORDER BY id ASC", nativeQuery = true)
-    List<Category> findAll();
+    List<Category> findAllByOrderById();
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/repository/CategoryRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package org.dinosaur.foodbowl.domain.post.repository;
+
+import java.util.List;
+import org.dinosaur.foodbowl.domain.post.entity.Category;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+public interface CategoryRepository extends Repository<Category, Long> {
+
+    @Query(value = "select * from Category ORDER BY id ASC", nativeQuery = true)
+    List<Category> findAll();
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostCategoryRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostCategoryRepository.java
@@ -1,0 +1,7 @@
+package org.dinosaur.foodbowl.domain.post.repository;
+
+import org.dinosaur.foodbowl.domain.post.entity.PostCategory;
+import org.springframework.data.repository.Repository;
+
+public interface PostCategoryRepository extends Repository<PostCategory, Long> {
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package org.dinosaur.foodbowl.domain.post.repository;
+
+import org.dinosaur.foodbowl.domain.post.entity.Post;
+import org.springframework.data.repository.Repository;
+
+public interface PostRepository extends Repository<Post, Long> {
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/category/entity/CategoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/category/entity/CategoryTest.java
@@ -25,7 +25,7 @@ class CategoryTest extends RepositoryTest {
                 .map(Category::from)
                 .collect(Collectors.toList());
 
-        List<Category> dbCategories = categoryRepository.findAll();
+        List<Category> dbCategories = categoryRepository.findAllByOrderById();
 
         assertThat(dbCategories).isEqualTo(categories);
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/category/entity/CategoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/category/entity/CategoryTest.java
@@ -1,0 +1,32 @@
+package org.dinosaur.foodbowl.domain.category.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.dinosaur.foodbowl.RepositoryTest;
+import org.dinosaur.foodbowl.domain.post.entity.Category;
+import org.dinosaur.foodbowl.domain.post.entity.Category.CategoryType;
+import org.dinosaur.foodbowl.domain.post.repository.CategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CategoryTest extends RepositoryTest {
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Test
+    @DisplayName("DB에 저장된 카테고리와 일치한다.")
+    void hasSameCategoryWithDB() {
+        List<Category> categories = Arrays.stream(CategoryType.values())
+                .map(Category::from)
+                .collect(Collectors.toList());
+
+        List<Category> dbCategories = categoryRepository.findAll();
+
+        assertThat(dbCategories).isEqualTo(categories);
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #3

## 📝 작업 요약

- 카테고리 엔티티 생성
- 게시글 엔티티 생성
- 게시글 - 카테고리 매핑 엔티티 생성

## 🔎 작업 상세 설명

- @ManyToOne Lazy 로딩 설정
- Post의 Thumbnail cascade 설정
- category가 unique 인덱스 기준으로 오름차순으로 DB에 정렬되어, ID 기준으로 정렬해서 가져오는 메서드를 추가했습니다.

## 🌟 리뷰 요구 사항

> 10분
