### PR TITLE
Feature/#10 애플 로그인 기능을 구현한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2022.0.2")
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 

--- a/src/docs/asciidoc/auth/auth.adoc
+++ b/src/docs/asciidoc/auth/auth.adoc
@@ -1,0 +1,36 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= USER API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../foodbowl.html[API 목록으로 돌아가기]
+
+== *애플 로그인* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-apple-login/http-request.adoc[]
+
+=== Request Fields
+
+include::{snippets}/api-v1-apple-login/request-fields.adoc[]
+
+== 응답
+
+=== Response
+
+include::{snippets}/api-v1-apple-login/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/api-v1-apple-login/response-fields.adoc[]

--- a/src/docs/asciidoc/auth/auth.adoc
+++ b/src/docs/asciidoc/auth/auth.adoc
@@ -34,3 +34,7 @@ include::{snippets}/api-v1-apple-login/http-response.adoc[]
 === Response Fields
 
 include::{snippets}/api-v1-apple-login/response-fields.adoc[]
+
+=== Response Cookies
+
+include::{snippets}/api-v1-apple-login/response-cookies.adoc[]

--- a/src/docs/asciidoc/foodbowl.adoc
+++ b/src/docs/asciidoc/foodbowl.adoc
@@ -9,22 +9,10 @@ endif::[]
 :toclevels: 1
 :sectlinks:
 
-== *Health Check*
+== *Health Check* ==
 
-헬스 체크시 확인할 수 있는 응답 형식을 제공합니다.
+link:health_check/health_check.html[API 문서 보기]
 
-=== 요청
+== *Auth*
 
-=== Request
-
-include::{snippets}/api-v1-health-check/http-request.adoc[]
-
-=== 응답
-
-=== Response
-
-include::{snippets}/api-v1-health-check/http-response.adoc[]
-
-=== Response Fields
-
-include::{snippets}/api-v1-health-check/response-fields.adoc[]
+link:auth/auth.html[API 문서 보기]

--- a/src/docs/asciidoc/health_check/health_check.adoc
+++ b/src/docs/asciidoc/health_check/health_check.adoc
@@ -1,0 +1,34 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= USER API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../foodbowl.html[API 목록으로 돌아가기]
+
+== *Health Check*
+
+헬스 체크시 확인할 수 있는 응답 형식을 제공합니다.
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-health-check/http-request.adoc[]
+
+=== 응답
+
+=== Response
+
+include::{snippets}/api-v1-health-check/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/api-v1-health-check/response-fields.adoc[]

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -1,10 +1,14 @@
 package org.dinosaur.foodbowl.domain.auth.api;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
+import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
 import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,10 +21,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/apple/login")
