### PR TITLE
Feature/#30 회원 프로필 북마크 목록 조회 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/bookmark/bookmark.adoc
+++ b/src/docs/asciidoc/bookmark/bookmark.adoc
@@ -1,0 +1,40 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= 북마크 API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../foodbowl.html[API 목록으로 돌아가기]
+
+== *프로필 북마크 게시글 썸네일 목록 조회* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-bookmarks-thumbnails/http-request.adoc[]
+
+=== Request Headers
+
+include::{snippets}/api-v1-bookmarks-thumbnails/request-headers.adoc[]
+
+=== Query Parameters
+
+include::{snippets}/api-v1-bookmarks-thumbnails/query-parameters.adoc[]
+
+=== 응답
+
+=== Response
+
+include::{snippets}/api-v1-bookmarks-thumbnails/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/api-v1-bookmarks-thumbnails/response-fields.adoc[]

--- a/src/docs/asciidoc/foodbowl.adoc
+++ b/src/docs/asciidoc/foodbowl.adoc
@@ -24,3 +24,7 @@ link:member/member.html[API 문서 보기]
 == *게시글*
 
 link:post/post.html[API 문서 보기]
+
+== *북마크*
+
+link:bookmark/bookmark.html[API 문서 보기]

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/api/BookmarkController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/api/BookmarkController.java
@@ -1,0 +1,31 @@
+package org.dinosaur.foodbowl.domain.bookmark.api;
+
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.bookmark.application.BookmarkService;
+import org.dinosaur.foodbowl.domain.bookmark.dto.response.BookmarkThumbnailResponse;
+import org.dinosaur.foodbowl.global.dto.PageResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/bookmarks")
+@RestController
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @GetMapping("/thumbnails")
+    public ResponseEntity<PageResponse<BookmarkThumbnailResponse>> findThumbnailsInProfile(
+            @RequestParam Long memberId,
+            @PageableDefault(page = 0, size = 18, sort = "createdAt", direction = Direction.DESC) Pageable pageable
+    ) {
+        PageResponse<BookmarkThumbnailResponse> response = bookmarkService.findThumbnailsInProfile(memberId, pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkService.java
@@ -1,0 +1,33 @@
+package org.dinosaur.foodbowl.domain.bookmark.application;
+
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.MEMBER_NOT_FOUND;
+
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.bookmark.dto.response.BookmarkThumbnailResponse;
+import org.dinosaur.foodbowl.domain.bookmark.repository.BookmarkRepository;
+import org.dinosaur.foodbowl.domain.member.entity.Member;
+import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
+import org.dinosaur.foodbowl.global.dto.PageResponse;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final MemberRepository memberRepository;
+
+    public PageResponse<BookmarkThumbnailResponse> findThumbnailsInProfile(Long memberId, Pageable pageable) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FoodbowlException(MEMBER_NOT_FOUND));
+
+        Page<BookmarkThumbnailResponse> pageOfResponse = bookmarkRepository.findAllByMember(member, pageable)
+                .map(BookmarkThumbnailResponse::from);
+        return PageResponse.from(pageOfResponse);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/dto/response/BookmarkThumbnailResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/dto/response/BookmarkThumbnailResponse.java
@@ -1,0 +1,28 @@
+package org.dinosaur.foodbowl.domain.bookmark.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.bookmark.entity.Bookmark;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookmarkThumbnailResponse {
+
+    private Long bookmarkId;
+    private Long postId;
+    private String thumbnailPath;
+    private LocalDateTime createdAt;
+
+    public static BookmarkThumbnailResponse from(Bookmark bookmark) {
+        return new BookmarkThumbnailResponse(
+                bookmark.getId(),
+                bookmark.getPost().getId(),
+                bookmark.getPost().getThumbnail().getPath(),
+                bookmark.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import org.dinosaur.foodbowl.domain.bookmark.entity.Bookmark;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.Repository;
 
 public interface BookmarkRepository extends Repository<Bookmark, Long> {
@@ -11,6 +14,9 @@ public interface BookmarkRepository extends Repository<Bookmark, Long> {
     List<Bookmark> findAll();
 
     List<Bookmark> findAllByMember(Member member);
+
+    @EntityGraph(attributePaths = {"post", "post.thumbnail"})
+    Page<Bookmark> findAllByMember(Member member, Pageable pageable);
 
     List<Bookmark> findAllByPost(Post post);
 

--- a/src/main/java/org/dinosaur/foodbowl/global/config/jpa/JpaConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/jpa/JpaConfig.java
@@ -1,5 +1,8 @@
 package org.dinosaur.foodbowl.global.config.jpa;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -7,4 +10,10 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 public class JpaConfig {
 
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
 }

--- a/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/MockApiTest.java
@@ -5,7 +5,6 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.mo
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dinosaur.foodbowl.global.config.security.CustomAccessDeniedHandler;
 import org.dinosaur.foodbowl.global.config.security.CustomAuthenticationEntryPoint;
 import org.dinosaur.foodbowl.global.config.security.SecurityConfig;
@@ -34,7 +33,6 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
 public class MockApiTest {
 
-    protected ObjectMapper objectMapper = new ObjectMapper();
     protected MockMvc mockMvc;
 
     @BeforeEach

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
@@ -34,6 +35,9 @@ class AuthControllerTest extends MockApiTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockBean
     private AuthService authService;

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
@@ -17,6 +17,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.api.AuthController;
@@ -40,6 +41,9 @@ public class AuthControllerDocsTest extends MockApiTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockBean
     private AuthService authService;

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/api/BookmarkControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/api/BookmarkControllerTest.java
@@ -1,0 +1,98 @@
+package org.dinosaur.foodbowl.domain.bookmark.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.Charset;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.dinosaur.foodbowl.MockApiTest;
+import org.dinosaur.foodbowl.domain.bookmark.application.BookmarkService;
+import org.dinosaur.foodbowl.domain.bookmark.dto.response.BookmarkThumbnailResponse;
+import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.global.dto.PageResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(BookmarkController.class)
+class BookmarkControllerTest extends MockApiTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private BookmarkService bookmarkService;
+
+    @Nested
+    @DisplayName("프로필 북마크 썸네일 목록 조회 시 ")
+    class FindThumbnailsInProfile {
+
+        private String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+        @Test
+        @DisplayName("유효한 요청이라면 게시글 목록을 조회한다.")
+        void findThumbnailsInProfile() throws Exception {
+            PageResponse<BookmarkThumbnailResponse> response = new PageResponse<>(
+                    List.of(new BookmarkThumbnailResponse(1L, 1L, "path", LocalDateTime.now())),
+                    true,
+                    true,
+                    false,
+                    0,
+                    1,
+                    1,
+                    1
+            );
+            given(bookmarkService.findThumbnailsInProfile(anyLong(), any(Pageable.class))).willReturn(response);
+
+            MvcResult mvcResult = mockMvc.perform(get("/api/v1/bookmarks/thumbnails")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .queryParam("memberId", String.valueOf(1L)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+            String jsonResponse = mvcResult.getResponse().getContentAsString(Charset.forName("UTF-8"));
+            PageResponse<BookmarkThumbnailResponse> result = objectMapper.readValue(
+                    jsonResponse,
+                    new TypeReference<PageResponse<BookmarkThumbnailResponse>>() {
+                    }
+            );
+            assertThat(result).usingRecursiveComparison().isEqualTo(response);
+        }
+
+        @Test
+        @DisplayName("멤버 ID를 파라미터로 전달하지 않으면 400 상태를 반환한다.")
+        void findThumbnailsInProfileWithEmptyParam() throws Exception {
+            mockMvc.perform(get("/api/v1/bookmarks/thumbnails")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("멤버 ID가 변환할 수 없는 타입이라면 400 상태를 반환한다.")
+        void findThumbnailsInProfileWithInvalidType() throws Exception {
+            mockMvc.perform(get("/api/v1/bookmarks/thumbnails")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .queryParam("memberId", "id"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkServiceTest.java
@@ -1,0 +1,59 @@
+package org.dinosaur.foodbowl.domain.bookmark.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.dinosaur.foodbowl.IntegrationTest;
+import org.dinosaur.foodbowl.domain.bookmark.dto.response.BookmarkThumbnailResponse;
+import org.dinosaur.foodbowl.domain.member.entity.Member;
+import org.dinosaur.foodbowl.domain.post.entity.Post;
+import org.dinosaur.foodbowl.global.dto.PageResponse;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+class BookmarkServiceTest extends IntegrationTest {
+
+    @Autowired
+    private BookmarkService bookmarkService;
+
+    @Nested
+    @DisplayName("findThumbnailsInProfile 메서드는 ")
+    class FindThumbnailsInProfile {
+
+        @Test
+        @DisplayName("멤버가 존재하지 않으면 예외를 던진다.")
+        void findThumbnailsInProfileWithInvalidMember() {
+            Pageable pageable = PageRequest.of(0, 5);
+
+            assertThatThrownBy(() -> bookmarkService.findThumbnailsInProfile(-1L, pageable))
+                    .isInstanceOf(FoodbowlException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
+        @DisplayName("멤버의 북마크 페이징 목록을 조회한다.")
+        void findThumbnailsInProfile() {
+            Post oldPost = postTestSupport.postBuilder().build();
+            Post newPost = postTestSupport.postBuilder().build();
+            Member member = memberTestSupport.memberBuilder().build();
+            bookmarkTestSupport.builder().member(member).post(oldPost).build();
+            bookmarkTestSupport.builder().member(member).post(newPost).build();
+
+            Pageable pageable = PageRequest.of(0, 5);
+            PageResponse<BookmarkThumbnailResponse> result =
+                    bookmarkService.findThumbnailsInProfile(member.getId(), pageable);
+
+            assertAll(
+                    () -> assertThat(result.getContent()).hasSize(2),
+                    () -> assertThat(result.isLast()).isTrue(),
+                    () -> assertThat(result.isHasNext()).isFalse()
+            );
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/docs/BookmarkControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/docs/BookmarkControllerDocsTest.java
@@ -1,0 +1,103 @@
+package org.dinosaur.foodbowl.domain.bookmark.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.dinosaur.foodbowl.MockApiTest;
+import org.dinosaur.foodbowl.domain.bookmark.api.BookmarkController;
+import org.dinosaur.foodbowl.domain.bookmark.application.BookmarkService;
+import org.dinosaur.foodbowl.domain.bookmark.dto.response.BookmarkThumbnailResponse;
+import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.global.dto.PageResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
+
+@WebMvcTest(BookmarkController.class)
+class BookmarkControllerDocsTest extends MockApiTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private BookmarkService bookmarkService;
+
+    @Test
+    @DisplayName("프로필 북마크 게시글 썸네일 목록 조회를 문서화한다.")
+    void findThumbnailsInProfile() throws Exception {
+        PageResponse<BookmarkThumbnailResponse> response = new PageResponse<>(
+                List.of(new BookmarkThumbnailResponse(1L, 1L, "path", LocalDateTime.now())),
+                true,
+                true,
+                false,
+                0,
+                1,
+                1,
+                1
+        );
+        given(bookmarkService.findThumbnailsInProfile(anyLong(), any(Pageable.class))).willReturn(response);
+
+        var headerDescriptors = new HeaderDescriptor[]{
+                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
+        };
+
+        var parameterDescriptors = new ParameterDescriptor[]{
+                parameterWithName("memberId").description("프로필 멤버 ID"),
+                parameterWithName("page").optional().description("프로필 북마크 게시글 썸네일 목록 페이지 숫자 (입력하지 않으면, default = 0)"),
+                parameterWithName("size").optional().description("프로필 북마크 게시글 썸네일 목록 데이터 개수 (입력하지 않으면, default = 18)")
+        };
+
+        var responseFieldDescriptors = new FieldDescriptor[]{
+                fieldWithPath("content").description("북마크 게시글 썸네일 정보 목록"),
+                fieldWithPath("content[].bookmarkId").description("북마크 ID"),
+                fieldWithPath("content[].postId").description("북마크 게시글 ID"),
+                fieldWithPath("content[].thumbnailPath").description("북마크 게시글 썸네일 경로"),
+                fieldWithPath("content[].createdAt").description("북마크 게시글 작성 시간"),
+                fieldWithPath("first").description("첫 페이지 여부"),
+                fieldWithPath("last").description("마지막 페이지 여부"),
+                fieldWithPath("hasNext").description("다음 페이지 존재 여부"),
+                fieldWithPath("currentPage").description("현재 페이지 인덱스"),
+                fieldWithPath("currentElementSize").description("현재 데이터 개수"),
+                fieldWithPath("totalPage").description("전체 페이지 숫자"),
+                fieldWithPath("totalElementSize").description("전체 데이터 개수"),
+        };
+
+        mockMvc.perform(get("/api/v1/bookmarks/thumbnails")
+                        .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                        .queryParam("memberId", String.valueOf(1L)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("api-v1-bookmarks-thumbnails",
+                        requestHeaders(
+                                headerDescriptors
+                        ),
+                        queryParameters(
+                                parameterDescriptors
+                        ),
+                        responseFields(
+                                responseFieldDescriptors
+                        )
+                ));
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepositoryTest.java
@@ -57,7 +57,7 @@ class BookmarkRepositoryTest extends RepositoryTest {
 
         assertAll(
                 () -> assertThat(result.getContent()).hasSize(1),
-                () -> assertThat(result.hasNext()).isEqualTo(true),
+                () -> assertThat(result.hasNext()).isTrue(),
                 () -> assertThat(result.getTotalElements()).isEqualTo(2),
                 () -> assertThat(result.getTotalPages()).isEqualTo(2)
         );

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/repository/BookmarkRepositoryTest.java
@@ -1,13 +1,20 @@
 package org.dinosaur.foodbowl.domain.bookmark.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.dinosaur.foodbowl.RepositoryTest;
+import org.dinosaur.foodbowl.domain.bookmark.entity.Bookmark;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 
 class BookmarkRepositoryTest extends RepositoryTest {
 
@@ -34,5 +41,25 @@ class BookmarkRepositoryTest extends RepositoryTest {
         bookmarkRepository.deleteAllByPost(post);
 
         assertThat(bookmarkRepository.findAllByPost(post)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("엔티티 그래프, 멤버, 페이징 정보를 바탕으로 북마크를 조회한다.")
+    void findAllByMemberWithEntityGraph() {
+        Post oldPost = postTestSupport.postBuilder().build();
+        Post newPost = postTestSupport.postBuilder().build();
+        Member member = memberTestSupport.memberBuilder().build();
+        bookmarkTestSupport.builder().member(member).post(oldPost).build();
+        bookmarkTestSupport.builder().member(member).post(newPost).build();
+
+        Pageable pageable = PageRequest.of(0, 1, Sort.by(Direction.DESC, "id"));
+        Page<Bookmark> result = bookmarkRepository.findAllByMember(member, pageable);
+
+        assertAll(
+                () -> assertThat(result.getContent()).hasSize(1),
+                () -> assertThat(result.hasNext()).isEqualTo(true),
+                () -> assertThat(result.getTotalElements()).isEqualTo(2),
+                () -> assertThat(result.getTotalPages()).isEqualTo(2)
+        );
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #30

## 📝 작업 요약

프로필에서 북마크한 게시글 썸네일 목록을 조회하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- `@EntityGraph`에서 연관 객체의 필드도 조인하여 가져오도록 합니다.

## 🌟 리뷰 요구 사항

> 30분
