### PR TITLE
Fix/#61 사진 저장 테스트 이후 사진 파일이 삭제되지 않는 문제를 해결한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/ImageUtils.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/ImageUtils.java
@@ -68,7 +68,7 @@ public abstract class ImageUtils {
     }
 
     public void deleteImageFile(String imagePath) {
-        File file = new File(getFullPath(imagePath));
+        File file = new File(imagePath);
         file.delete();
     }
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #61 

## 📝 작업 요약

테스트 이후 사진이 삭제되지 않는 문제를 해결했습니다.

## 🔎 작업 상세 설명

저장  후 `fullPath`를 반환하도록 수정하고 삭제 로직에 적용을 안했었습니다.. 😅 🙇‍♂️

## 🌟 리뷰 요구 사항

> 1분