-    public ResponseEntity<AppleTokenResponseDto> appleLogin(@Valid @RequestBody AppleLoginRequestDto request) {
-        AppleTokenResponseDto response = authService.appleLogin(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<AppleTokenResponseDto> appleLogin(
+            @Valid @RequestBody AppleLoginRequestDto request,
+            HttpServletResponse response
+    ) {
+        FoodbowlTokenDto foodbowlTokenDto = authService.appleLogin(request);
+        registerRefreshCookie(response, foodbowlTokenDto.getRefreshToken());
+        return ResponseEntity.ok(new AppleTokenResponseDto(foodbowlTokenDto.getAccessToken()));
+    }
+
+    private void registerRefreshCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge((int) jwtTokenProvider.getValidRefreshMilliSecond() / 1000);
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/auth")
 @RestController
 public class AuthController {
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -6,8 +6,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
-import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
-import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponse;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,13 +24,13 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/apple/login")
-    public ResponseEntity<AppleTokenResponseDto> appleLogin(
-            @Valid @RequestBody AppleLoginRequestDto request,
+    public ResponseEntity<AppleTokenResponse> appleLogin(
+            @Valid @RequestBody AppleLoginRequest request,
             HttpServletResponse response
     ) {
         FoodbowlTokenDto foodbowlTokenDto = authService.appleLogin(request);
         registerRefreshCookie(response, foodbowlTokenDto.getRefreshToken());
-        return ResponseEntity.ok(new AppleTokenResponseDto(foodbowlTokenDto.getAccessToken()));
+        return ResponseEntity.ok(new AppleTokenResponse(foodbowlTokenDto.getAccessToken()));
     }
 
     private void registerRefreshCookie(HttpServletResponse response, String refreshToken) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -1,0 +1,26 @@
+package org.dinosaur.foodbowl.domain.auth.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.auth.application.AuthService;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
+import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/apple/login")
+    public ResponseEntity<AppleTokenResponseDto> appleLogin(@Valid @RequestBody AppleLoginRequestDto request) {
+        AppleTokenResponseDto response = authService.appleLogin(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClaimsValidator.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClaimsValidator.java
@@ -1,0 +1,31 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleClaimsValidator {
+
+    private static final String NONCE_KEY = "nonce";
+
+    private final String iss;
+    private final String clientId;
+    private final String nonce;
+
+    public AppleClaimsValidator(
+            @Value("${oauth.apple.iss}") String iss,
+            @Value("${oauth.apple.client-id}") String clientId,
+            @Value("${oauth.apple.nonce}") String nonce
+    ) {
+        this.iss = iss;
+        this.clientId = clientId;
+        this.nonce = nonce;
+    }
+
+    public boolean isValid(Claims claims) {
+        return claims.getIssuer().contains(iss) &&
+                claims.getAudience().equals(clientId) &&
+                claims.get(NONCE_KEY, String.class).equals(nonce);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClient.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClient.java
@@ -1,0 +1,11 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com/auth/")
+public interface AppleClient {
+
+    @GetMapping("keys")
+    ApplePublicKeys getApplePublicKeys();
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClient.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClient.java
@@ -3,9 +3,9 @@ package org.dinosaur.foodbowl.domain.auth.apple;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 
-@FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com/auth/")
+@FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com")
 public interface AppleClient {
 
-    @GetMapping("keys")
+    @GetMapping("/auth/keys")
     ApplePublicKeys getApplePublicKeys();
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleJwtParser.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleJwtParser.java
@@ -1,0 +1,51 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.*;
+
+@RequiredArgsConstructor
+@Component
+public class AppleJwtParser {
+
+    private static final String APPLE_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public Map<String, String> extractHeaders(String appleToken) {
+        try {
+            String encodedHeader = appleToken.split(APPLE_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            return objectMapper.readValue(decodedHeader, Map.class);
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            throw new FoodbowlException(APPLE_INVALID_TOKEN);
+        }
+    }
+
+    public Claims extractClaims(String appleToken, PublicKey publicKey) {
+        try {
+            JwtParser appleJwtParser = Jwts.parserBuilder().setSigningKey(publicKey).build();
+            return appleJwtParser.parseClaimsJws(appleToken).getBody();
+        } catch (ExpiredJwtException e) {
+            throw new FoodbowlException(JWT_EXPIRED);
+        } catch (MalformedJwtException e) {
+            throw new FoodbowlException(JWT_MALFORMED);
+        } catch (UnsupportedJwtException e) {
+            throw new FoodbowlException(JWT_UNSUPPORTED);
+        } catch (SignatureException e) {
+            throw new FoodbowlException(JWT_WRONG_SIGNATURE);
+        } catch (Exception e) {
+            throw new FoodbowlException(JWT_UNKNOWN);
+        }
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProvider.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProvider.java
@@ -2,7 +2,7 @@ package org.dinosaur.foodbowl.domain.auth.apple;
 
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
-import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponseDto;
+import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponse;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
 import org.springframework.stereotype.Component;
 
@@ -20,7 +20,7 @@ public class AppleOAuthUserProvider {
     private final PublicKeyGenerator publicKeyGenerator;
     private final AppleClaimsValidator appleClaimsValidator;
 
-    public ApplePlatformUserResponseDto extractApplePlatformUser(String appleToken) {
+    public ApplePlatformUserResponse extractApplePlatformUser(String appleToken) {
         Map<String, String> headers = appleJwtParser.extractHeaders(appleToken);
         ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
         PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys);
@@ -30,6 +30,6 @@ public class AppleOAuthUserProvider {
             throw new FoodbowlException(APPLE_INVALID_CLAIMS);
         }
 
-        return new ApplePlatformUserResponseDto(claims.getSubject(), claims.get("email", String.class));
+        return new ApplePlatformUserResponse(claims.getSubject(), claims.get("email", String.class));
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProvider.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProvider.java
@@ -1,0 +1,35 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponseDto;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_CLAIMS;
+
+@RequiredArgsConstructor
+@Component
+public class AppleOAuthUserProvider {
+
+    private final AppleJwtParser appleJwtParser;
+    private final AppleClient appleClient;
+    private final PublicKeyGenerator publicKeyGenerator;
+    private final AppleClaimsValidator appleClaimsValidator;
+
+    public ApplePlatformUserResponseDto extractApplePlatformUser(String appleToken) {
+        Map<String, String> headers = appleJwtParser.extractHeaders(appleToken);
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+        PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys);
+
+        Claims claims = appleJwtParser.extractClaims(appleToken, publicKey);
+        if (!appleClaimsValidator.isValid(claims)) {
+            throw new FoodbowlException(APPLE_INVALID_CLAIMS);
+        }
+
+        return new ApplePlatformUserResponseDto(claims.getSubject(), claims.get("email", String.class));
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKey.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKey.java
@@ -1,0 +1,27 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplePublicKey {
+
+    private String kty;
+    private String kid;
+    private String use;
+    private String alg;
+    private String n;
+    private String e;
+
+    public boolean isSameAlg(String alg) {
+        return this.alg.equals(alg);
+    }
+
+    public boolean isSameKid(String kid) {
+        return this.kid.equals(kid);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeys.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeys.java
@@ -1,0 +1,26 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+
+import java.util.List;
+
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_HEADER;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplePublicKeys {
+
+    private List<ApplePublicKey> keys;
+
+    public ApplePublicKey getMatchingKey(String alg, String kid) {
+        return keys.stream()
+                .filter(key -> key.isSameAlg(alg) && key.isSameKid(kid))
+                .findFirst()
+                .orElseThrow(() -> new FoodbowlException(APPLE_INVALID_HEADER));
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/PublicKeyGenerator.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/PublicKeyGenerator.java
@@ -1,0 +1,46 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_PUBLIC_KEY;
+
+@Component
+public class PublicKeyGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+    public PublicKey generatePublicKey(Map<String, String> headers, ApplePublicKeys applePublicKeys) {
+        ApplePublicKey applePublicKey =
+                applePublicKeys.getMatchingKey(headers.get(SIGN_ALGORITHM_HEADER_KEY), headers.get(KEY_ID_HEADER_KEY));
+        return generatePublicKeyByApplePublicKey(applePublicKey);
+    }
+
+    private PublicKey generatePublicKeyByApplePublicKey(ApplePublicKey applePublicKey) {
+        byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKey.getN());
+        byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKey.getE());
+
+        BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+
+        RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.getKty());
+            return keyFactory.generatePublic(rsaPublicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new FoodbowlException(APPLE_INVALID_PUBLIC_KEY);
+        }
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -2,13 +2,16 @@ package org.dinosaur.foodbowl.domain.auth.application;
 
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
+import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
 import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponseDto;
-import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
 import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
@@ -21,8 +24,9 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final AppleOAuthUserProvider appleOAuthUserProvider;
+    private final RedisTemplate<String, Object> redisTemplate;
 
-    public AppleTokenResponseDto appleLogin(AppleLoginRequestDto appleLoginRequestDto) {
+    public FoodbowlTokenDto appleLogin(AppleLoginRequestDto appleLoginRequestDto) {
         ApplePlatformUserResponseDto applePlatformUserResponseDto =
                 appleOAuthUserProvider.extractApplePlatformUser(appleLoginRequestDto.getAppleToken());
         String socialId = applePlatformUserResponseDto.getSocialId();
@@ -30,8 +34,20 @@ public class AuthService {
         return memberRepository.findBySocialTypeAndSocialId(SocialType.APPLE, socialId)
                 .map(member -> {
                     String accessToken = jwtTokenProvider.createAccessToken(member.getId(), RoleType.ROLE_회원);
-                    return new AppleTokenResponseDto(accessToken);
+                    String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+                    registerRefreshToken(member.getId(), refreshToken);
+                    return new FoodbowlTokenDto(accessToken, refreshToken);
                 })
                 .orElseThrow(() -> new FoodbowlException(APPLE_NOT_REGISTER));
+    }
+
+    private void registerRefreshToken(Long memberId, String refreshToken) {
+        redisTemplate.opsForValue()
+                .set(
+                        String.valueOf(memberId),
+                        refreshToken,
+                        jwtTokenProvider.getValidRefreshMilliSecond(),
+                        TimeUnit.MILLISECONDS
+                );
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -1,0 +1,37 @@
+package org.dinosaur.foodbowl.domain.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
+import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponseDto;
+import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
+import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.stereotype.Service;
+
+import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_NOT_REGISTER;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AppleOAuthUserProvider appleOAuthUserProvider;
+
+    public AppleTokenResponseDto appleLogin(AppleLoginRequestDto appleLoginRequestDto) {
+        ApplePlatformUserResponseDto applePlatformUserResponseDto =
+                appleOAuthUserProvider.extractApplePlatformUser(appleLoginRequestDto.getAppleToken());
+        String socialId = applePlatformUserResponseDto.getSocialId();
+
+        return memberRepository.findBySocialTypeAndSocialId(SocialType.APPLE, socialId)
+                .map(member -> {
+                    String accessToken = jwtTokenProvider.createAccessToken(member.getId(), RoleType.ROLE_회원);
+                    return new AppleTokenResponseDto(accessToken);
+                })
+                .orElseThrow(() -> new FoodbowlException(APPLE_NOT_REGISTER));
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -3,8 +3,8 @@ package org.dinosaur.foodbowl.domain.auth.application;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
-import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
-import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponseDto;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
@@ -27,10 +27,10 @@ public class AuthService {
     private final AppleOAuthUserProvider appleOAuthUserProvider;
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public FoodbowlTokenDto appleLogin(AppleLoginRequestDto appleLoginRequestDto) {
-        ApplePlatformUserResponseDto applePlatformUserResponseDto =
-                appleOAuthUserProvider.extractApplePlatformUser(appleLoginRequestDto.getAppleToken());
-        String socialId = applePlatformUserResponseDto.getSocialId();
+    public FoodbowlTokenDto appleLogin(AppleLoginRequest appleLoginRequest) {
+        ApplePlatformUserResponse applePlatformUserResponse =
+                appleOAuthUserProvider.extractApplePlatformUser(appleLoginRequest.getAppleToken());
+        String socialId = applePlatformUserResponse.getSocialId();
 
         final Member member = memberRepository.findBySocialTypeAndSocialId(SocialType.APPLE, socialId)
                 .orElseThrow(() -> new FoodbowlException(APPLE_NOT_REGISTER));

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/FoodbowlTokenDto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/FoodbowlTokenDto.java
@@ -1,0 +1,15 @@
+package org.dinosaur.foodbowl.domain.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoodbowlTokenDto {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/request/AppleLoginRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/request/AppleLoginRequest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AppleLoginRequestDto {
+public class AppleLoginRequest {
 
     @NotBlank(message = "애플 토큰이 필요합니다.")
     private String appleToken;

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/request/AppleLoginRequestDto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/request/AppleLoginRequestDto.java
@@ -1,0 +1,14 @@
+package org.dinosaur.foodbowl.domain.auth.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppleLoginRequestDto {
+
+    private String appleToken;
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/request/AppleLoginRequestDto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/request/AppleLoginRequestDto.java
@@ -1,6 +1,6 @@
 package org.dinosaur.foodbowl.domain.auth.dto.request;
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AppleLoginRequestDto {
 
-    @NotEmpty(message = "애플 토큰이 필요합니다.")
+    @NotBlank(message = "애플 토큰이 필요합니다.")
     private String appleToken;
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/request/AppleLoginRequestDto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/request/AppleLoginRequestDto.java
@@ -1,5 +1,6 @@
 package org.dinosaur.foodbowl.domain.auth.dto.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,5 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AppleLoginRequestDto {
 
+    @NotEmpty(message = "애플 토큰이 필요합니다.")
     private String appleToken;
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/ApplePlatformUserResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/ApplePlatformUserResponse.java
@@ -8,7 +8,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AppleTokenResponseDto {
+public class ApplePlatformUserResponse {
 
-    private String accessToken;
+    private String socialId;
+    private String email;
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/ApplePlatformUserResponseDto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/ApplePlatformUserResponseDto.java
@@ -1,0 +1,15 @@
+package org.dinosaur.foodbowl.domain.auth.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplePlatformUserResponseDto {
+
+    private String socialId;
+    private String email;
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/AppleTokenResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/AppleTokenResponse.java
@@ -8,8 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ApplePlatformUserResponseDto {
+public class AppleTokenResponse {
 
-    private String socialId;
-    private String email;
+    private String accessToken;
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/AppleTokenResponseDto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/AppleTokenResponseDto.java
@@ -1,0 +1,14 @@
+package org.dinosaur.foodbowl.domain.auth.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppleTokenResponseDto {
+
+    private String accessToken;
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckController.java
@@ -21,4 +21,11 @@ public class HealthCheckController {
 
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/health-check/auth")
+    public ResponseEntity<HealthCheckDto> authCheck() {
+        HealthCheckDto response = healthCheckService.check();
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepository.java
@@ -3,7 +3,13 @@ package org.dinosaur.foodbowl.domain.member.repository;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.springframework.data.repository.Repository;
 
+import java.util.Optional;
+
+import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
+
 public interface MemberRepository extends Repository<Member, Long> {
 
     Member save(Member member);
+
+    Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/redis/RedisConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/redis/RedisConfig.java
@@ -1,0 +1,34 @@
+package org.dinosaur.foodbowl.global.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package org.dinosaur.foodbowl.global.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package org.dinosaur.foodbowl.global.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package org.dinosaur.foodbowl.global.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
@@ -1,36 +1,57 @@
 package org.dinosaur.foodbowl.global.config.security;
 
 import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtAuthenticationFilter;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtExceptionFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-@Configuration
-@EnableWebSecurity
 @RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
 public class SecurityConfig {
+
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers("/docs/**", "/thumbnail/**", "/api/v1/health-check");
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests()
                 .requestMatchers("/docs/**", "/thumbnail/**", "/api/v1/health-check").permitAll()
-                .anyRequest().hasRole("회원")
+                .anyRequest().hasRole("ROLE_회원")
                 .and()
                 .httpBasic().disable()
                 .csrf().disable()
                 .logout().disable()
                 .cors().configurationSource(corsConfigurationSource())
                 .and()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .exceptionHandling().accessDeniedHandler(customAccessDeniedHandler)
+                .and()
+                .exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint)
+                .and()
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }
@@ -54,3 +75,4 @@ public class SecurityConfig {
         return source;
     }
 }
+

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests()
                 .requestMatchers("/docs/**", "/api/v1/health-check").permitAll()
-                .requestMatchers("/api/v1/apple/login").permitAll()
+                .requestMatchers("/api/v1/auth/apple/login").permitAll()
                 .anyRequest().hasRole("회원")
                 .and()
                 .httpBasic().disable()

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package org.dinosaur.foodbowl.global.config.security;
 
 import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,28 +10,39 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-@Configuration
-@EnableWebSecurity
 @RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
 public class SecurityConfig {
+
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests()
-                .requestMatchers("/docs/**", "/thumbnail/**", "/api/v1/health-check").permitAll()
-                .anyRequest().hasRole("회원")
+                .requestMatchers("/docs/**", "/api/v1/health-check").permitAll()
+                .anyRequest().hasRole("ROLE_회원")
                 .and()
                 .httpBasic().disable()
                 .csrf().disable()
                 .logout().disable()
                 .cors().configurationSource(corsConfigurationSource())
                 .and()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .exceptionHandling().accessDeniedHandler(customAccessDeniedHandler)
+                .and()
+                .exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint)
+                .and()
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -54,3 +66,4 @@ public class SecurityConfig {
         return source;
     }
 }
+

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests()
                 .requestMatchers("/docs/**", "/api/v1/health-check").permitAll()
+                .requestMatchers("/api/v1/apple/login").permitAll()
                 .anyRequest().hasRole("회원")
                 .and()
                 .httpBasic().disable()

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests()
                 .requestMatchers("/docs/**", "/api/v1/health-check").permitAll()
-                .anyRequest().hasRole("ROLE_회원")
+                .anyRequest().hasRole("회원")
                 .and()
                 .httpBasic().disable()
                 .csrf().disable()

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,34 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthorizationExtractor jwtAuthorizationExtractor;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        Optional<String> accessToken = jwtAuthorizationExtractor.extractAccessToken(request);
+
+        if (accessToken.isPresent()) {
+            Optional<Authentication> authentication = jwtTokenProvider.getAuthentication(accessToken.get());
+            authentication.ifPresent(auth -> SecurityContextHolder.getContext().setAuthentication(auth));
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,33 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthorizationExtractor jwtAuthorizationExtractor;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = jwtAuthorizationExtractor.extractAccessToken(request);
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -25,7 +25,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Optional<String> accessToken = jwtAuthorizationExtractor.extractAccessToken(request);
 
         if (accessToken.isPresent()) {
-            Optional<Authentication> authentication = jwtTokenProvider.getAuthentication(accessToken.get());
+            Optional<Authentication> authentication = jwtTokenProvider.generateAuth(accessToken.get());
             authentication.ifPresent(auth -> SecurityContextHolder.getContext().setAuthentication(auth));
         }
 

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthorizationExtractor.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthorizationExtractor.java
@@ -1,0 +1,27 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.Enumeration;
+import java.util.Optional;
+
+@Component
+public class JwtAuthorizationExtractor {
+
+    private static final String AUTHENTICATION_TYPE = "Bearer";
+    private static final String AUTHENTICATION_HEADER_KEY = "Authorization";
+    private static final int TOKEN_INDEX = 1;
+
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        Enumeration<String> headers = request.getHeaders(AUTHENTICATION_HEADER_KEY);
+
+        while (headers.hasMoreElements()) {
+            String value = headers.nextElement();
+            if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
+                return Optional.ofNullable(value.split(" ")[TOKEN_INDEX]);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthorizationExtractor.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthorizationExtractor.java
@@ -11,6 +11,7 @@ public class JwtAuthorizationExtractor {
 
     private static final String AUTHENTICATION_TYPE = "Bearer";
     private static final String AUTHENTICATION_HEADER_KEY = "Authorization";
+    private static final String AUTHENTICATION_DELIMITER = " ";
     private static final int TOKEN_INDEX = 1;
 
     public Optional<String> extractAccessToken(HttpServletRequest request) {
@@ -19,7 +20,7 @@ public class JwtAuthorizationExtractor {
         while (headers.hasMoreElements()) {
             String value = headers.nextElement();
             if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
-                return Optional.ofNullable(value.split(" ")[TOKEN_INDEX]);
+                return Optional.ofNullable(value.split(AUTHENTICATION_DELIMITER)[TOKEN_INDEX]);
             }
         }
         return Optional.empty();

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthorizationExtractor.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthorizationExtractor.java
@@ -1,0 +1,28 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.dinosaur.foodbowl.global.exception.ErrorStatus;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.stereotype.Component;
+
+import java.util.Enumeration;
+
+@Component
+public class JwtAuthorizationExtractor {
+
+    private static final String AUTHENTICATION_TYPE = "Bearer";
+    private static final String AUTHENTICATION_HEADER_KEY = "Authorization";
+    private static final int TOKEN_INDEX = 1;
+
+    public String extractAccessToken(HttpServletRequest request) {
+        Enumeration<String> headers = request.getHeaders(AUTHENTICATION_HEADER_KEY);
+
+        while (headers.hasMoreElements()) {
+            String value = headers.nextElement();
+            if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
+                return value.split(" ")[TOKEN_INDEX];
+            }
+        }
+        throw new FoodbowlException(ErrorStatus.JWT_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtConstant.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtConstant.java
@@ -1,0 +1,19 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+public enum JwtConstant {
+
+    DELIMITER(","),
+    CLAMS_ROLES("roles"),
+    ACCESS_TOKEN("accessToken"),
+    REFRESH_TOKEN("refreshToken");
+
+    private final String name;
+
+    JwtConstant(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtExceptionFilter.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtExceptionFilter.java
@@ -1,0 +1,34 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.global.exception.FoodbowlErrorResponse;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (FoodbowlException e) {
+            response.setStatus(e.getHttpStatus().value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            objectMapper.writeValue(response.getWriter(), new FoodbowlErrorResponse(e.getMessage(), e.getCode()));
+        }
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,104 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import org.dinosaur.foodbowl.global.exception.ErrorStatus;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.CLAMS_ROLES;
+import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.DELIMITER;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+    private final long validAccessMilliSecond;
+    private final long validRefreshMilliSecond;
+    private final JwtParser jwtParser;
+
+    public JwtTokenProvider(
+            @Value("${spring.jwt.token.secret-key}") String secretKey,
+            @Value("${spring.jwt.token.access-expire-time}") long validAccessMilliSecond,
+            @Value("${spring.jwt.token.refresh-expire-time}") long validRefreshMilliSecond
+    ) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.validAccessMilliSecond = validAccessMilliSecond;
+        this.validRefreshMilliSecond = validRefreshMilliSecond;
+        this.jwtParser = Jwts.parserBuilder().setSigningKey(key).build();
+    }
+
+    public String createAccessToken(Long userId, RoleType... roleTypes) {
+        String[] roleNames = Arrays.stream(roleTypes)
+                .map(RoleType::name)
+                .toArray(String[]::new);
+        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
+        claims.put(CLAMS_ROLES.getName(), String.join(DELIMITER.getName(), roleNames));
+
+        Date now = new Date();
+        Date validDate = new Date(now.getTime() + validAccessMilliSecond);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validDate)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
+
+        Date now = new Date();
+        Date validDate = new Date(now.getTime() + validRefreshMilliSecond);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validDate)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getSubject(String token) {
+        Claims claims = extractClaims(token);
+        return claims.getSubject();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = extractClaims(token);
+        List<String> roleNames = Arrays.stream(
+                claims.get(CLAMS_ROLES.getName()).toString().split(DELIMITER.getName())
+        ).toList();
+        UserDetails userDetails = new JwtUser(claims.getSubject(), roleNames);
+        return new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+    }
+
+    private Claims extractClaims(String token) {
+        try {
+            return jwtParser.parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            throw new FoodbowlException(ErrorStatus.JWT_EXPIRED);
+        } catch (MalformedJwtException e) {
+            throw new FoodbowlException(ErrorStatus.JWT_MALFORMED);
+        } catch (UnsupportedJwtException e) {
+            throw new FoodbowlException(ErrorStatus.JWT_UNSUPPORTED);
+        } catch (SignatureException e) {
+            throw new FoodbowlException(ErrorStatus.JWT_WRONG_SIGNATURE);
+        } catch (Exception e) {
+            throw new FoodbowlException(ErrorStatus.JWT_UNKNOWN);
+        }
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
@@ -114,4 +114,8 @@ public class JwtTokenProvider {
         }
         return new JwtTokenValid(false, errorStatus.getMessage(), errorStatus.getCode());
     }
+
+    public long getValidRefreshMilliSecond() {
+        return validRefreshMilliSecond;
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
@@ -72,7 +72,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public Optional<String> getSubject(String token) {
+    public Optional<String> extractSubject(String token) {
         JwtTokenValid jwtTokenValid = validateToken(token);
 
         if (jwtTokenValid.isValid()) {
@@ -82,7 +82,7 @@ public class JwtTokenProvider {
         return Optional.empty();
     }
 
-    public Optional<Authentication> getAuthentication(String token) {
+    public Optional<Authentication> generateAuth(String token) {
         JwtTokenValid jwtTokenValid = validateToken(token);
 
         if (jwtTokenValid.isValid()) {

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,117 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import org.dinosaur.foodbowl.global.exception.ErrorStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.CLAMS_ROLES;
+import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.DELIMITER;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+    private final long validAccessMilliSecond;
+    private final long validRefreshMilliSecond;
+    private final JwtParser jwtParser;
+
+    public JwtTokenProvider(
+            @Value("${spring.jwt.token.secret-key}") String secretKey,
+            @Value("${spring.jwt.token.access-expire-time}") long validAccessMilliSecond,
+            @Value("${spring.jwt.token.refresh-expire-time}") long validRefreshMilliSecond
+    ) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.validAccessMilliSecond = validAccessMilliSecond;
+        this.validRefreshMilliSecond = validRefreshMilliSecond;
+        this.jwtParser = Jwts.parserBuilder().setSigningKey(key).build();
+    }
+
+    public String createAccessToken(Long userId, RoleType... roleTypes) {
+        String[] roleNames = Arrays.stream(roleTypes)
+                .map(RoleType::name)
+                .toArray(String[]::new);
+        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
+        claims.put(CLAMS_ROLES.getName(), String.join(DELIMITER.getName(), roleNames));
+
+        Date now = new Date();
+        Date validDate = new Date(now.getTime() + validAccessMilliSecond);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validDate)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
+
+        Date now = new Date();
+        Date validDate = new Date(now.getTime() + validRefreshMilliSecond);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validDate)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Optional<String> getSubject(String token) {
+        JwtTokenValid jwtTokenValid = validateToken(token);
+
+        if (jwtTokenValid.isValid()) {
+            Claims claims = jwtParser.parseClaimsJws(token).getBody();
+            return Optional.ofNullable(claims.getSubject());
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Authentication> getAuthentication(String token) {
+        JwtTokenValid jwtTokenValid = validateToken(token);
+
+        if (jwtTokenValid.isValid()) {
+            Claims claims = jwtParser.parseClaimsJws(token).getBody();
+            List<String> roleNames = Arrays.stream(
+                    claims.get(CLAMS_ROLES.getName()).toString().split(DELIMITER.getName())
+            ).toList();
+            UserDetails userDetails = new JwtUser(claims.getSubject(), roleNames);
+            return Optional.of(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
+        }
+        return Optional.empty();
+    }
+
+    private JwtTokenValid validateToken(String token) {
+        ErrorStatus errorStatus;
+        try {
+            jwtParser.parseClaimsJws(token).getBody();
+            return new JwtTokenValid(true, "", 0);
+        } catch (ExpiredJwtException e) {
+            errorStatus = ErrorStatus.JWT_EXPIRED;
+        } catch (MalformedJwtException e) {
+            errorStatus = ErrorStatus.JWT_MALFORMED;
+        } catch (UnsupportedJwtException e) {
+            errorStatus = ErrorStatus.JWT_UNSUPPORTED;
+        } catch (SignatureException e) {
+            errorStatus = ErrorStatus.JWT_WRONG_SIGNATURE;
+        } catch (Exception e) {
+            errorStatus = ErrorStatus.JWT_UNKNOWN;
+        }
+        return new JwtTokenValid(false, errorStatus.getMessage(), errorStatus.getCode());
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenValid.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenValid.java
@@ -1,0 +1,5 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+public record JwtTokenValid(boolean isValid, String errorMessage, int code) {
+
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtUser.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtUser.java
@@ -1,0 +1,54 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class JwtUser implements UserDetails {
+
+    private final String id;
+    private final List<String> roleNames;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return roleNames.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return id;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/config/web/FeignClientConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/web/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package org.dinosaur.foodbowl.global.config.web;
+
+import org.dinosaur.foodbowl.FoodbowlApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = FoodbowlApplication.class)
+public class FeignClientConfig {
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/exception/ErrorStatus.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/exception/ErrorStatus.java
@@ -1,0 +1,36 @@
+package org.dinosaur.foodbowl.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorStatus {
+
+    //JWT code: 1xxx
+    JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.", 1000),
+    JWT_MALFORMED(HttpStatus.UNAUTHORIZED, "손상된 토큰입니다.", 1001),
+    JWT_UNSUPPORTED(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다.", 1002),
+    JWT_WRONG_SIGNATURE(HttpStatus.UNAUTHORIZED, "시그니처 검증에 실패한 토큰입니다.", 1003),
+    JWT_UNKNOWN(HttpStatus.UNAUTHORIZED, "알 수 없는 이유로 유효하지 않은 토큰입니다.", 1004),
+    JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "로그인 토큰이 존재하지 않습니다.", 1005);
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final int code;
+
+    ErrorStatus(HttpStatus httpStatus, String message, int code) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.code = code;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/exception/ErrorStatus.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/exception/ErrorStatus.java
@@ -10,7 +10,14 @@ public enum ErrorStatus {
     JWT_UNSUPPORTED(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰입니다.", 1002),
     JWT_WRONG_SIGNATURE(HttpStatus.UNAUTHORIZED, "시그니처 검증에 실패한 토큰입니다.", 1003),
     JWT_UNKNOWN(HttpStatus.UNAUTHORIZED, "알 수 없는 이유로 유효하지 않은 토큰입니다.", 1004),
-    JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "로그인 토큰이 존재하지 않습니다.", 1005);
+    JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "로그인 토큰이 존재하지 않습니다.", 1005),
+
+    //Apple code: 3xxx
+    APPLE_INVALID_TOKEN(HttpStatus.BAD_REQUEST, "올바르지 않은 애플 OAuth 토큰입니다.", 3000),
+    APPLE_INVALID_HEADER(HttpStatus.BAD_REQUEST, "올바르지 않은 애플 OAuth 토큰 헤더 정보입니다.", 3001),
+    APPLE_INVALID_CLAIMS(HttpStatus.INTERNAL_SERVER_ERROR, "올바르지 않은 애플 OAuth 토큰 조각 정보입니다.", 3002),
+    APPLE_INVALID_PUBLIC_KEY(HttpStatus.INTERNAL_SERVER_ERROR, "애플 OAuth 퍼블릭 키 생성 중 문제가 발생하였습니다.", 3003),
+    APPLE_NOT_REGISTER(HttpStatus.UNAUTHORIZED, "애플 회원가입이 되지 않은 회원입니다.", 3004);
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/dinosaur/foodbowl/global/exception/FoodbowlErrorResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/exception/FoodbowlErrorResponse.java
@@ -1,0 +1,20 @@
+package org.dinosaur.foodbowl.global.exception;
+
+public class FoodbowlErrorResponse {
+
+    private final String message;
+    private final int code;
+
+    public FoodbowlErrorResponse(String message, int code) {
+        this.message = message;
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/exception/FoodbowlException.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/exception/FoodbowlException.java
@@ -1,0 +1,29 @@
+package org.dinosaur.foodbowl.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class FoodbowlException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final int code;
+
+    public FoodbowlException(ErrorStatus errorStatus) {
+        this.httpStatus = errorStatus.getHttpStatus();
+        this.message = errorStatus.getMessage();
+        this.code = errorStatus.getCode();
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/exception/GlobalExceptionAdvice.java
@@ -1,6 +1,10 @@
 package org.dinosaur.foodbowl.global.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -8,8 +12,27 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionAdvice {
 
     @ExceptionHandler(FoodbowlException.class)
-    public ResponseEntity<FoodbowlErrorResponse> foodbowlException(FoodbowlException foodbowlException) {
-        return ResponseEntity.status(foodbowlException.getHttpStatus())
-                .body(new FoodbowlErrorResponse(foodbowlException.getMessage(), foodbowlException.getCode()));
+    public ResponseEntity<FoodbowlErrorResponse> handleException(FoodbowlException e) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(new FoodbowlErrorResponse(e.getMessage(), e.getCode()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<FoodbowlErrorResponse> handleException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            stringBuilder.append("[");
+            stringBuilder.append(fieldError.getField());
+            stringBuilder.append("] 필드는 ");
+            stringBuilder.append(fieldError.getDefaultMessage());
+            stringBuilder.append(" 입력된 값 : [");
+            stringBuilder.append(fieldError.getRejectedValue());
+            stringBuilder.append("]");
+        }
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new FoodbowlErrorResponse(stringBuilder.toString(), -1000));
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,15 @@
+package org.dinosaur.foodbowl.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+
+    @ExceptionHandler(FoodbowlException.class)
+    public ResponseEntity<FoodbowlErrorResponse> foodbowlException(FoodbowlException foodbowlException) {
+        return ResponseEntity.status(foodbowlException.getHttpStatus())
+                .body(new FoodbowlErrorResponse(foodbowlException.getMessage(), foodbowlException.getCode()));
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
@@ -1,11 +1,11 @@
 package org.dinosaur.foodbowl;
 
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-
+import org.dinosaur.foodbowl.global.config.security.CustomAccessDeniedHandler;
+import org.dinosaur.foodbowl.global.config.security.CustomAuthenticationEntryPoint;
 import org.dinosaur.foodbowl.global.config.security.SecurityConfig;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtAuthenticationFilter;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtAuthorizationExtractor;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Import;
@@ -17,7 +17,19 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@Import(SecurityConfig.class)
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+@Import(value = {
+        SecurityConfig.class,
+        JwtTokenProvider.class,
+        JwtAuthorizationExtractor.class,
+        JwtAuthenticationFilter.class,
+        CustomAccessDeniedHandler.class,
+        CustomAuthenticationEntryPoint.class
+})
 @ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
 public class MockApiTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
@@ -1,5 +1,6 @@
 package org.dinosaur.foodbowl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dinosaur.foodbowl.global.config.security.CustomAccessDeniedHandler;
 import org.dinosaur.foodbowl.global.config.security.CustomAuthenticationEntryPoint;
 import org.dinosaur.foodbowl.global.config.security.SecurityConfig;
@@ -22,18 +23,18 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.mo
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
-
 @Import(value = {
         SecurityConfig.class,
         JwtTokenProvider.class,
         JwtAuthorizationExtractor.class,
         JwtAuthenticationFilter.class,
         CustomAccessDeniedHandler.class,
-        CustomAuthenticationEntryPoint.class
+        CustomAuthenticationEntryPoint.class,
 })
 @ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
 public class MockApiTest {
 
+    protected ObjectMapper objectMapper = new ObjectMapper();
     protected MockMvc mockMvc;
 
     @BeforeEach

--- a/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
@@ -1,23 +1,38 @@
 package org.dinosaur.foodbowl;
 
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-
+import org.dinosaur.foodbowl.global.config.security.CustomAccessDeniedHandler;
+import org.dinosaur.foodbowl.global.config.security.CustomAuthenticationEntryPoint;
 import org.dinosaur.foodbowl.global.config.security.SecurityConfig;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtAuthenticationFilter;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtAuthorizationExtractor;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtExceptionFilter;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@Import(SecurityConfig.class)
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+@Import(value = {
+        JwtTokenProvider.class,
+        JwtAuthorizationExtractor.class,
+        JwtAuthenticationFilter.class,
+        JwtExceptionFilter.class,
+        CustomAccessDeniedHandler.class,
+        CustomAuthenticationEntryPoint.class
+})
+@ContextConfiguration(classes = SecurityConfig.class)
 @ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
 public class MockApiTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/TestUtils.java
+++ b/src/test/java/org/dinosaur/foodbowl/TestUtils.java
@@ -1,0 +1,21 @@
+package org.dinosaur.foodbowl;
+
+import com.jayway.jsonpath.JsonPath;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestUtils {
+
+    public static ResultMatcher jsonPathLocalDateTimeEquals(String expression, LocalDateTime expectedLocalDateTime) {
+        return result -> {
+            String content = result.getResponse().getContentAsString();
+            String localDateTimeString = JsonPath.read(content, expression);
+            LocalDateTime localDateTime = LocalDateTime.parse(localDateTimeString, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            assertEquals(localDateTime, expectedLocalDateTime);
+        };
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -3,7 +3,7 @@ package org.dinosaur.foodbowl.domain.auth.api;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
-import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,12 +33,12 @@ class AuthControllerTest extends MockApiTest {
         @Test
         @DisplayName("유효한 애플 토큰 값을 요청 받으면 Foodbowl 토큰을 응답한다.")
         void appleLogin() throws Exception {
-            AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
+            AppleLoginRequest appleLoginRequest = new AppleLoginRequest("AppleToken");
             FoodbowlTokenDto foodbowlTokenDto = new FoodbowlTokenDto("AccessToken", "RefreshToken");
 
             given(authService.appleLogin(any())).willReturn(foodbowlTokenDto);
 
-            appleLoginApi(appleLoginRequestDto)
+            appleLoginApi(appleLoginRequest)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.accessToken").value("AccessToken"));
         }
@@ -46,15 +46,15 @@ class AuthControllerTest extends MockApiTest {
         @Test
         @DisplayName("토큰이 존재하지 않으면 400 예외를 발생시킨다.")
         void appleLoginWithEmptyToken() throws Exception {
-            AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto(null);
+            AppleLoginRequest appleLoginRequest = new AppleLoginRequest(null);
 
-            appleLoginApi(appleLoginRequestDto)
+            appleLoginApi(appleLoginRequest)
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message", containsString("애플 토큰이 필요합니다.")))
                     .andExpect(jsonPath("$.code").value(-1000));
         }
 
-        private ResultActions appleLoginApi(AppleLoginRequestDto request) throws Exception {
+        private ResultActions appleLoginApi(AppleLoginRequest request) throws Exception {
             return mockMvc.perform(post("/api/v1/auth/apple/login")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON_VALUE))

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -55,7 +55,7 @@ class AuthControllerTest extends MockApiTest {
         }
 
         private ResultActions appleLoginApi(AppleLoginRequestDto request) throws Exception {
-            return mockMvc.perform(post("/api/v1/apple/login")
+            return mockMvc.perform(post("/api/v1/auth/apple/login")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON_VALUE))
                     .andDo(print());

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -2,8 +2,8 @@ package org.dinosaur.foodbowl.domain.auth.api;
 
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
+import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
-import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,13 +34,13 @@ class AuthControllerTest extends MockApiTest {
         @DisplayName("유효한 애플 토큰 값을 요청 받으면 Foodbowl 토큰을 응답한다.")
         void appleLogin() throws Exception {
             AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
-            AppleTokenResponseDto appleTokenResponseDto = new AppleTokenResponseDto("FoodbowlToken");
+            FoodbowlTokenDto foodbowlTokenDto = new FoodbowlTokenDto("AccessToken", "RefreshToken");
 
-            given(authService.appleLogin(any())).willReturn(appleTokenResponseDto);
+            given(authService.appleLogin(any())).willReturn(foodbowlTokenDto);
 
             appleLoginApi(appleLoginRequestDto)
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.accessToken").value("FoodbowlToken"));
+                    .andExpect(jsonPath("$.accessToken").value("AccessToken"));
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -1,0 +1,64 @@
+package org.dinosaur.foodbowl.domain.auth.api;
+
+import org.dinosaur.foodbowl.MockApiTest;
+import org.dinosaur.foodbowl.domain.auth.application.AuthService;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
+import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest extends MockApiTest {
+
+    @MockBean
+    private AuthService authService;
+
+    @Nested
+    @DisplayName("애플 로그인 api는 ")
+    class AppleLogin {
+
+        @Test
+        @DisplayName("유효한 애플 토큰 값을 요청 받으면 Foodbowl 토큰을 응답한다.")
+        void appleLogin() throws Exception {
+            AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
+            AppleTokenResponseDto appleTokenResponseDto = new AppleTokenResponseDto("FoodbowlToken");
+
+            given(authService.appleLogin(any())).willReturn(appleTokenResponseDto);
+
+            appleLoginApi(appleLoginRequestDto)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken").value("FoodbowlToken"));
+        }
+
+        @Test
+        @DisplayName("토큰이 존재하지 않으면 400 예외를 발생시킨다.")
+        void appleLoginWithEmptyToken() throws Exception {
+            AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto(null);
+
+            appleLoginApi(appleLoginRequestDto)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message", containsString("애플 토큰이 필요합니다.")))
+                    .andExpect(jsonPath("$.code").value(-1000));
+        }
+
+        private ResultActions appleLoginApi(AppleLoginRequestDto request) throws Exception {
+            return mockMvc.perform(post("/api/v1/apple/login")
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE))
+                    .andDo(print());
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClaimsValidatorTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClaimsValidatorTest.java
@@ -1,0 +1,51 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppleClaimsValidatorTest {
+
+    private static final String ISS = "iss";
+    private static final String CLIENT_ID = "clientID";
+    private static final String NONCE = "nonce";
+    private static final String NONCE_KEY = "nonce";
+
+    private final AppleClaimsValidator appleClaimsValidator = new AppleClaimsValidator(ISS, CLIENT_ID, NONCE);
+
+    @Test
+    @DisplayName("유효한 claims 정보를 가지고 있으면 true 반환한다.")
+    void validClaims() {
+        Claims claims = Jwts.claims()
+                .setIssuer(ISS)
+                .setAudience(CLIENT_ID);
+        claims.put(NONCE_KEY, NONCE);
+
+        boolean result = appleClaimsValidator.isValid(claims);
+
+        assertThat(result).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "invalidIss,clientID,nonce",
+            "iss,invalidClientID,nonce",
+            "iss,clientID,invalidNonce"
+    })
+    @DisplayName("유효하지 않은 claims 정보를 가지고 있으면 false 반환한다.")
+    void invalidClaims(String iss, String clientId, String nonce) {
+        Claims claims = Jwts.claims()
+                .setIssuer(iss)
+                .setAudience(clientId);
+        claims.put(NONCE_KEY, nonce);
+
+        boolean result = appleClaimsValidator.isValid(claims);
+
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClientTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClientTest.java
@@ -1,0 +1,35 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import org.dinosaur.foodbowl.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppleClientTest extends IntegrationTest {
+
+    @Autowired
+    private AppleClient appleClient;
+
+    @Test
+    @DisplayName("Apple 서버와 통신하여 Apple Public Keys를 구성한다.")
+    void getApplePublicKeys() {
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+        List<ApplePublicKey> keys = applePublicKeys.getKeys();
+
+        boolean result = keys.stream()
+                .allMatch(this::isAllNotNull);
+
+        assertThat(result).isTrue();
+    }
+
+    private boolean isAllNotNull(ApplePublicKey applePublicKey) {
+        return Objects.nonNull(applePublicKey.getKty()) && Objects.nonNull(applePublicKey.getKid())
+                && Objects.nonNull(applePublicKey.getUse()) && Objects.nonNull(applePublicKey.getAlg())
+                && Objects.nonNull(applePublicKey.getN()) && Objects.nonNull(applePublicKey.getE());
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleJwtParserTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleJwtParserTest.java
@@ -1,0 +1,143 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.security.*;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class AppleJwtParserTest {
+
+    private final AppleJwtParser appleJwtParser = new AppleJwtParser();
+
+    @Test
+    @DisplayName("Apple Jwt 토큰에서 헤더 정보를 추출한다.")
+    void extractHeaders() throws NoSuchAlgorithmException {
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        String appleToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "1234")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+
+        Map<String, String> headers = appleJwtParser.extractHeaders(appleToken);
+
+        assertThat(headers).containsKeys("alg", "kid");
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 Apple Jwt 토큰에서 헤더 정보를 추출하면 예외를 던진다.")
+    void extractHeadersWithInvalidToken() {
+        assertThatThrownBy(() -> appleJwtParser.extractHeaders("invalidToken"))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage("올바르지 않은 애플 OAuth 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("Apple Jwt 토큰, Public Key를 받아 Claims를 추출한다.")
+    void extractClaims() throws NoSuchAlgorithmException {
+        String subject = "9876";
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+        String appleToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "1234")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(subject)
+                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+
+        Claims claims = appleJwtParser.extractClaims(appleToken, publicKey);
+
+        assertAll(
+                () -> assertThat(claims).isNotEmpty(),
+                () -> assertThat(claims.getSubject()).isEqualTo(subject)
+        );
+    }
+
+    @Test
+    @DisplayName("만료 기간이 지난 토큰에서 Claims를 추출하면 예외를 던진다.")
+    void extractClaimsWithExpiredToken() throws NoSuchAlgorithmException {
+        String subject = "9876";
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+        String appleToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "1234")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(subject)
+                .setExpiration(new Date(now.getTime() - 1000 * 60 * 60 * 24))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+
+        assertThatThrownBy(() -> appleJwtParser.extractClaims(appleToken, publicKey))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage("만료된 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 Apple Jwt 토큰에서 Claims를 추출하면 예외를 던진다.")
+    void extractClaimsWithInvalidToken() throws NoSuchAlgorithmException {
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+
+        assertThatThrownBy(() -> appleJwtParser.extractClaims("invalidToken", publicKey))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage("손상된 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("암호화 방식이 다른 토큰에서 Claims를 추출하면 예외를 던진다.")
+    void extractClaimsWithNotSecuredToken() throws NoSuchAlgorithmException {
+        String subject = "9876";
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        KeyPair invalidKeyPair = KeyPairGenerator.getInstance("DSA")
+                .generateKeyPair();
+        PublicKey publicKey = invalidKeyPair.getPublic();
+        String appleToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "1234")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(subject)
+                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+
+        assertThatThrownBy(() -> appleJwtParser.extractClaims(appleToken, publicKey))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage("지원하지 않는 토큰입니다.");
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProviderTest.java
@@ -28,13 +28,10 @@ class AppleOAuthUserProviderTest extends IntegrationTest {
 
     @MockBean
     private AppleJwtParser appleJwtParser;
-
     @MockBean
     private AppleClient appleClient;
-
     @MockBean
     private PublicKeyGenerator publicKeyGenerator;
-
     @MockBean
     private AppleClaimsValidator appleClaimsValidator;
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProviderTest.java
@@ -1,0 +1,80 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.dinosaur.foodbowl.IntegrationTest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponseDto;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class AppleOAuthUserProviderTest extends IntegrationTest {
+
+    @Autowired
+    private AppleOAuthUserProvider appleOAuthUserProvider;
+
+    @MockBean
+    private AppleJwtParser appleJwtParser;
+
+    @MockBean
+    private AppleClient appleClient;
+
+    @MockBean
+    private PublicKeyGenerator publicKeyGenerator;
+
+    @MockBean
+    private AppleClaimsValidator appleClaimsValidator;
+
+    @Test
+    @DisplayName("유효한 Claims를 가진 토큰이면 애플 유저 정보를 추출한다.")
+    void extractApplePlatformUser() {
+        Claims claims = Jwts.claims()
+                .setSubject("subject");
+        claims.put("email", "email");
+
+        given(appleJwtParser.extractHeaders(anyString())).willReturn(mock(Map.class));
+        given(appleClient.getApplePublicKeys()).willReturn(mock(ApplePublicKeys.class));
+        given(publicKeyGenerator.generatePublicKey(any(), any())).willReturn(mock(PublicKey.class));
+        given(appleJwtParser.extractClaims(anyString(), any())).willReturn(claims);
+        given(appleClaimsValidator.isValid(any())).willReturn(true);
+
+        ApplePlatformUserResponseDto result = appleOAuthUserProvider.extractApplePlatformUser("validToken");
+
+        assertAll(
+                () -> assertThat(result.getSocialId()).isEqualTo("subject"),
+                () -> assertThat(result.getEmail()).isEqualTo("email")
+        );
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 Claims를 가진 토큰이면 예외를 던진다.")
+    void extractApplePlatformUserWithInvalidClaims() {
+        Claims claims = Jwts.claims()
+                .setSubject("InvalidSubject");
+        claims.put("email", "InvalidEmail");
+
+        given(appleJwtParser.extractHeaders(anyString())).willReturn(mock(Map.class));
+        given(appleClient.getApplePublicKeys()).willReturn(mock(ApplePublicKeys.class));
+        given(publicKeyGenerator.generatePublicKey(any(), any())).willReturn(mock(PublicKey.class));
+        given(appleJwtParser.extractClaims(anyString(), any())).willReturn(claims);
+        given(appleClaimsValidator.isValid(any())).willReturn(false);
+
+        assertThatThrownBy(() -> appleOAuthUserProvider.extractApplePlatformUser("InvalidToken"))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage("올바르지 않은 애플 OAuth 토큰 조각 정보입니다.");
+
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProviderTest.java
@@ -3,7 +3,7 @@ package org.dinosaur.foodbowl.domain.auth.apple;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.dinosaur.foodbowl.IntegrationTest;
-import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponseDto;
+import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponse;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,7 +48,7 @@ class AppleOAuthUserProviderTest extends IntegrationTest {
         given(appleJwtParser.extractClaims(anyString(), any())).willReturn(claims);
         given(appleClaimsValidator.isValid(any())).willReturn(true);
 
-        ApplePlatformUserResponseDto result = appleOAuthUserProvider.extractApplePlatformUser("validToken");
+        ApplePlatformUserResponse result = appleOAuthUserProvider.extractApplePlatformUser("validToken");
 
         assertAll(
                 () -> assertThat(result.getSocialId()).isEqualTo("subject"),

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeyTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeyTest.java
@@ -1,0 +1,42 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplePublicKeyTest {
+
+    private static final String KTY = "kty";
+    private static final String KID = "kid";
+    private static final String USE = "use";
+    private static final String ALG = "alg";
+    private static final String N = "n";
+    private static final String E = "e";
+
+    private final ApplePublicKey applePublicKey = new ApplePublicKey(KTY, KID, USE, ALG, N, E);
+
+    @Test
+    @DisplayName("같은 알고리즘이라면 true 반환한다.")
+    void isSameAlg() {
+        assertThat(applePublicKey.isSameAlg("alg")).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 알고리즘이라면 false 반환한다.")
+    void isDifferentAlg() {
+        assertThat(applePublicKey.isSameAlg("invalidAlg")).isFalse();
+    }
+
+    @Test
+    @DisplayName("같은 키 ID 라면 true 반환한다.")
+    void isSameKid() {
+        assertThat(applePublicKey.isSameKid("kid")).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 키 ID 라면 false 반환한다.")
+    void isDifferentKid() {
+        assertThat(applePublicKey.isSameKid("invalidKid")).isFalse();
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeysTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeysTest.java
@@ -1,0 +1,38 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApplePublicKeysTest {
+
+    @Test
+    @DisplayName("알고리즘과 키 ID를 받아 알맞은 Public Key를 반환한다.")
+    void getMatchingKey() {
+        ApplePublicKey applePublicKey = new ApplePublicKey("kty", "kid", "use", "alg", "n", "e");
+
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(applePublicKey));
+
+        assertThat(applePublicKeys.getMatchingKey("alg", "kid")).isEqualTo(applePublicKey);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"invalidAlg,kid", "alg,invalidKid"})
+    @DisplayName("알고리즘과 키 ID 매칭되는 Public Key 존재하지 않으면 예외를 던진다.")
+    void getMatchingKey(String alg, String kid) {
+        ApplePublicKey applePublicKey = new ApplePublicKey("kty", "kid", "use", "alg", "n", "e");
+
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(applePublicKey));
+
+        assertThatThrownBy(() -> applePublicKeys.getMatchingKey(alg, kid))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage("올바르지 않은 애플 OAuth 토큰 헤더 정보입니다.");
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/PublicKeyGeneratorTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/PublicKeyGeneratorTest.java
@@ -1,0 +1,60 @@
+package org.dinosaur.foodbowl.domain.auth.apple;
+
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.security.PublicKey;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PublicKeyGeneratorTest {
+
+    private final PublicKeyGenerator publicKeyGenerator = new PublicKeyGenerator();
+
+    @Test
+    @DisplayName("헤더 정보를 바탕으로 Public Key를 생성한다.")
+    void generatePublicKey() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("alg", "RS256");
+        headers.put("kid", "YuyXoY");
+        ApplePublicKey applePublicKey = new ApplePublicKey(
+                "rsa",
+                "YuyXoY",
+                "sig",
+                "RS256",
+                "1JiU4l3YCeT4o0gVmxGTEK1IXR-Ghdg5Bzka12tzmtdCxU00ChH66aV-4HRBjF1t95IsaeHeDFRgmF0lJbTDTqa6_VZo2hc0zTiUAsGLacN6slePvDcR1IMucQGtPP5tGhIbU-HKabsKOFdD4VQ5PCXifjpN9R-1qOR571BxCAl4u1kUUIePAAJcBcqGRFSI_I1j_jbN3gflK_8ZNmgnPrXA0kZXzj1I7ZHgekGbZoxmDrzYm2zmja1MsE5A_JX7itBYnlR41LOtvLRCNtw7K3EFlbfB6hkPL-Swk5XNGbWZdTROmaTNzJhV-lWT0gGm6V1qWAK2qOZoIDa_3Ud0Gw",
+                "AQAB"
+        );
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(applePublicKey));
+
+        PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys);
+
+        assertThat(publicKey.getAlgorithm()).isEqualTo("RSA");
+    }
+
+    @Test
+    @DisplayName("헤더 정보가 올바르지 않으면 예외를 던진다.")
+    void generatePublicKeyWithInvalidHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("alg", "alg");
+        headers.put("kid", "kid");
+        ApplePublicKey applePublicKey = new ApplePublicKey(
+                "kty",
+                "kid",
+                "use",
+                "alg",
+                "1JiU4l3YCeT4o0gVmxGTEK1IXR-Ghdg5Bzka12tzmtdCxU00ChH66aV-4HRBjF1t95IsaeHeDFRgmF0lJbTDTqa6_VZo2hc0zTiUAsGLacN6slePvDcR1IMucQGtPP5tGhIbU-HKabsKOFdD4VQ5PCXifjpN9R-1qOR571BxCAl4u1kUUIePAAJcBcqGRFSI_I1j_jbN3gflK_8ZNmgnPrXA0kZXzj1I7ZHgekGbZoxmDrzYm2zmja1MsE5A_JX7itBYnlR41LOtvLRCNtw7K3EFlbfB6hkPL-Swk5XNGbWZdTROmaTNzJhV-lWT0gGm6V1qWAK2qOZoIDa_3Ud0Gw",
+                "AQAB"
+        );
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(applePublicKey));
+
+        assertThatThrownBy(() -> publicKeyGenerator.generatePublicKey(headers, applePublicKeys))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage("애플 OAuth 퍼블릭 키 생성 중 문제가 발생하였습니다.");
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
@@ -1,0 +1,74 @@
+package org.dinosaur.foodbowl.domain.auth.application;
+
+import org.dinosaur.foodbowl.IntegrationTest;
+import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
+import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponseDto;
+import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
+import org.dinosaur.foodbowl.domain.member.entity.Member;
+import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+class AuthServiceTest extends IntegrationTest {
+
+    @Autowired
+    private AuthService authService;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private AppleOAuthUserProvider appleOAuthUserProvider;
+
+    @Nested
+    @DisplayName("appleLogin 메서드는 ")
+    class AppleLogin {
+
+        @Test
+        @DisplayName("이전에 회원가입을 한 회원이라면 서버에서 발급한 Jwt 토큰을 반환한다.")
+        void appleLogin() {
+            Member member = Member.builder()
+                    .socialType(Member.SocialType.APPLE)
+                    .socialId("1234")
+                    .nickname("member1234")
+                    .build();
+            memberRepository.save(member);
+            AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
+            ApplePlatformUserResponseDto applePlatformUserResponseDto = new ApplePlatformUserResponseDto(
+                    "1234",
+                    "member@foodbowl.com"
+            );
+
+            given(appleOAuthUserProvider.extractApplePlatformUser(anyString())).willReturn(applePlatformUserResponseDto);
+
+            AppleTokenResponseDto result = authService.appleLogin(appleLoginRequestDto);
+
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("이전에 회원가입을 하지 않은 회원이라면 예외를 던진다.")
+        void appleLoginWithNotRegistered() {
+            AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
+            ApplePlatformUserResponseDto applePlatformUserResponseDto = new ApplePlatformUserResponseDto(
+                    "1234",
+                    "member@foodbowl.com"
+            );
+
+            given(appleOAuthUserProvider.extractApplePlatformUser(anyString())).willReturn(applePlatformUserResponseDto);
+
+            assertThatThrownBy(() -> authService.appleLogin(appleLoginRequestDto))
+                    .isInstanceOf(FoodbowlException.class)
+                    .hasMessage("애플 회원가입이 되지 않은 회원입니다.");
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
@@ -3,8 +3,8 @@ package org.dinosaur.foodbowl.domain.auth.application;
 import org.dinosaur.foodbowl.IntegrationTest;
 import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
-import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
-import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponseDto;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
@@ -46,15 +46,15 @@ class AuthServiceTest extends IntegrationTest {
                     .nickname("member1234")
                     .build();
             memberRepository.save(member);
-            AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
-            ApplePlatformUserResponseDto applePlatformUserResponseDto = new ApplePlatformUserResponseDto(
+            AppleLoginRequest appleLoginRequest = new AppleLoginRequest("AppleToken");
+            ApplePlatformUserResponse applePlatformUserResponse = new ApplePlatformUserResponse(
                     "1234",
                     "member@foodbowl.com"
             );
 
-            given(appleOAuthUserProvider.extractApplePlatformUser(anyString())).willReturn(applePlatformUserResponseDto);
+            given(appleOAuthUserProvider.extractApplePlatformUser(anyString())).willReturn(applePlatformUserResponse);
 
-            FoodbowlTokenDto result = authService.appleLogin(appleLoginRequestDto);
+            FoodbowlTokenDto result = authService.appleLogin(appleLoginRequest);
 
             assertAll(
                     () -> assertThat(result.getAccessToken()).isNotNull(),
@@ -67,15 +67,15 @@ class AuthServiceTest extends IntegrationTest {
         @Test
         @DisplayName("이전에 회원가입을 하지 않은 회원이라면 예외를 던진다.")
         void appleLoginWithNotRegistered() {
-            AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
-            ApplePlatformUserResponseDto applePlatformUserResponseDto = new ApplePlatformUserResponseDto(
+            AppleLoginRequest appleLoginRequest = new AppleLoginRequest("AppleToken");
+            ApplePlatformUserResponse applePlatformUserResponse = new ApplePlatformUserResponse(
                     "1234",
                     "member@foodbowl.com"
             );
 
-            given(appleOAuthUserProvider.extractApplePlatformUser(anyString())).willReturn(applePlatformUserResponseDto);
+            given(appleOAuthUserProvider.extractApplePlatformUser(anyString())).willReturn(applePlatformUserResponse);
 
-            assertThatThrownBy(() -> authService.appleLogin(appleLoginRequestDto))
+            assertThatThrownBy(() -> authService.appleLogin(appleLoginRequest))
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessage("애플 회원가입이 되지 않은 회원입니다.");
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
@@ -4,7 +4,7 @@ import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.api.AuthController;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
-import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -32,7 +32,7 @@ public class AuthControllerDocsTest extends MockApiTest {
     @Test
     @DisplayName("애플 로그인을 문서화한다.")
     void appleLogin() throws Exception {
-        AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
+        AppleLoginRequest appleLoginRequest = new AppleLoginRequest("AppleToken");
         FoodbowlTokenDto foodbowlTokenDto = new FoodbowlTokenDto("AccessToken", "RefreshToken");
 
         given(authService.appleLogin(any())).willReturn(foodbowlTokenDto);
@@ -50,7 +50,7 @@ public class AuthControllerDocsTest extends MockApiTest {
         };
 
         mockMvc.perform(post("/api/v1/auth/apple/login")
-                        .content(objectMapper.writeValueAsString(appleLoginRequestDto))
+                        .content(objectMapper.writeValueAsString(appleLoginRequest))
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andDo(print())
                 .andExpect(status().isOk())

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
@@ -1,0 +1,58 @@
+package org.dinosaur.foodbowl.domain.auth.docs;
+
+import org.dinosaur.foodbowl.MockApiTest;
+import org.dinosaur.foodbowl.domain.auth.api.AuthController;
+import org.dinosaur.foodbowl.domain.auth.application.AuthService;
+import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
+import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+public class AuthControllerDocsTest extends MockApiTest {
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    @DisplayName("애플 로그인을 문서화한다.")
+    void appleLogin() throws Exception {
+        AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
+        AppleTokenResponseDto appleTokenResponseDto = new AppleTokenResponseDto("FoodbowlToken");
+
+        given(authService.appleLogin(any())).willReturn(appleTokenResponseDto);
+
+        var requestFieldDescriptors = new FieldDescriptor[]{
+                fieldWithPath("appleToken").description("애플에서 발급한 토큰")
+        };
+
+        var responseFieldDescriptors = new FieldDescriptor[]{
+                fieldWithPath("accessToken").description("서버에서 발급한 토큰")
+        };
+
+        mockMvc.perform(post("/api/v1/apple/login")
+                        .content(objectMapper.writeValueAsString(appleLoginRequestDto))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("api-v1-apple-login",
+                        requestFields(
+                                requestFieldDescriptors
+                        ),
+                        responseFields(
+                                responseFieldDescriptors
+                        )));
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
@@ -3,17 +3,20 @@ package org.dinosaur.foodbowl.domain.auth.docs;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.api.AuthController;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
+import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequestDto;
-import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.cookies.CookieDescriptor;
 import org.springframework.restdocs.payload.FieldDescriptor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -30,16 +33,20 @@ public class AuthControllerDocsTest extends MockApiTest {
     @DisplayName("애플 로그인을 문서화한다.")
     void appleLogin() throws Exception {
         AppleLoginRequestDto appleLoginRequestDto = new AppleLoginRequestDto("AppleToken");
-        AppleTokenResponseDto appleTokenResponseDto = new AppleTokenResponseDto("FoodbowlToken");
+        FoodbowlTokenDto foodbowlTokenDto = new FoodbowlTokenDto("AccessToken", "RefreshToken");
 
-        given(authService.appleLogin(any())).willReturn(appleTokenResponseDto);
+        given(authService.appleLogin(any())).willReturn(foodbowlTokenDto);
 
         var requestFieldDescriptors = new FieldDescriptor[]{
                 fieldWithPath("appleToken").description("애플에서 발급한 토큰")
         };
 
+        var cookieDescriptors = new CookieDescriptor[]{
+                cookieWithName("refreshToken").description("서버에서 발급한 리프레쉬 토큰")
+        };
+
         var responseFieldDescriptors = new FieldDescriptor[]{
-                fieldWithPath("accessToken").description("서버에서 발급한 토큰")
+                fieldWithPath("accessToken").description("서버에서 발급한 엑세스 토큰")
         };
 
         mockMvc.perform(post("/api/v1/apple/login")
@@ -50,6 +57,9 @@ public class AuthControllerDocsTest extends MockApiTest {
                 .andDo(document("api-v1-apple-login",
                         requestFields(
                                 requestFieldDescriptors
+                        ),
+                        responseCookies(
+                                cookieDescriptors
                         ),
                         responseFields(
                                 responseFieldDescriptors

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
@@ -49,7 +49,7 @@ public class AuthControllerDocsTest extends MockApiTest {
                 fieldWithPath("accessToken").description("서버에서 발급한 엑세스 토큰")
         };
 
-        mockMvc.perform(post("/api/v1/apple/login")
+        mockMvc.perform(post("/api/v1/auth/apple/login")
                         .content(objectMapper.writeValueAsString(appleLoginRequestDto))
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andDo(print())

--- a/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
@@ -1,24 +1,30 @@
 package org.dinosaur.foodbowl.domain.health_check.api;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.time.LocalDateTime;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.health_check.application.HealthCheckService;
 import org.dinosaur.foodbowl.domain.health_check.dto.HealthCheckDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(HealthCheckController.class)
 class HealthCheckControllerTest extends MockApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
 
     @MockBean
     private HealthCheckService healthCheckService;

--- a/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
@@ -1,6 +1,5 @@
 package org.dinosaur.foodbowl.domain.health_check.api;
 
-import com.jayway.jsonpath.JsonPath;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.health_check.application.HealthCheckService;
 import org.dinosaur.foodbowl.domain.health_check.dto.HealthCheckDto;
@@ -13,13 +12,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.ResultMatcher;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
+import static org.dinosaur.foodbowl.TestUtils.jsonPathLocalDateTimeEquals;
 import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -36,15 +33,6 @@ class HealthCheckControllerTest extends MockApiTest {
 
     @MockBean
     private HealthCheckService healthCheckService;
-
-    private ResultMatcher jsonPathLocalDateTimeEquals(String expression, LocalDateTime expectedLocalDateTime) {
-        return result -> {
-            String content = result.getResponse().getContentAsString();
-            String localDateTimeString = JsonPath.read(content, expression);
-            LocalDateTime localDateTime = LocalDateTime.parse(localDateTimeString, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-            assertEquals(localDateTime, expectedLocalDateTime);
-        };
-    }
 
     @Nested
     @DisplayName("인증 없는 헬스 체크 요청 시")

--- a/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
@@ -3,6 +3,7 @@ package org.dinosaur.foodbowl.domain.health_check.api;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.health_check.application.HealthCheckService;
 import org.dinosaur.foodbowl.domain.health_check.dto.HealthCheckDto;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
 
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -26,15 +28,18 @@ class HealthCheckControllerTest extends MockApiTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
     @MockBean
     private HealthCheckService healthCheckService;
 
-    @DisplayName("헬스 체크 요청 시")
     @Nested
+    @DisplayName("인증 없는 헬스 체크 요청 시")
     class Check {
 
-        @DisplayName("정상적인 경우 성공 응답을 반환한다.")
         @Test
+        @DisplayName("정상적인 경우 성공 응답을 반환한다.")
         void returnSuccessResponseWhenValid() throws Exception {
             String message = "success";
             LocalDateTime now = LocalDateTime.now();
@@ -50,6 +55,62 @@ class HealthCheckControllerTest extends MockApiTest {
 
         private ResultActions requestCheckApi() throws Exception {
             return mockMvc.perform(get("/api/v1/health-check"))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 있는 헬스 체크 요청 시")
+    class AuthCheck {
+
+        @Test
+        @DisplayName("유효하지 않은 토큰인 경우 401 예외를 던진다.")
+        void throwExceptionNotExistToken() throws Exception {
+            String message = "success";
+            LocalDateTime now = LocalDateTime.now();
+            HealthCheckDto response = new HealthCheckDto(message, now);
+
+            given(healthCheckService.check()).willReturn(response);
+
+            requestAuthCheckApi("invalid-token")
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("인증 토큰 권한이 맞지 않는 경우 403 예외를 던진다")
+        void throwExceptionNotMatchAuthority() throws Exception {
+            String message = "success";
+            LocalDateTime now = LocalDateTime.now();
+            HealthCheckDto response = new HealthCheckDto(message, now);
+
+            String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_관리자);
+
+            given(healthCheckService.check()).willReturn(response);
+
+            requestAuthCheckApi(accessToken)
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 있는 경우 성공 응답을 반환한다.")
+        void returnSuccessResponseWhenExistToken() throws Exception {
+            String message = "success";
+            LocalDateTime now = LocalDateTime.now();
+            HealthCheckDto response = new HealthCheckDto(message, now);
+
+            String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+            given(healthCheckService.check()).willReturn(response);
+
+            requestAuthCheckApi(accessToken)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(message))
+                    .andExpect(jsonPath("$.created").value(now.toString()));
+        }
+
+        private ResultActions requestAuthCheckApi(String token) throws Exception {
+            return mockMvc.perform(get("/api/v1/health-check/auth")
+                            .header("Authorization", "Bearer " + token))
                     .andDo(print());
         }
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
@@ -27,7 +27,6 @@ class HealthCheckControllerTest extends MockApiTest {
 
     @Autowired
     private MockMvc mockMvc;
-
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,60 @@
+package org.dinosaur.foodbowl.domain.member.repository;
+
+import org.dinosaur.foodbowl.RepositoryTest;
+import org.dinosaur.foodbowl.domain.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
+import static org.dinosaur.foodbowl.domain.member.entity.Member.builder;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class MemberRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("findBySocialTypeAndSocialId 메서드는 ")
+    class FindBySocialTypeAndSocialId {
+
+        @BeforeEach
+        void setUp() {
+            Member member = builder()
+                    .socialType(SocialType.APPLE)
+                    .socialId("1234")
+                    .nickname("member1234")
+                    .build();
+            memberRepository.save(member);
+        }
+
+        @Test
+        @DisplayName("소셜 타입과 소셜 ID에 일치하는 멤버가 존재하면 해당 멤버를 가져온다.")
+        void getMember() {
+            Optional<Member> findMember = memberRepository.findBySocialTypeAndSocialId(SocialType.APPLE, "1234");
+
+            assertAll(
+                    () -> assertThat(findMember).isNotEmpty(),
+                    () -> assertThat(findMember.get().getSocialType()).isEqualTo(SocialType.APPLE),
+                    () -> assertThat(findMember.get().getSocialId()).isEqualTo("1234"),
+                    () -> assertThat(findMember.get().getNickname()).isEqualTo("member1234"),
+                    () -> assertThat(findMember.get().getCreatedAt()).isNotNull(),
+                    () -> assertThat(findMember.get().getUpdatedAt()).isNotNull()
+            );
+        }
+
+        @Test
+        @DisplayName("소셜 타입과 소셜 ID에 일치하는 멤버가 존재하지 않으면 가져오지 않는다.")
+        void getNoMember() {
+            Optional<Member> findMember = memberRepository.findBySocialTypeAndSocialId(SocialType.APPLE, "9876");
+
+            assertThat(findMember).isEmpty();
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,125 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import org.dinosaur.foodbowl.IntegrationTest;
+import org.dinosaur.foodbowl.global.exception.ErrorStatus;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType.ROLE_회원;
+
+class JwtTokenProviderTest extends IntegrationTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("엑세스 토큰을 생성한다.")
+    void createAccessToken() {
+        String accessToken = jwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        List<String> roleNames = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        assertThat(roleNames).containsExactly(ROLE_회원.name());
+    }
+
+    @Test
+    @DisplayName("리프레쉬 토큰을 생성한다.")
+    void createRefreshToken() {
+        String refreshToken = jwtTokenProvider.createRefreshToken(1L);
+
+        String id = jwtTokenProvider.getSubject(refreshToken);
+
+        assertThat(id).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰에서 인증 정보를 얻을 때 예외가 발생한다.")
+    void getAuthenticationByInvalidToken() {
+        String accessToken = "invalid-token";
+
+        assertThatThrownBy(() -> jwtTokenProvider.getAuthentication(accessToken))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage(ErrorStatus.JWT_MALFORMED.getMessage());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰에서 제목 정보를 얻을 때 예외가 발생한다.")
+    void getSubjectByInvalidToken() {
+        String accessToken = "invalid-token";
+
+        assertThatThrownBy(() -> jwtTokenProvider.getSubject(accessToken))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage(ErrorStatus.JWT_MALFORMED.getMessage());
+    }
+
+    @Test
+    @DisplayName("만료된 토큰에서 인증 정보를 얻을 때 예외가 발생한다.")
+    void getAuthenticationByExpiredToken() {
+        JwtTokenProvider expiredJwtTokenProvider = new JwtTokenProvider(
+                "4944284173b906fc7409a2de29391af31c45b55abc248bb4807c52334f800e308c5069e3379021fae9c01d78273111721158e99c24c46f217bb50021b3c03953",
+                1,
+                1
+        );
+        String accessToken = expiredJwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        assertThatThrownBy(() -> expiredJwtTokenProvider.getAuthentication(accessToken))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage(ErrorStatus.JWT_EXPIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("만료된 토큰에서 제목 정보를 얻을 때 예외가 발생한다.")
+    void getSubjectByExpiredToken() {
+        JwtTokenProvider expiredJwtTokenProvider = new JwtTokenProvider(
+                "4944284173b906fc7409a2de29391af31c45b55abc248bb4807c52334f800e308c5069e3379021fae9c01d78273111721158e99c24c46f217bb50021b3c03953",
+                1,
+                1
+        );
+        String accessToken = expiredJwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        assertThatThrownBy(() -> expiredJwtTokenProvider.getSubject(accessToken))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage(ErrorStatus.JWT_EXPIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 키로 생성된 토큰에서 인증 정보를 얻을 때 예외가 발생한다.")
+    void getAuthenticationByInvalidKeyToken() {
+        JwtTokenProvider invalidJwtTokenProvider = new JwtTokenProvider(
+                "4944284173b906fc7409a2de29391af31c45b55abc248bb4807c52334f800e308c5069e3379021fae9c01d78273111721158e99c24c46f217bb50021b3c03953",
+                100000,
+                100000
+        );
+        String accessToken = invalidJwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        assertThatThrownBy(() -> jwtTokenProvider.getAuthentication(accessToken))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage(ErrorStatus.JWT_WRONG_SIGNATURE.getMessage());
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 키로 생성된 토큰에서 제목 정보를 얻을 때 예외가 발생한다.")
+    void getSubjectByInvalidKeyToken() {
+        JwtTokenProvider invalidJwtTokenProvider = new JwtTokenProvider(
+                "4944284173b906fc7409a2de29391af31c45b55abc248bb4807c52334f800e308c5069e3379021fae9c01d78273111721158e99c24c46f217bb50021b3c03953",
+                100000,
+                100000
+        );
+        String accessToken = invalidJwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        assertThatThrownBy(() -> jwtTokenProvider.getSubject(accessToken))
+                .isInstanceOf(FoodbowlException.class)
+                .hasMessage(ErrorStatus.JWT_WRONG_SIGNATURE.getMessage());
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,123 @@
+package org.dinosaur.foodbowl.global.config.security.jwt;
+
+import org.dinosaur.foodbowl.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType.ROLE_회원;
+
+class JwtTokenProviderTest extends IntegrationTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("엑세스 토큰을 생성한다.")
+    void createAccessToken() {
+        String accessToken = jwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken).get();
+        List<String> roleNames = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        assertThat(roleNames).containsExactly(ROLE_회원.name());
+    }
+
+    @Test
+    @DisplayName("리프레쉬 토큰을 생성한다.")
+    void createRefreshToken() {
+        String refreshToken = jwtTokenProvider.createRefreshToken(1L);
+
+        String id = jwtTokenProvider.getSubject(refreshToken).get();
+
+        assertThat(id).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰에서 인증 정보를 얻을 수 없다.")
+    void getAuthenticationByInvalidToken() {
+        String accessToken = "invalid-token";
+
+        Optional<Authentication> authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+        assertThat(authentication).isEmpty();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰에서 제목 정보를 얻을 수 없다.")
+    void getSubjectByInvalidToken() {
+        String accessToken = "invalid-token";
+
+        Optional<String> subject = jwtTokenProvider.getSubject(accessToken);
+
+        assertThat(subject).isEmpty();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰에서 인증 정보를 얻을 수 없다.")
+    void getAuthenticationByExpiredToken() {
+        JwtTokenProvider expiredJwtTokenProvider = new JwtTokenProvider(
+                "4944284173b906fc7409a2de29391af31c45b55abc248bb4807c52334f800e308c5069e3379021fae9c01d78273111721158e99c24c46f217bb50021b3c03953",
+                1,
+                1
+        );
+        String accessToken = expiredJwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        Optional<Authentication> authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+        assertThat(authentication).isEmpty();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰에서 제목 정보를 얻을 수 없다.")
+    void getSubjectByExpiredToken() {
+        JwtTokenProvider expiredJwtTokenProvider = new JwtTokenProvider(
+                "4944284173b906fc7409a2de29391af31c45b55abc248bb4807c52334f800e308c5069e3379021fae9c01d78273111721158e99c24c46f217bb50021b3c03953",
+                1,
+                1
+        );
+        String accessToken = expiredJwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        Optional<String> subject = jwtTokenProvider.getSubject(accessToken);
+
+        assertThat(subject).isEmpty();
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 키로 생성된 토큰에서 인증 정보를 얻을 수 없다.")
+    void getAuthenticationByInvalidKeyToken() {
+        JwtTokenProvider invalidJwtTokenProvider = new JwtTokenProvider(
+                "4944284173b906fc7409a2de29391af31c45b55abc248bb4807c52334f800e308c5069e3379021fae9c01d78273111721158e99c24c46f217bb50021b3c03953",
+                100000,
+                100000
+        );
+        String accessToken = invalidJwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        Optional<Authentication> authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+        assertThat(authentication).isEmpty();
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 키로 생성된 토큰에서 제목 정보를 얻을 수 없다.")
+    void getSubjectByInvalidKeyToken() {
+        JwtTokenProvider invalidJwtTokenProvider = new JwtTokenProvider(
+                "4944284173b906fc7409a2de29391af31c45b55abc248bb4807c52334f800e308c5069e3379021fae9c01d78273111721158e99c24c46f217bb50021b3c03953",
+                100000,
+                100000
+        );
+        String accessToken = invalidJwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        Optional<String> subject = jwtTokenProvider.getSubject(accessToken);
+
+        assertThat(subject).isEmpty();
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProviderTest.java
@@ -23,7 +23,7 @@ class JwtTokenProviderTest extends IntegrationTest {
     void createAccessToken() {
         String accessToken = jwtTokenProvider.createAccessToken(1L, ROLE_회원);
 
-        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken).get();
+        Authentication authentication = jwtTokenProvider.generateAuth(accessToken).get();
         List<String> roleNames = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .toList();
@@ -36,7 +36,7 @@ class JwtTokenProviderTest extends IntegrationTest {
     void createRefreshToken() {
         String refreshToken = jwtTokenProvider.createRefreshToken(1L);
 
-        String id = jwtTokenProvider.getSubject(refreshToken).get();
+        String id = jwtTokenProvider.extractSubject(refreshToken).get();
 
         assertThat(id).isEqualTo("1");
     }
@@ -46,7 +46,7 @@ class JwtTokenProviderTest extends IntegrationTest {
     void getAuthenticationByInvalidToken() {
         String accessToken = "invalid-token";
 
-        Optional<Authentication> authentication = jwtTokenProvider.getAuthentication(accessToken);
+        Optional<Authentication> authentication = jwtTokenProvider.generateAuth(accessToken);
 
         assertThat(authentication).isEmpty();
     }
@@ -56,7 +56,7 @@ class JwtTokenProviderTest extends IntegrationTest {
     void getSubjectByInvalidToken() {
         String accessToken = "invalid-token";
 
-        Optional<String> subject = jwtTokenProvider.getSubject(accessToken);
+        Optional<String> subject = jwtTokenProvider.extractSubject(accessToken);
 
         assertThat(subject).isEmpty();
     }
@@ -71,7 +71,7 @@ class JwtTokenProviderTest extends IntegrationTest {
         );
         String accessToken = expiredJwtTokenProvider.createAccessToken(1L, ROLE_회원);
 
-        Optional<Authentication> authentication = jwtTokenProvider.getAuthentication(accessToken);
+        Optional<Authentication> authentication = jwtTokenProvider.generateAuth(accessToken);
 
         assertThat(authentication).isEmpty();
     }
@@ -86,7 +86,7 @@ class JwtTokenProviderTest extends IntegrationTest {
         );
         String accessToken = expiredJwtTokenProvider.createAccessToken(1L, ROLE_회원);
 
-        Optional<String> subject = jwtTokenProvider.getSubject(accessToken);
+        Optional<String> subject = jwtTokenProvider.extractSubject(accessToken);
 
         assertThat(subject).isEmpty();
     }
@@ -101,7 +101,7 @@ class JwtTokenProviderTest extends IntegrationTest {
         );
         String accessToken = invalidJwtTokenProvider.createAccessToken(1L, ROLE_회원);
 
-        Optional<Authentication> authentication = jwtTokenProvider.getAuthentication(accessToken);
+        Optional<Authentication> authentication = jwtTokenProvider.generateAuth(accessToken);
 
         assertThat(authentication).isEmpty();
     }
@@ -116,7 +116,7 @@ class JwtTokenProviderTest extends IntegrationTest {
         );
         String accessToken = invalidJwtTokenProvider.createAccessToken(1L, ROLE_회원);
 
-        Optional<String> subject = jwtTokenProvider.getSubject(accessToken);
+        Optional<String> subject = jwtTokenProvider.extractSubject(accessToken);
 
         assertThat(subject).isEmpty();
     }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #10

## 📝 작업 요약

애플 OAuth 로그인을 구현하였습니다.

## 🔎 작업 상세 설명

- `@FeignClient`를 이용해 HTTP 클라이언트를 구현하였습니다.
- 애플 퍼플릭 키 정보를 바탕으로 퍼플릭 키를 생성하는 기능을 구현하였습니다.
- 생성한 퍼플릭 키를 통해 클라이언트에서 보낸 애플 토큰을 파싱하는 기능을 구현하였습니다.

## 🌟 리뷰 요구 사항

> 1시간
> 오래 걸린 작업이라 리뷰에 많은 시간이 들 수 있습니다. 잘 부탁드립니다 :)
