### PR TITLE
Feature/#33 닉네임, 소개를 수정하는 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/auth/auth.adoc
+++ b/src/docs/asciidoc/auth/auth.adoc
@@ -60,3 +60,25 @@ include::{snippets}/api-v1-auth-apple-logout/request-cookies.adoc[]
 === Response
 
 include::{snippets}/api-v1-auth-apple-logout/http-response.adoc[]
+
+== *닉네임 중복 확인* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-auth-check-nickname/http-request.adoc[]
+
+=== Query Parameters
+
+include::{snippets}/api-v1-auth-check-nickname/query-parameters.adoc[]
+
+=== 응답
+
+=== Response
+
+include::{snippets}/api-v1-auth-check-nickname/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/api-v1-auth-check-nickname/response-fields.adoc[]

--- a/src/docs/asciidoc/member/member.adoc
+++ b/src/docs/asciidoc/member/member.adoc
@@ -30,3 +30,25 @@ include::{snippets}/api-v1-members-delete/request-headers.adoc[]
 === Response
 
 include::{snippets}/api-v1-members-delete/http-response.adoc[]
+
+== *닉네임, 소개 수정* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-members-update-profile/http-request.adoc[]
+
+=== Request Headers
+
+include::{snippets}/api-v1-members-update-profile/request-headers.adoc[]
+
+=== Request Fields
+
+include::{snippets}/api-v1-members-update-profile/request-fields.adoc[]
+
+=== 응답
+
+=== Response
+
+include::{snippets}/api-v1-members-update-profile/http-response.adoc[]

--- a/src/docs/asciidoc/member/member.adoc
+++ b/src/docs/asciidoc/member/member.adoc
@@ -3,7 +3,6 @@ ifndef::snippets[]
 endif::[]
 
 = 멤버 API 문서
-
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
@@ -13,32 +12,6 @@ endif::[]
 == API 목록
 
 link:../foodbowl.html[API 목록으로 돌아가기]
