### PR TITLE
Feature/#13 로그아웃 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/auth/auth.adoc
+++ b/src/docs/asciidoc/auth/auth.adoc
@@ -19,22 +19,44 @@ link:../foodbowl.html[API 목록으로 돌아가기]
 
 === Request
 
-include::{snippets}/api-v1-apple-login/http-request.adoc[]
+include::{snippets}/api-v1-auth-apple-login/http-request.adoc[]
 
 === Request Fields
 
-include::{snippets}/api-v1-apple-login/request-fields.adoc[]
+include::{snippets}/api-v1-auth-apple-login/request-fields.adoc[]
 
 == 응답
 
 === Response
 
-include::{snippets}/api-v1-apple-login/http-response.adoc[]
+include::{snippets}/api-v1-auth-apple-login/http-response.adoc[]
 
 === Response Fields
 
-include::{snippets}/api-v1-apple-login/response-fields.adoc[]
+include::{snippets}/api-v1-auth-apple-login/response-fields.adoc[]
 
 === Response Cookies
 
-include::{snippets}/api-v1-apple-login/response-cookies.adoc[]
+include::{snippets}/api-v1-auth-apple-login/response-cookies.adoc[]
+
+== *애플 로그아웃* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-auth-apple-logout/http-request.adoc[]
+
+=== Request Headers
+
+include::{snippets}/api-v1-auth-apple-logout/request-headers.adoc[]
+
+=== Request Cookies
+
+include::{snippets}/api-v1-auth-apple-logout/request-cookies.adoc[]
+
+== 응답
+
+=== Response
+
+include::{snippets}/api-v1-auth-apple-logout/http-response.adoc[]

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -1,5 +1,7 @@
 package org.dinosaur.foodbowl.domain.auth.api;
 
+import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.REFRESH_TOKEN;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -9,6 +11,7 @@ import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponse;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.global.resolver.MemberId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,9 +37,23 @@ public class AuthController {
     }
 
     private void registerRefreshCookie(HttpServletResponse response, String refreshToken) {
-        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        Cookie cookie = new Cookie(REFRESH_TOKEN.getName(), refreshToken);
         cookie.setHttpOnly(true);
         cookie.setMaxAge((int) jwtTokenProvider.getValidRefreshMilliSecond() / 1000);
+        response.addCookie(cookie);
+    }
+
+    @PostMapping("/apple/logout")
+    public ResponseEntity<Void> appleLogout(@MemberId Long memberId, HttpServletResponse response) {
+        authService.appleLogout(memberId);
+        deleteRefreshCookie(response);
+        return ResponseEntity.noContent().build();
+    }
+
+    private void deleteRefreshCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN.getName(), null);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
         response.addCookie(cookie);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleJwtParser.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleJwtParser.java
@@ -1,18 +1,27 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_TOKEN;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.JWT_EXPIRED;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.JWT_MALFORMED;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.JWT_UNKNOWN;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.JWT_UNSUPPORTED;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.JWT_WRONG_SIGNATURE;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
-import lombok.RequiredArgsConstructor;
-import org.dinosaur.foodbowl.global.exception.FoodbowlException;
-import org.springframework.stereotype.Component;
-
 import java.security.PublicKey;
 import java.util.Base64;
 import java.util.Map;
-
-import static org.dinosaur.foodbowl.global.exception.ErrorStatus.*;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProvider.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProvider.java
@@ -1,15 +1,14 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_CLAIMS;
+
 import io.jsonwebtoken.Claims;
+import java.security.PublicKey;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponse;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
 import org.springframework.stereotype.Component;
-
-import java.security.PublicKey;
-import java.util.Map;
-
-import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_CLAIMS;
 
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeys.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeys.java
@@ -1,14 +1,13 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_HEADER;
+
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
-
-import java.util.List;
-
-import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_HEADER;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/PublicKeyGenerator.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/apple/PublicKeyGenerator.java
@@ -1,7 +1,6 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
-import org.dinosaur.foodbowl.global.exception.FoodbowlException;
-import org.springframework.stereotype.Component;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_PUBLIC_KEY;
 
 import java.math.BigInteger;
 import java.security.KeyFactory;
@@ -11,8 +10,8 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 import java.util.Map;
-
-import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_INVALID_PUBLIC_KEY;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.stereotype.Component;
 
 @Component
 public class PublicKeyGenerator {

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -16,8 +16,10 @@ import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class AuthService {
 
@@ -26,6 +28,7 @@ public class AuthService {
     private final AppleOAuthUserProvider appleOAuthUserProvider;
     private final RedisTemplate<String, Object> redisTemplate;
 
+    @Transactional
     public FoodbowlTokenDto appleLogin(AppleLoginRequest appleLoginRequest) {
         ApplePlatformUserResponse applePlatformUserResponse =
                 appleOAuthUserProvider.extractApplePlatformUser(appleLoginRequest.getAppleToken());
@@ -54,6 +57,7 @@ public class AuthService {
                 );
     }
 
+    @Transactional
     public void appleLogout(Long memberId) {
         redisTemplate.delete(String.valueOf(memberId));
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -53,4 +53,8 @@ public class AuthService {
                         TimeUnit.MILLISECONDS
                 );
     }
+
+    public void appleLogout(Long memberId) {
+        redisTemplate.delete(String.valueOf(memberId));
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -1,5 +1,10 @@
 package org.dinosaur.foodbowl.domain.auth.application;
 
+import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_NOT_REGISTER;
+
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
@@ -11,12 +16,6 @@ import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-
-import java.util.concurrent.TimeUnit;
-
-import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
-import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
-import static org.dinosaur.foodbowl.global.exception.ErrorStatus.APPLE_NOT_REGISTER;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/entity/Blame.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/entity/Blame.java
@@ -1,6 +1,16 @@
 package org.dinosaur.foodbowl.domain.blame.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/repository/BlameRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/repository/BlameRepository.java
@@ -4,4 +4,5 @@ import org.dinosaur.foodbowl.domain.blame.entity.Blame;
 import org.springframework.data.repository.Repository;
 
 public interface BlameRepository extends Repository<Blame, Long> {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/entity/Bookmark.java
@@ -1,8 +1,20 @@
 package org.dinosaur.foodbowl.domain.bookmark.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepository.java
@@ -4,4 +4,5 @@ import org.dinosaur.foodbowl.domain.bookmark.entity.Bookmark;
 import org.springframework.data.repository.Repository;
 
 public interface BookmarkRepository extends Repository<Bookmark, Long> {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/comment/entity/Comment.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/comment/entity/Comment.java
@@ -1,14 +1,26 @@
 package org.dinosaur.foodbowl.domain.comment.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity

--- a/src/main/java/org/dinosaur/foodbowl/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/comment/repository/CommentRepository.java
@@ -4,4 +4,5 @@ import org.dinosaur.foodbowl.domain.comment.entity.Comment;
 import org.springframework.data.repository.Repository;
 
 public interface CommentRepository extends Repository<Comment, Long> {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/entity/Follow.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/entity/Follow.java
@@ -1,8 +1,20 @@
 package org.dinosaur.foodbowl.domain.follow.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/repository/FollowRepository.java
@@ -4,4 +4,5 @@ import org.dinosaur.foodbowl.domain.follow.entity.Follow;
 import org.springframework.data.repository.Repository;
 
 public interface FollowRepository extends Repository<Follow, Long> {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckController.java
@@ -18,14 +18,12 @@ public class HealthCheckController {
     @GetMapping("/health-check")
     public ResponseEntity<HealthCheckDto> check() {
         HealthCheckDto response = healthCheckService.check();
-
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/health-check/auth")
     public ResponseEntity<HealthCheckDto> authCheck() {
         HealthCheckDto response = healthCheckService.check();
-
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/health_check/application/HealthCheckService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/health_check/application/HealthCheckService.java
@@ -1,11 +1,10 @@
 package org.dinosaur.foodbowl.domain.health_check.application;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.health_check.dto.HealthCheckDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
@@ -1,8 +1,22 @@
 package org.dinosaur.foodbowl.domain.member.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;
 
@@ -49,14 +63,8 @@ public class Member extends AuditingEntity {
 
     @Builder
     private Member(
-            Thumbnail thumbnail,
-            SocialType socialType,
-            String socialId,
-            String email,
-            String nickname,
-            String introduction,
-            String region1depthName,
-            String region2depthName
+            Thumbnail thumbnail, SocialType socialType, String socialId, String email, String nickname,
+            String introduction, String region1depthName, String region2depthName
     ) {
         this.thumbnail = thumbnail;
         this.socialType = socialType;

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/MemberRole.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/MemberRole.java
@@ -1,8 +1,20 @@
 package org.dinosaur.foodbowl.domain.member.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;
 
 @Getter

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Role.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Role.java
@@ -1,6 +1,13 @@
 package org.dinosaur.foodbowl.domain.member.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepository.java
@@ -1,11 +1,10 @@
 package org.dinosaur.foodbowl.domain.member.repository;
 
-import org.dinosaur.foodbowl.domain.member.entity.Member;
-import org.springframework.data.repository.Repository;
+import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
 
 import java.util.Optional;
-
-import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
+import org.dinosaur.foodbowl.domain.member.entity.Member;
+import org.springframework.data.repository.Repository;
 
 public interface MemberRepository extends Repository<Member, Long> {
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/repository/MemberRoleRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/repository/MemberRoleRepository.java
@@ -4,4 +4,5 @@ import org.dinosaur.foodbowl.domain.member.entity.MemberRole;
 import org.springframework.data.repository.Repository;
 
 public interface MemberRoleRepository extends Repository<MemberRole, Long> {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/repository/RoleRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/repository/RoleRepository.java
@@ -1,9 +1,8 @@
 package org.dinosaur.foodbowl.domain.member.repository;
 
+import java.util.List;
 import org.dinosaur.foodbowl.domain.member.entity.Role;
 import org.springframework.data.repository.Repository;
-
-import java.util.List;
 
 public interface RoleRepository extends Repository<Role, Long> {
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Photo.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Photo.java
@@ -1,8 +1,20 @@
 package org.dinosaur.foodbowl.domain.photo.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Thumbnail.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/entity/Thumbnail.java
@@ -1,8 +1,17 @@
 package org.dinosaur.foodbowl.domain.photo.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;
 
 @Getter

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/repository/PhotoRepository.java
@@ -4,4 +4,5 @@ import org.dinosaur.foodbowl.domain.photo.entity.Photo;
 import org.springframework.data.repository.Repository;
 
 public interface PhotoRepository extends Repository<Photo, Long> {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Category.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Category.java
@@ -1,6 +1,13 @@
 package org.dinosaur.foodbowl.domain.post.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -1,8 +1,22 @@
 package org.dinosaur.foodbowl.domain.post.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
 import org.dinosaur.foodbowl.domain.store.entity.Store;

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/entity/PostCategory.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/entity/PostCategory.java
@@ -1,8 +1,20 @@
 package org.dinosaur.foodbowl.domain.post.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;
 
 @Getter

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/repository/CategoryRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/repository/CategoryRepository.java
@@ -1,9 +1,8 @@
 package org.dinosaur.foodbowl.domain.post.repository;
 
+import java.util.List;
 import org.dinosaur.foodbowl.domain.post.entity.Category;
 import org.springframework.data.repository.Repository;
-
-import java.util.List;
 
 public interface CategoryRepository extends Repository<Category, Long> {
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostCategoryRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostCategoryRepository.java
@@ -4,4 +4,5 @@ import org.dinosaur.foodbowl.domain.post.entity.PostCategory;
 import org.springframework.data.repository.Repository;
 
 public interface PostCategoryRepository extends Repository<PostCategory, Long> {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostRepository.java
@@ -4,4 +4,5 @@ import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.springframework.data.repository.Repository;
 
 public interface PostRepository extends Repository<Post, Long> {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/entity/Address.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/entity/Address.java
@@ -3,11 +3,10 @@ package org.dinosaur.foodbowl.domain.store.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.math.BigDecimal;
 
 @Getter
 @Embeddable
@@ -57,18 +56,11 @@ public class Address {
     private BigDecimal y;
 
     @Builder
-    private Address(String addressName,
-                    String region1depthName,
-                    String region2depthName,
-                    String region3depthName,
-                    String roadName,
-                    String undergroundYN,
-                    String mainBuildingNo,
-                    String subBuildingNo,
-                    String buildingName,
-                    String zoneNo,
-                    BigDecimal x,
-                    BigDecimal y) {
+    private Address(
+            String addressName, String region1depthName, String region2depthName, String region3depthName,
+            String roadName, String undergroundYN, String mainBuildingNo, String subBuildingNo, String buildingName,
+            String zoneNo, BigDecimal x, BigDecimal y
+    ) {
         this.addressName = addressName;
         this.region1depthName = region1depthName;
         this.region2depthName = region2depthName;

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/entity/Store.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/entity/Store.java
@@ -1,9 +1,19 @@
 package org.dinosaur.foodbowl.domain.store.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;
 
 @Getter

--- a/src/main/java/org/dinosaur/foodbowl/global/config/jpa/JpaConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/jpa/JpaConfig.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAccessDeniedHandler.java
@@ -3,17 +3,17 @@ package org.dinosaur.foodbowl.global.config.security;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
 
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException, ServletException {
         response.sendError(HttpServletResponse.SC_FORBIDDEN);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAuthenticationEntryPoint.java
@@ -3,17 +3,17 @@ package org.dinosaur.foodbowl.global.config.security;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
 
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAuthenticationEntryPoint.java
@@ -14,6 +14,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException authException) throws IOException, ServletException {
+        response.getWriter().write("인증에 실패하였습니다.");
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -4,14 +4,13 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Component
@@ -21,7 +20,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtAuthorizationExtractor jwtAuthorizationExtractor;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
         Optional<String> accessToken = jwtAuthorizationExtractor.extractAccessToken(request);
 
         if (accessToken.isPresent()) {

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthorizationExtractor.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtAuthorizationExtractor.java
@@ -1,10 +1,9 @@
 package org.dinosaur.foodbowl.global.config.security.jwt;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.stereotype.Component;
-
 import java.util.Enumeration;
 import java.util.Optional;
+import org.springframework.stereotype.Component;
 
 @Component
 public class JwtAuthorizationExtractor {

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProvider.java
@@ -1,25 +1,30 @@
 package org.dinosaur.foodbowl.global.config.security.jwt;
 
-import io.jsonwebtoken.*;
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.CLAMS_ROLES;
+import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.DELIMITER;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import javax.crypto.SecretKey;
 import org.dinosaur.foodbowl.global.exception.ErrorStatus;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
-
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
-import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
-import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.CLAMS_ROLES;
-import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.DELIMITER;
 
 @Component
 public class JwtTokenProvider {
@@ -91,7 +96,8 @@ public class JwtTokenProvider {
                     claims.get(CLAMS_ROLES.getName()).toString().split(DELIMITER.getName())
             ).toList();
             UserDetails userDetails = new JwtUser(claims.getSubject(), roleNames);
-            return Optional.of(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
+            return Optional.of(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(),
+                    userDetails.getAuthorities()));
         }
         return Optional.empty();
     }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtUser.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtUser.java
@@ -1,13 +1,12 @@
 package org.dinosaur.foodbowl.global.config.security.jwt;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class JwtUser implements UserDetails {

--- a/src/main/java/org/dinosaur/foodbowl/global/config/web/FeignClientConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/web/FeignClientConfig.java
@@ -7,4 +7,5 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableFeignClients(basePackageClasses = FoodbowlApplication.class)
 public class FeignClientConfig {
+
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/web/WebConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/web/WebConfig.java
@@ -1,0 +1,20 @@
+package org.dinosaur.foodbowl.global.config.web;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.global.resolver.MemberIdArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final MemberIdArgumentResolver memberIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(memberIdArgumentResolver);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/entity/AuditingEntity.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/entity/AuditingEntity.java
@@ -3,12 +3,11 @@ package org.dinosaur.foodbowl.global.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass

--- a/src/main/java/org/dinosaur/foodbowl/global/resolver/MemberId.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/resolver/MemberId.java
@@ -1,0 +1,12 @@
+package org.dinosaur.foodbowl.global.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberId {
+
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/resolver/MemberIdArgumentResolver.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/resolver/MemberIdArgumentResolver.java
@@ -1,0 +1,41 @@
+package org.dinosaur.foodbowl.global.resolver;
+
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.JWT_MALFORMED;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.JWT_NOT_FOUND;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtAuthorizationExtractor;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtAuthorizationExtractor jwtAuthorizationExtractor;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Long.class)
+                && parameter.hasParameterAnnotation(MemberId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String accessToken =
+                jwtAuthorizationExtractor.extractAccessToken(webRequest.getNativeRequest(HttpServletRequest.class))
+                        .orElseThrow(() -> new FoodbowlException(JWT_NOT_FOUND));
+        String memberId = jwtTokenProvider.extractSubject(accessToken)
+                .orElseThrow(() -> new FoodbowlException(JWT_MALFORMED));
+        return Long.parseLong(memberId);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/resolver/MemberIdArgumentResolver.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/resolver/MemberIdArgumentResolver.java
@@ -36,6 +36,14 @@ public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
                         .orElseThrow(() -> new FoodbowlException(JWT_NOT_FOUND));
         String memberId = jwtTokenProvider.extractSubject(accessToken)
                 .orElseThrow(() -> new FoodbowlException(JWT_MALFORMED));
-        return Long.parseLong(memberId);
+        return parseToLong(memberId);
+    }
+    
+    private Long parseToLong(String memberId) {
+        try {
+            return Long.parseLong(memberId);
+        } catch (NumberFormatException e) {
+            throw new FoodbowlException(JWT_MALFORMED);
+        }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/IntegrationTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/IntegrationTest.java
@@ -6,5 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @SpringBootTest
 public class IntegrationTest {
+
 }
 

--- a/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
@@ -1,5 +1,10 @@
 package org.dinosaur.foodbowl;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dinosaur.foodbowl.global.config.security.CustomAccessDeniedHandler;
 import org.dinosaur.foodbowl.global.config.security.CustomAuthenticationEntryPoint;
@@ -17,11 +22,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
-
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 @Import(value = {
         SecurityConfig.class,

--- a/src/test/java/org/dinosaur/foodbowl/RepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/RepositoryTest.java
@@ -10,4 +10,5 @@ import org.springframework.context.annotation.Import;
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @DataJpaTest
 public class RepositoryTest {
+
 }

--- a/src/test/java/org/dinosaur/foodbowl/TestUtils.java
+++ b/src/test/java/org/dinosaur/foodbowl/TestUtils.java
@@ -1,12 +1,11 @@
 package org.dinosaur.foodbowl;
 
-import com.jayway.jsonpath.JsonPath;
-import org.springframework.test.web.servlet.ResultMatcher;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.jayway.jsonpath.JsonPath;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.springframework.test.web.servlet.ResultMatcher;
 
 public class TestUtils {
 
@@ -14,7 +13,8 @@ public class TestUtils {
         return result -> {
             String content = result.getResponse().getContentAsString();
             String localDateTimeString = JsonPath.read(content, expression);
-            LocalDateTime localDateTime = LocalDateTime.parse(localDateTimeString, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            LocalDateTime localDateTime = LocalDateTime.parse(localDateTimeString,
+                    DateTimeFormatter.ISO_LOCAL_DATE_TIME);
             assertEquals(localDateTime, expectedLocalDateTime);
         };
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/address/AddressTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/address/AddressTest.java
@@ -1,12 +1,11 @@
 package org.dinosaur.foodbowl.domain.address;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
 import org.dinosaur.foodbowl.domain.store.entity.Address;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.math.BigDecimal;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class AddressTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -1,5 +1,13 @@
 package org.dinosaur.foodbowl.domain.auth.api;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
@@ -11,14 +19,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends MockApiTest {

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -1,20 +1,29 @@
 package org.dinosaur.foodbowl.domain.auth.api;
 
+import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.REFRESH_TOKEN;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.Cookie;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -22,6 +31,9 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends MockApiTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     @MockBean
     private AuthService authService;
@@ -58,6 +70,40 @@ class AuthControllerTest extends MockApiTest {
             return mockMvc.perform(post("/api/v1/auth/apple/login")
                             .content(objectMapper.writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON_VALUE))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("애플 로그아웃 api는 ")
+    class AppleLogout {
+
+        @Test
+        @DisplayName("성공 시 리프레쉬 토큰을 삭제한다.")
+        void appleLogout() throws Exception {
+            String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+            willDoNothing().given(authService).appleLogout(any());
+
+            appleLogoutApi(accessToken)
+                    .andExpect(status().isNoContent())
+                    .andExpect(cookie().exists("refreshToken"))
+                    .andExpect(cookie().value("refreshToken", nullValue()))
+                    .andExpect(cookie().maxAge("refreshToken", 0));
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 존재하지 않으면 401 예외를 발생시킨다.")
+        void appleLogoutWithEmptyToken() throws Exception {
+            appleLogoutApi(null)
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(content().string("인증에 실패하였습니다."));
+        }
+
+        private ResultActions appleLogoutApi(String accessToken) throws Exception {
+            return mockMvc.perform(post("/api/v1/auth/apple/logout")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .cookie(new Cookie(REFRESH_TOKEN.getName(), "refreshToken")))
                     .andDo(print());
         }
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClaimsValidatorTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClaimsValidatorTest.java
@@ -1,13 +1,13 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class AppleClaimsValidatorTest {
 
@@ -32,11 +32,7 @@ class AppleClaimsValidatorTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {
-            "invalidIss,clientID,nonce",
-            "iss,invalidClientID,nonce",
-            "iss,clientID,invalidNonce"
-    })
+    @CsvSource(value = {"invalidIss,clientID,nonce", "iss,invalidClientID,nonce", "iss,clientID,invalidNonce"})
     @DisplayName("유효하지 않은 claims 정보를 가지고 있으면 false 반환한다.")
     void invalidClaims(String iss, String clientId, String nonce) {
         Claims claims = Jwts.claims()

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClientTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleClientTest.java
@@ -1,14 +1,13 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Objects;
 import org.dinosaur.foodbowl.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-import java.util.Objects;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class AppleClientTest extends IntegrationTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleJwtParserTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleJwtParserTest.java
@@ -1,19 +1,22 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import org.dinosaur.foodbowl.global.exception.FoodbowlException;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.security.*;
-import java.util.Date;
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Date;
+import java.util.Map;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class AppleJwtParserTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/AppleOAuthUserProviderTest.java
@@ -1,18 +1,5 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import org.dinosaur.foodbowl.IntegrationTest;
-import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponse;
-import org.dinosaur.foodbowl.global.exception.FoodbowlException;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-
-import java.security.PublicKey;
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -20,6 +7,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.security.PublicKey;
+import java.util.Map;
+import org.dinosaur.foodbowl.IntegrationTest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponse;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 class AppleOAuthUserProviderTest extends IntegrationTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeyTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeyTest.java
@@ -1,9 +1,9 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class ApplePublicKeyTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeysTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/ApplePublicKeysTest.java
@@ -1,15 +1,14 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ApplePublicKeysTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/PublicKeyGeneratorTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/apple/PublicKeyGeneratorTest.java
@@ -1,16 +1,15 @@
 package org.dinosaur.foodbowl.domain.auth.apple;
 
-import org.dinosaur.foodbowl.global.exception.FoodbowlException;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.security.PublicKey;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class PublicKeyGeneratorTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
+import java.util.concurrent.TimeUnit;
 import org.dinosaur.foodbowl.IntegrationTest;
 import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
@@ -79,5 +80,21 @@ class AuthServiceTest extends IntegrationTest {
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessage("애플 회원가입이 되지 않은 회원입니다.");
         }
+    }
+
+    @Test
+    @DisplayName("애플 로그아웃은 리프레쉬 토큰을 삭제한다.")
+    void appleLogout() {
+        Long memberId = 1L;
+        redisTemplate.opsForValue().set(
+                String.valueOf(memberId),
+                "refreshToken",
+                5,
+                TimeUnit.MINUTES
+        );
+
+        authService.appleLogout(memberId);
+
+        assertThat(redisTemplate.opsForValue().get(String.valueOf(memberId))).isNull();
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
@@ -1,5 +1,11 @@
 package org.dinosaur.foodbowl.domain.auth.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
 import org.dinosaur.foodbowl.IntegrationTest;
 import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
@@ -14,12 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.redis.core.RedisTemplate;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 
 class AuthServiceTest extends IntegrationTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
@@ -1,5 +1,17 @@
 package org.dinosaur.foodbowl.domain.auth.docs;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.api.AuthController;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
@@ -12,16 +24,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.cookies.CookieDescriptor;
 import org.springframework.restdocs.payload.FieldDescriptor;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
-import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AuthController.class)
 public class AuthControllerDocsTest extends MockApiTest {

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
@@ -1,9 +1,14 @@
 package org.dinosaur.foodbowl.domain.auth.docs;
 
+import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.REFRESH_TOKEN;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -12,21 +17,29 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.Cookie;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.api.AuthController;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.cookies.CookieDescriptor;
+import org.springframework.restdocs.headers.HeaderDescriptor;
 import org.springframework.restdocs.payload.FieldDescriptor;
 
 @WebMvcTest(AuthController.class)
 public class AuthControllerDocsTest extends MockApiTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     @MockBean
     private AuthService authService;
@@ -56,7 +69,7 @@ public class AuthControllerDocsTest extends MockApiTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andDo(document("api-v1-apple-login",
+                .andDo(document("api-v1-auth-apple-login",
                         requestFields(
                                 requestFieldDescriptors
                         ),
@@ -65,6 +78,36 @@ public class AuthControllerDocsTest extends MockApiTest {
                         ),
                         responseFields(
                                 responseFieldDescriptors
+                        )));
+    }
+
+    @Test
+    @DisplayName("애플 로그아웃을 문서화한다.")
+    void appleLogout() throws Exception {
+        String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+        String refreshToken = jwtTokenProvider.createRefreshToken(1L);
+
+        willDoNothing().given(authService).appleLogout(any());
+
+        var requestHeaders = new HeaderDescriptor[]{
+                headerWithName("Authorization").description("Foodbowl 인증 토큰")
+        };
+
+        var requestCookies = new CookieDescriptor[]{
+                cookieWithName("refreshToken").description("Foodbowl 리프레쉬 토큰")
+        };
+
+        mockMvc.perform(post("/api/v1/auth/apple/logout")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .cookie(new Cookie(REFRESH_TOKEN.getName(), refreshToken)))
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andDo(document("api-v1-auth-apple-logout",
+                        requestHeaders(
+                                requestHeaders
+                        ),
+                        requestCookies(
+                                requestCookies
                         )));
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/category/entity/CategoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/category/entity/CategoryTest.java
@@ -1,5 +1,10 @@
 package org.dinosaur.foodbowl.domain.category.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.dinosaur.foodbowl.RepositoryTest;
 import org.dinosaur.foodbowl.domain.post.entity.Category;
 import org.dinosaur.foodbowl.domain.post.entity.Category.CategoryType;
@@ -7,12 +12,6 @@ import org.dinosaur.foodbowl.domain.post.repository.CategoryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class CategoryTest extends RepositoryTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/health_check/api/HealthCheckControllerTest.java
@@ -1,5 +1,14 @@
 package org.dinosaur.foodbowl.domain.health_check.api;
 
+import static org.dinosaur.foodbowl.TestUtils.jsonPathLocalDateTimeEquals;
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.health_check.application.HealthCheckService;
 import org.dinosaur.foodbowl.domain.health_check.dto.HealthCheckDto;
@@ -12,16 +21,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.time.LocalDateTime;
-
-import static org.dinosaur.foodbowl.TestUtils.jsonPathLocalDateTimeEquals;
-import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(HealthCheckController.class)
 class HealthCheckControllerTest extends MockApiTest {

--- a/src/test/java/org/dinosaur/foodbowl/domain/health_check/application/HealthCheckServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/health_check/application/HealthCheckServiceTest.java
@@ -1,12 +1,12 @@
 package org.dinosaur.foodbowl.domain.health_check.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.dinosaur.foodbowl.IntegrationTest;
 import org.dinosaur.foodbowl.domain.health_check.dto.HealthCheckDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class HealthCheckServiceTest extends IntegrationTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/health_check/docs/HealthCheckControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/health_check/docs/HealthCheckControllerDocsTest.java
@@ -1,5 +1,14 @@
 package org.dinosaur.foodbowl.domain.health_check.docs;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.health_check.api.HealthCheckController;
 import org.dinosaur.foodbowl.domain.health_check.application.HealthCheckService;
@@ -9,16 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.payload.FieldDescriptor;
-
-import java.time.LocalDateTime;
-
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(HealthCheckController.class)
 class HealthCheckControllerDocsTest extends MockApiTest {

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/entity/RoleTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/entity/RoleTest.java
@@ -1,12 +1,12 @@
 package org.dinosaur.foodbowl.domain.member.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 class RoleTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepositoryTest.java
@@ -1,5 +1,11 @@
 package org.dinosaur.foodbowl.domain.member.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
+import static org.dinosaur.foodbowl.domain.member.entity.Member.builder;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Optional;
 import org.dinosaur.foodbowl.RepositoryTest;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,13 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.dinosaur.foodbowl.domain.member.entity.Member.SocialType;
-import static org.dinosaur.foodbowl.domain.member.entity.Member.builder;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 class MemberRepositoryTest extends RepositoryTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/repository/RoleRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/repository/RoleRepositoryTest.java
@@ -1,17 +1,16 @@
 package org.dinosaur.foodbowl.domain.member.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import org.dinosaur.foodbowl.RepositoryTest;
 import org.dinosaur.foodbowl.domain.member.entity.Role;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class RoleRepositoryTest extends RepositoryTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/global/config/security/jwt/JwtTokenProviderTest.java
@@ -1,17 +1,16 @@
 package org.dinosaur.foodbowl.global.config.security.jwt;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType.ROLE_회원;
+
+import java.util.List;
+import java.util.Optional;
 import org.dinosaur.foodbowl.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.dinosaur.foodbowl.domain.member.entity.Role.RoleType.ROLE_회원;
 
 class JwtTokenProviderTest extends IntegrationTest {
 

--- a/src/test/java/org/dinosaur/foodbowl/global/entity/AuditingEntityTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/global/entity/AuditingEntityTest.java
@@ -1,13 +1,13 @@
 package org.dinosaur.foodbowl.global.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.dinosaur.foodbowl.RepositoryTest;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class AuditingEntityTest extends RepositoryTest {
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #13

## 📝 작업 요약

애플 로그아웃 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 로그아웃 시 인증 토큰을 기반으로 Redis에 저장되어 있는 리프레쉬 토큰을 삭제합니다.
- 로그아웃 시 쿠키에 설정되어있던 리프레쉬 토큰을 만료하도록 합니다.

## 🌟 리뷰 요구 사항

> 10분