-
-== *닉네임 중복 확인* ==
-
-=== 요청
-
-=== Request
-
-include::{snippets}/api-v1-members-check-nickname/http-request.adoc[]
-
-=== Request Headers
-
-include::{snippets}/api-v1-members-check-nickname/request-headers.adoc[]
-
-=== Query Parameters
-
-include::{snippets}/api-v1-members-check-nickname/query-parameters.adoc[]
-
-=== 응답
-
-=== Response
-
-include::{snippets}/api-v1-members-check-nickname/http-response.adoc[]
-
-=== Response Fields
-
-include::{snippets}/api-v1-members-check-nickname/response-fields.adoc[]
 
 == *회원 탈퇴* ==
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -5,20 +5,26 @@ import static org.dinosaur.foodbowl.global.config.security.jwt.JwtConstant.REFRE
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.response.AppleTokenResponse;
+import org.dinosaur.foodbowl.domain.auth.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.global.resolver.MemberId;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/v1/auth")
 @RestController
 public class AuthController {
@@ -55,5 +61,13 @@ public class AuthController {
         cookie.setHttpOnly(true);
         cookie.setMaxAge(0);
         response.addCookie(cookie);
+    }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<NicknameDuplicateCheckResponse> checkDuplicate(
+            @Pattern(regexp = "^[a-zA-Z가-힣0-9]{1,16}$", message = "닉네임은 1자 이상 16자 이하 한글,영문,숫자만 가능합니다")
+            @RequestParam String nickname
+    ) {
+        return ResponseEntity.ok(authService.checkDuplicate(nickname));
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -65,7 +65,7 @@ public class AuthController {
 
     @GetMapping("/check-nickname")
     public ResponseEntity<NicknameDuplicateCheckResponse> checkDuplicate(
-            @Pattern(regexp = "^[a-zA-Z가-힣0-9]{1,16}$", message = "닉네임은 1자 이상 16자 이하 한글,영문,숫자만 가능합니다")
+            @Pattern(regexp = "^[a-zA-Z가-힣0-9]{1,16}$", message = "닉네임은 1자 이상 16자 이하 한글, 영문, 숫자만 가능합니다")
             @RequestParam String nickname
     ) {
         return ResponseEntity.ok(authService.checkDuplicate(nickname));

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -10,6 +10,7 @@ import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponse;
+import org.dinosaur.foodbowl.domain.auth.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
@@ -59,5 +60,10 @@ public class AuthService {
     @Transactional
     public void appleLogout(Long memberId) {
         redisTemplate.delete(String.valueOf(memberId));
+    }
+
+    public NicknameDuplicateCheckResponse checkDuplicate(String nickname) {
+        boolean hasDuplicate = memberRepository.existsByNickname(nickname);
+        return new NicknameDuplicateCheckResponse(hasDuplicate);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/NicknameDuplicateCheckResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/NicknameDuplicateCheckResponse.java
@@ -1,4 +1,4 @@
-package org.dinosaur.foodbowl.domain.member.dto.response;
+package org.dinosaur.foodbowl.domain.auth.dto.response;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/api/MemberController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/api/MemberController.java
@@ -1,10 +1,14 @@
 package org.dinosaur.foodbowl.domain.member.api;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
+import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
 import org.dinosaur.foodbowl.global.resolver.MemberId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,6 +22,14 @@ public class MemberController {
     @DeleteMapping
     public ResponseEntity<Void> withDraw(@MemberId Long memberId) {
         memberService.withDraw(memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateProfile(
+            @MemberId Long memberId,
+            @Valid @RequestBody ProfileUpdateRequest profileUpdateRequest) {
+        memberService.updateProfile(memberId, profileUpdateRequest);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/api/MemberController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/api/MemberController.java
@@ -1,34 +1,19 @@
 package org.dinosaur.foodbowl.domain.member.api;
 
-import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
-import org.dinosaur.foodbowl.domain.member.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.global.resolver.MemberId;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Validated
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
 @RestController
 public class MemberController {
 
     private final MemberService memberService;
-
-
-    @GetMapping("/check-nickname")
-    public ResponseEntity<NicknameDuplicateCheckResponse> checkDuplicate(
-            @Pattern(regexp = "^[a-zA-Z가-힣0-9]{1,16}$", message = "닉네임은 1자 이상 16자 이하 한글,영문,숫자만 가능합니다")
-            @RequestParam String nickname
-    ) {
-        return ResponseEntity.ok(memberService.checkDuplicate(nickname));
-    }
 
     @DeleteMapping
     public ResponseEntity<Void> withDraw(@MemberId Long memberId) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
@@ -8,7 +8,6 @@ import org.dinosaur.foodbowl.domain.blame.repository.BlameRepository;
 import org.dinosaur.foodbowl.domain.bookmark.repository.BookmarkRepository;
 import org.dinosaur.foodbowl.domain.comment.repository.CommentRepository;
 import org.dinosaur.foodbowl.domain.follow.repository.FollowRepository;
-import org.dinosaur.foodbowl.domain.member.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRoleRepository;
@@ -36,11 +35,6 @@ public class MemberService {
     private final CommentRepository commentRepository;
     private final BookmarkRepository bookmarkRepository;
     private final BlameRepository blameRepository;
-
-    public NicknameDuplicateCheckResponse checkDuplicate(String nickname) {
-        boolean hasDuplicate = memberRepository.existsByNickname(nickname);
-        return new NicknameDuplicateCheckResponse(hasDuplicate);
-    }
 
     @Transactional
     public void withDraw(Long memberId) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
@@ -8,6 +8,7 @@ import org.dinosaur.foodbowl.domain.blame.repository.BlameRepository;
 import org.dinosaur.foodbowl.domain.bookmark.repository.BookmarkRepository;
 import org.dinosaur.foodbowl.domain.comment.repository.CommentRepository;
 import org.dinosaur.foodbowl.domain.follow.repository.FollowRepository;
+import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRoleRepository;
@@ -57,5 +58,13 @@ public class MemberService {
         }
         memberRepository.delete(member);
         thumbnailRepository.delete(member.getThumbnail());
+    }
+
+    @Transactional
+    public void updateProfile(Long memberId, ProfileUpdateRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FoodbowlException(MEMBER_NOT_FOUND));
+
+        member.updateProfile(request.getNickname(), request.getIntroduction());
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/dto/request/ProfileUpdateRequest.java
@@ -2,6 +2,7 @@ package org.dinosaur.foodbowl.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,5 +17,6 @@ public class ProfileUpdateRequest {
     @Pattern(regexp = "^[a-zA-Z가-힣0-9]{1,16}$", message = "닉네임은 1자 이상 16자 이하 한글, 영문, 숫자만 가능합니다")
     private String nickname;
 
+    @Size(max = 255, message = "소개는 최대 255자까지만 가능합니다.")
     private String introduction;
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,20 @@
+package org.dinosaur.foodbowl.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileUpdateRequest {
+
+    @NotBlank(message = "닉네임은 존재해야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z가-힣0-9]{1,16}$", message = "닉네임은 1자 이상 16자 이하 한글, 영문, 숫자만 가능합니다")
+    private String nickname;
+
+    private String introduction;
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
@@ -83,6 +83,11 @@ public class Member extends AuditingEntity {
         this.region2depthName = region2depthName;
     }
 
+    public void updateProfile(final String nickname, final String introduction) {
+        this.nickname = nickname;
+        this.introduction = introduction;
+    }
+
     public enum SocialType {
 
         APPLE

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests()
                 .requestMatchers("/docs/**", "/api/v1/health-check").permitAll()
-                .requestMatchers("/api/v1/auth/apple/login").permitAll()
+                .requestMatchers("/api/v1/auth/apple/login", "/api/v1/auth/check-nickname").permitAll()
                 .anyRequest().hasRole("회원")
                 .and()
                 .httpBasic().disable()

--- a/src/main/java/org/dinosaur/foodbowl/global/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/exception/GlobalExceptionAdvice.java
@@ -37,7 +37,7 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
             stringBuilder.append("[");
             stringBuilder.append(fieldError.getField());
-            stringBuilder.append("] 필드는 ");
+            stringBuilder.append("] ");
             stringBuilder.append(fieldError.getDefaultMessage());
             stringBuilder.append(" 입력된 값 : [");
             stringBuilder.append(fieldError.getRejectedValue());

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -163,7 +163,7 @@ class AuthControllerTest extends MockApiTest {
                             .queryParam("nickname", nickname)
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value("닉네임은 1자 이상 16자 이하 한글,영문,숫자만 가능합니다"))
+                    .andExpect(jsonPath("$.message").value("닉네임은 1자 이상 16자 이하 한글, 영문, 숫자만 가능합니다"))
                     .andDo(print());
         }
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
@@ -18,11 +19,14 @@ import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -104,6 +108,62 @@ class AuthControllerTest extends MockApiTest {
             return mockMvc.perform(post("/api/v1/auth/apple/logout")
                             .header("Authorization", "Bearer " + accessToken)
                             .cookie(new Cookie(REFRESH_TOKEN.getName(), "refreshToken")))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 중복 검증은")
+    class CheckDuplicate {
+
+        @Test
+        @DisplayName("요청 파라미터가 없으면 BAD REQUEST가 발생한다.")
+        void checkDuplicateFailWithNoParams() throws Exception {
+            given(authService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(false));
+
+            mockMvc.perform(get("/api/v1/auth/check-nickname")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("요청 닉네임이 존재하면 true를 반환한다.")
+        void checkDuplicateTrue() throws Exception {
+            given(authService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(true));
+
+            mockMvc.perform(get("/api/v1/auth/check-nickname")
+                            .queryParam("nickname", "gray")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.hasDuplicate").value(true))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("요청 닉네임이 존재하지 않으면 false를 반환한다.")
+        void checkDuplicateFalse() throws Exception {
+            given(authService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(false));
+
+            mockMvc.perform(get("/api/v1/auth/check-nickname")
+                            .queryParam("nickname", "gray")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.hasDuplicate").value(false))
+                    .andDo(print());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " ", "graygraygraygrayhoy", "@!!dsafdsf$"})
+        @DisplayName("닉네임은 1자 이상 16자 이하 한글,영문,숫자가 아니면 BAD REQUEST가 발생한다.")
+        void checkDuplicateFail(String nickname) throws Exception {
+            given(authService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(false));
+
+            mockMvc.perform(get("/api/v1/auth/check-nickname")
+                            .queryParam("nickname", nickname)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("닉네임은 1자 이상 16자 이하 한글,영문,숫자만 가능합니다"))
                     .andDo(print());
         }
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
@@ -12,6 +12,7 @@ import org.dinosaur.foodbowl.domain.auth.apple.AppleOAuthUserProvider;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.response.ApplePlatformUserResponse;
+import org.dinosaur.foodbowl.domain.auth.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
@@ -95,6 +96,43 @@ class AuthServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> authService.appleLogin(appleLoginRequest))
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessage("애플 회원가입이 되지 않은 회원입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("checkDuplicate 메서드는")
+    class checkDuplicate {
+
+        @Test
+        @DisplayName("닉네임과 일치하는 회원이 존재하면 true를 반환한다.")
+        void checkDuplicateMember() {
+            String nickname = "gray";
+            Member member = Member.builder()
+                    .socialType(Member.SocialType.APPLE)
+                    .socialId("1234")
+                    .nickname(nickname)
+                    .build();
+            memberRepository.save(member);
+
+            NicknameDuplicateCheckResponse nicknameDuplicateCheckResponse = authService.checkDuplicate(nickname);
+
+            assertThat(nicknameDuplicateCheckResponse.isHasDuplicate()).isTrue();
+        }
+
+        @Test
+        @DisplayName("닉네임과 일치하는 회원이 존재하면 false를 반환한다.")
+        void checkNoneDuplicateMember() {
+            String nickname = "gray";
+            Member member = Member.builder()
+                    .socialType(Member.SocialType.APPLE)
+                    .socialId("1234")
+                    .nickname("dazzle")
+                    .build();
+            memberRepository.save(member);
+
+            NicknameDuplicateCheckResponse nicknameDuplicateCheckResponse = authService.checkDuplicate(nickname);
+
+            assertThat(nicknameDuplicateCheckResponse.isHasDuplicate()).isFalse();
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/docs/AuthControllerDocsTest.java
@@ -14,6 +14,9 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,6 +26,7 @@ import org.dinosaur.foodbowl.domain.auth.api.AuthController;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.FoodbowlTokenDto;
 import org.dinosaur.foodbowl.domain.auth.dto.request.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +38,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.cookies.CookieDescriptor;
 import org.springframework.restdocs.headers.HeaderDescriptor;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 @WebMvcTest(AuthController.class)
 public class AuthControllerDocsTest extends MockApiTest {
@@ -108,6 +113,25 @@ public class AuthControllerDocsTest extends MockApiTest {
                         ),
                         requestCookies(
                                 requestCookies
+                        )));
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 검증을 문서화한다.")
+    void checkDuplicate() throws Exception {
+        given(authService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(false));
+
+        mockMvc.perform(get("/api/v1/auth/check-nickname")
+                        .queryParam("nickname", "gray")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("api-v1-auth-check-nickname",
+                        queryParameters(
+                                parameterWithName("nickname").description("닉네임")
+                        ),
+                        responseFields(
+                                fieldWithPath("hasDuplicate").type(JsonFieldType.BOOLEAN).description("닉네임 중복 여부")
                         )));
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
@@ -65,6 +65,7 @@ class MemberControllerTest extends MockApiTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request))
                     )
+                    .andDo(print())
                     .andExpect(status().isUnauthorized());
         }
 
@@ -79,6 +80,7 @@ class MemberControllerTest extends MockApiTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request))
                     )
+                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(content().string(containsString("닉네임은 존재해야 합니다.")));
         }
@@ -94,8 +96,24 @@ class MemberControllerTest extends MockApiTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request))
                     )
+                    .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(content().string(containsString("닉네임은 1자 이상 16자 이하 한글, 영문, 숫자만 가능합니다")));
+        }
+
+        @Test
+        @DisplayName("소개가 255자를 넘는다면 400 상태를 반환한다.")
+        void updateProfileWithInvalidIntroduction() throws Exception {
+            ProfileUpdateRequest request = new ProfileUpdateRequest("foodbowl", "a".repeat(256));
+
+            mockMvc.perform(put("/api/v1/members")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString("소개는 최대 255자까지만 가능합니다.")));
         }
 
         @Test
@@ -110,6 +128,7 @@ class MemberControllerTest extends MockApiTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request))
                     )
+                    .andDo(print())
                     .andExpect(status().isNoContent());
         }
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
@@ -1,30 +1,21 @@
 package org.dinosaur.foodbowl.domain.member.api;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.anyLong;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
-import org.dinosaur.foodbowl.domain.member.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 
 @WebMvcTest(controllers = MemberController.class)
 class MemberControllerTest extends MockApiTest {
@@ -35,79 +26,17 @@ class MemberControllerTest extends MockApiTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    @Nested
-    @DisplayName("닉네임 중복 검증은")
-    class CheckDuplicate {
+    @Test
+    @DisplayName("회원 탈퇴 요청 시 회원을 탈퇴시킨다.")
+    void withDraw() throws Exception {
+        willDoNothing().given(memberService).withDraw(anyLong());
 
-        private final String token = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+        mockMvc.perform(delete("/api/v1/members")
+                        .header(HttpHeaders.AUTHORIZATION,
+                                "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                )
+                .andDo(print())
+                .andExpect(status().isNoContent());
 
-        @Test
-        @DisplayName("요청 파라미터가 없으면 BAD REQUEST가 발생한다.")
-        void checkDuplicateFailWithNoParams() throws Exception {
-            given(memberService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(false));
-
-            mockMvc.perform(get("/api/v1/members/check-nickname")
-                            .header("Authorization", "Bearer " + token)
-                            .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest())
-                    .andDo(print());
-        }
-
-        @Test
-        @DisplayName("요청 닉네임이 존재하면 true를 반환한다.")
-        void checkDuplicateTrue() throws Exception {
-            given(memberService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(true));
-
-            mockMvc.perform(get("/api/v1/members/check-nickname")
-                            .header("Authorization", "Bearer " + token)
-                            .queryParam("nickname", "gray")
-                            .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.hasDuplicate").value(true))
-                    .andDo(print());
-        }
-
-        @Test
-        @DisplayName("요청 닉네임이 존재하지 않으면 false를 반환한다.")
-        void checkDuplicateFalse() throws Exception {
-            given(memberService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(false));
-
-            mockMvc.perform(get("/api/v1/members/check-nickname")
-                            .header("Authorization", "Bearer " + token)
-                            .queryParam("nickname", "gray")
-                            .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.hasDuplicate").value(false))
-                    .andDo(print());
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {"", " ", "graygraygraygrayhoy", "@!!dsafdsf$"})
-        @DisplayName("닉네임은 1자 이상 16자 이하 한글,영문,숫자가 아니면 BAD REQUEST가 발생한다.")
-        void checkDuplicateFail(String nickname) throws Exception {
-            given(memberService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(false));
-
-            mockMvc.perform(get("/api/v1/members/check-nickname")
-                            .header("Authorization", "Bearer " + token)
-                            .queryParam("nickname", nickname)
-                            .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value("닉네임은 1자 이상 16자 이하 한글,영문,숫자만 가능합니다"))
-                    .andDo(print());
-        }
-
-        @Test
-        @DisplayName("회원 탈퇴 요청 시 회원을 탈퇴시킨다.")
-        void withDraw() throws Exception {
-            willDoNothing().given(memberService).withDraw(anyLong());
-
-            mockMvc.perform(delete("/api/v1/members")
-                            .header(HttpHeaders.AUTHORIZATION,
-                                    "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
-                    )
-                    .andDo(print())
-                    .andExpect(status().isNoContent());
-
-        }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
@@ -1,21 +1,31 @@
 package org.dinosaur.foodbowl.domain.member.api;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.anyLong;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
+import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 @WebMvcTest(controllers = MemberController.class)
 class MemberControllerTest extends MockApiTest {
@@ -38,5 +48,69 @@ class MemberControllerTest extends MockApiTest {
                 .andDo(print())
                 .andExpect(status().isNoContent());
 
+    }
+
+    @Nested
+    @DisplayName("닉네임, 소개 수정 요청 시 ")
+    class updateProfile {
+
+        private String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+        @Test
+        @DisplayName("인증되지 않은 회원이라면 401 상태를 반환한다.")
+        void updateProfileWithUnAuthenticated() throws Exception {
+            ProfileUpdateRequest request = new ProfileUpdateRequest("foodbowl", "Foodbowl is Good");
+
+            mockMvc.perform(put("/api/v1/members")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("닉네임 정보가 존재하지 않으면 400 상태를 반환한다.")
+        void updateProfileWithNotExistNickname(String nickname) throws Exception {
+            ProfileUpdateRequest request = new ProfileUpdateRequest(nickname, "Foodbowl is Good");
+
+            mockMvc.perform(put("/api/v1/members")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString("닉네임은 존재해야 합니다.")));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " ", "graygraygraygrayhoy", "@!!dsafdsf$"})
+        @DisplayName("유효하지 않은 닉네임이라면 400 상태를 반환한다.")
+        void updateProfileWithInvalidNickname(String nickname) throws Exception {
+            ProfileUpdateRequest request = new ProfileUpdateRequest(nickname, "Foodbowl is Good");
+
+            mockMvc.perform(put("/api/v1/members")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(containsString("닉네임은 1자 이상 16자 이하 한글, 영문, 숫자만 가능합니다")));
+        }
+
+        @Test
+        @DisplayName("유효한 정보라면 204 상태를 반환한다.")
+        void updateProfile() throws Exception {
+            ProfileUpdateRequest request = new ProfileUpdateRequest("foodbowl", "Foodbowl is Good");
+
+            willDoNothing().given(memberService).updateProfile(anyLong(), any(ProfileUpdateRequest.class));
+
+            mockMvc.perform(put("/api/v1/members")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andExpect(status().isNoContent());
+        }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
@@ -10,7 +10,6 @@ import org.dinosaur.foodbowl.domain.blame.repository.BlameRepository;
 import org.dinosaur.foodbowl.domain.bookmark.repository.BookmarkRepository;
 import org.dinosaur.foodbowl.domain.comment.repository.CommentRepository;
 import org.dinosaur.foodbowl.domain.follow.repository.FollowRepository;
-import org.dinosaur.foodbowl.domain.member.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRoleRepository;
@@ -100,43 +99,6 @@ class MemberServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> memberService.withDraw(-1L))
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
-        }
-    }
-
-    @Nested
-    @DisplayName("checkDuplicate 메서드는")
-    class checkDuplicate {
-
-        @Test
-        @DisplayName("닉네임과 일치하는 회원이 존재하면 true를 반환한다.")
-        void checkDuplicateMember() {
-            String nickname = "gray";
-            Member member = Member.builder()
-                    .socialType(Member.SocialType.APPLE)
-                    .socialId("1234")
-                    .nickname(nickname)
-                    .build();
-            memberRepository.save(member);
-
-            NicknameDuplicateCheckResponse nicknameDuplicateCheckResponse = memberService.checkDuplicate(nickname);
-
-            assertThat(nicknameDuplicateCheckResponse.isHasDuplicate()).isTrue();
-        }
-
-        @Test
-        @DisplayName("닉네임과 일치하는 회원이 존재하면 false를 반환한다.")
-        void checkNoneDuplicateMember() {
-            String nickname = "gray";
-            Member member = Member.builder()
-                    .socialType(Member.SocialType.APPLE)
-                    .socialId("1234")
-                    .nickname("dazzle")
-                    .build();
-            memberRepository.save(member);
-
-            NicknameDuplicateCheckResponse nicknameDuplicateCheckResponse = memberService.checkDuplicate(nickname);
-
-            assertThat(nicknameDuplicateCheckResponse.isHasDuplicate()).isFalse();
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
@@ -10,6 +10,7 @@ import org.dinosaur.foodbowl.domain.blame.repository.BlameRepository;
 import org.dinosaur.foodbowl.domain.bookmark.repository.BookmarkRepository;
 import org.dinosaur.foodbowl.domain.comment.repository.CommentRepository;
 import org.dinosaur.foodbowl.domain.follow.repository.FollowRepository;
+import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRoleRepository;
@@ -99,6 +100,39 @@ class MemberServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> memberService.withDraw(-1L))
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateProfile 메서드는 ")
+    class UpdateProfile {
+
+        @Test
+        @DisplayName("해당 멤버가 존재하지 않으면 예외를 던진다.")
+        void updateProfileWithNotExistMember() {
+            ProfileUpdateRequest request = new ProfileUpdateRequest("foodbowl", "Foodbowl is Good");
+
+            assertThatThrownBy(() -> memberService.updateProfile(-1L, request))
+                    .isInstanceOf(FoodbowlException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
+        @DisplayName("유효한 정보라면 멤버의 닉네임, 소개를 수정한다.")
+        void updateProfile() {
+            Member member = memberTestSupport.memberBuilder().build();
+            ProfileUpdateRequest request = new ProfileUpdateRequest("foodbowl", "Foodbowl is Good");
+
+            memberService.updateProfile(member.getId(), request);
+
+            em.flush();
+            em.clear();
+
+            Member updatedMember = memberRepository.findById(member.getId()).get();
+            assertAll(
+                    () -> assertThat(updatedMember.getNickname()).isEqualTo("foodbowl"),
+                    () -> assertThat(updatedMember.getIntroduction()).isEqualTo("Foodbowl is Good")
+            );
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/docs/MemberControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/docs/MemberControllerDocsTest.java
@@ -1,25 +1,17 @@
 package org.dinosaur.foodbowl.domain.member.docs;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.member.api.MemberController;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
-import org.dinosaur.foodbowl.domain.member.dto.response.NicknameDuplicateCheckResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -28,9 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.restdocs.headers.HeaderDescriptor;
-import org.springframework.restdocs.payload.JsonFieldType;
 
 @WebMvcTest(controllers = MemberController.class)
 public class MemberControllerDocsTest extends MockApiTest {
@@ -40,30 +30,6 @@ public class MemberControllerDocsTest extends MockApiTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
-
-    @Test
-    @DisplayName("닉네임 중복 검증을 문서화한다.")
-    void appleLogin() throws Exception {
-        String token = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
-        given(memberService.checkDuplicate(any())).willReturn(new NicknameDuplicateCheckResponse(false));
-
-        mockMvc.perform(get("/api/v1/members/check-nickname")
-                        .header("Authorization", "Bearer " + token)
-                        .queryParam("nickname", "gray")
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andDo(document("api-v1-members-check-nickname",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                        ),
-                        queryParameters(
-                                parameterWithName("nickname").description("닉네임")
-                        ),
-                        responseFields(
-                                fieldWithPath("hasDuplicate").type(JsonFieldType.BOOLEAN).description("닉네임 중복 여부")
-                        )));
-    }
 
     @Test
     @DisplayName("회원 탈퇴를 문서화한다.")

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/docs/MemberControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/docs/MemberControllerDocsTest.java
@@ -1,17 +1,22 @@
 package org.dinosaur.foodbowl.domain.member.docs;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.member.api.MemberController;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
+import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +25,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.payload.FieldDescriptor;
 
 @WebMvcTest(controllers = MemberController.class)
 public class MemberControllerDocsTest extends MockApiTest {
@@ -49,6 +56,39 @@ public class MemberControllerDocsTest extends MockApiTest {
                 .andDo(document("api-v1-members-delete",
                         requestHeaders(
                                 headerDescriptors
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("닉네임, 소개 수정을 문서화한다.")
+    void updateProfile() throws Exception {
+        String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+        ProfileUpdateRequest request = new ProfileUpdateRequest("foodbowl", "Foodbowl is Good");
+
+        willDoNothing().given(memberService).updateProfile(anyLong(), any(ProfileUpdateRequest.class));
+
+        var headerDescriptors = new HeaderDescriptor[]{
+                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
+        };
+
+        var requestFieldDescriptors = new FieldDescriptor[]{
+                fieldWithPath("nickname").description("수정할 닉네임(수정하지 않을 시 기존 닉네임)"),
+                fieldWithPath("introduction").description("수정할 소개(수정하지 않을 시 기존 소개)").optional(),
+        };
+
+        mockMvc.perform(put("/api/v1/members")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isNoContent())
+                .andDo(document("api-v1-members-update-profile",
+                        requestHeaders(
+                                headerDescriptors
+                        ),
+                        requestFields(
+                                requestFieldDescriptors
                         )
                 ));
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/docs/MemberControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/docs/MemberControllerDocsTest.java
@@ -82,6 +82,7 @@ public class MemberControllerDocsTest extends MockApiTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 )
+                .andDo(print())
                 .andExpect(status().isNoContent())
                 .andDo(document("api-v1-members-update-profile",
                         requestHeaders(


### PR DESCRIPTION
## 🔥 연관 이슈

close: #33

## 📝 작업 요약

회원의 닉네임, 소개를 수정하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 닉네임이나 소개가 수정되지 않았을 때는 기존의 닉네임이나 소개를 받도록 하였습니다.

## 🌟 리뷰 요구 사항

> 10분