### PR TITLE
Feature/#67 가게 조회 및 가게 등록 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/foodbowl.adoc
+++ b/src/docs/asciidoc/foodbowl.adoc
@@ -32,3 +32,7 @@ link:post/post.html[API 문서 보기]
 == *북마크*
 
 link:bookmark/bookmark.html[API 문서 보기]
+
+== *가게*
+
+link:store/store.html[API 문서 보기]

--- a/src/docs/asciidoc/store/store.adoc
+++ b/src/docs/asciidoc/store/store.adoc
@@ -1,0 +1,67 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= 가게 API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../foodbowl.html[API 목록으로 돌아가기]
+
+== *가게 조회* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-stores-read/http-request.adoc[]
+
+=== Request Headers
+
+include::{snippets}/api-v1-stores-read/request-headers.adoc[]
+
+=== Query parameters
+
+include::{snippets}/api-v1-stores-read/query-parameters.adoc[]
+
+=== 응답
+
+=== Response
+
+include::{snippets}/api-v1-stores-read/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/api-v1-stores-read/response-fields.adoc[]
+
+
+== *가게 생성* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-stores-create/http-request.adoc[]
+
+=== Request Headers
+
+include::{snippets}/api-v1-stores-create/request-headers.adoc[]
+
+=== Request Fields
+
+include::{snippets}/api-v1-stores-create/request-fields.adoc[]
+
+=== 응답
+
+=== Response
+
+include::{snippets}/api-v1-stores-create/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/api-v1-stores-create/response-fields.adoc[]

--- a/src/docs/asciidoc/store/store.adoc
+++ b/src/docs/asciidoc/store/store.adoc
@@ -19,25 +19,25 @@ link:../foodbowl.html[API 목록으로 돌아가기]
 
 === Request
 
-include::{snippets}/api-v1-stores-read/http-request.adoc[]
+include::{snippets}/api-v1-stores-find/http-request.adoc[]
 
 === Request Headers
 
-include::{snippets}/api-v1-stores-read/request-headers.adoc[]
+include::{snippets}/api-v1-stores-find/request-headers.adoc[]
 
 === Query parameters
 
-include::{snippets}/api-v1-stores-read/query-parameters.adoc[]
+include::{snippets}/api-v1-stores-find/query-parameters.adoc[]
 
 === 응답
 
 === Response
 
-include::{snippets}/api-v1-stores-read/http-response.adoc[]
+include::{snippets}/api-v1-stores-find/http-response.adoc[]
 
 === Response Fields
 
-include::{snippets}/api-v1-stores-read/response-fields.adoc[]
+include::{snippets}/api-v1-stores-find/response-fields.adoc[]
 
 
 == *가게 생성* ==

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/api/StoreController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/api/StoreController.java
@@ -1,0 +1,40 @@
+package org.dinosaur.foodbowl.domain.store.api;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.store.application.StoreService;
+import org.dinosaur.foodbowl.domain.store.dto.StoreRequest;
+import org.dinosaur.foodbowl.domain.store.dto.StoreResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stores")
+@RestController
+public class StoreController {
+
+    private static final String ADDRESS_REQUEST_DELIMITER = "+";
+    private static final String ADDRESS_DELIMITER = " ";
+
+    private final StoreService storeService;
+
+    @GetMapping
+    public ResponseEntity<StoreResponse> findStore(@NotBlank(message = "주소는 반드시 포함되어야 합니다.") @RequestParam String address) {
+        StoreResponse storeResponse = storeService.findByAddress(address.replace(ADDRESS_REQUEST_DELIMITER, ADDRESS_DELIMITER));
+        return ResponseEntity.ok(storeResponse);
+    }
+
+    @PostMapping
+    public ResponseEntity<StoreResponse> saveStore(@Valid @RequestBody StoreRequest storeRequest) {
+        StoreResponse storeResponse = storeService.save(storeRequest);
+        return ResponseEntity.ok(storeResponse);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/api/StoreController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/api/StoreController.java
@@ -27,7 +27,8 @@ public class StoreController {
     private final StoreService storeService;
 
     @GetMapping
-    public ResponseEntity<StoreResponse> findStore(@NotBlank(message = "주소는 반드시 포함되어야 합니다.") @RequestParam String address) {
+    public ResponseEntity<StoreResponse> findStore(
+            @RequestParam @NotBlank(message = "주소는 반드시 포함되어야 합니다.") String address) {
         StoreResponse storeResponse = storeService.findByAddress(address.replace(ADDRESS_REQUEST_DELIMITER, ADDRESS_DELIMITER));
         return ResponseEntity.ok(storeResponse);
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
@@ -27,6 +27,12 @@ public class StoreService {
         return StoreResponse.from(store);
     }
 
+    public StoreResponse findByAddress(String address) {
+        Store store = storeRepository.findByAddress_AddressName(address)
+                .orElseThrow(() -> new FoodbowlException(ErrorStatus.STORE_NOT_FOUND));
+        return StoreResponse.from(store);
+    }
+
     public List<StoreResponse> findAll() {
         return storeRepository.findAll().stream()
                 .map(StoreResponse::from)

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/dto/StoreResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/dto/StoreResponse.java
@@ -1,6 +1,7 @@
 package org.dinosaur.foodbowl.domain.store.dto;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -41,6 +42,11 @@ public class StoreResponse {
 
     private BigDecimal y;
 
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+
     public static StoreResponse from(Store store) {
         Address address = store.getAddress();
         return new StoreResponse(
@@ -57,7 +63,9 @@ public class StoreResponse {
                 address.getBuildingName(),
                 address.getZoneNo(),
                 address.getX(),
-                address.getY()
+                address.getY(),
+                store.getCreatedAt(),
+                store.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/repository/StoreRepository.java
@@ -11,6 +11,8 @@ public interface StoreRepository extends Repository<Store, Long> {
 
     Optional<Store> findByStoreName(String storeName);
 
+    Optional<Store> findByAddress_AddressName(String address);
+
     List<Store> findAll();
 
     Store save(Store store);

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/api/StoreControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/api/StoreControllerTest.java
@@ -1,0 +1,391 @@
+package org.dinosaur.foodbowl.domain.store.api;
+
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.STORE_NOT_FOUND;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import org.dinosaur.foodbowl.MockApiTest;
+import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import org.dinosaur.foodbowl.domain.store.application.StoreService;
+import org.dinosaur.foodbowl.domain.store.dto.StoreRequest;
+import org.dinosaur.foodbowl.domain.store.dto.StoreResponse;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(controllers = StoreController.class)
+class StoreControllerTest extends MockApiTest {
+
+    @MockBean
+    private StoreService storeService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Nested
+    @DisplayName("가게를 조회할 때 ")
+    class FindStore {
+
+        @Test
+        @DisplayName("응답을 반환한다.")
+        void findSuccess() throws Exception {
+            String address = "서울시+송파구+올림픽로+473";
+            StoreResponse storeResponse = createResponse();
+            given(storeService.findByAddress(any(String.class))).willReturn(storeResponse);
+
+            mockMvc.perform(get("/api/v1/stores")
+                            .queryParam("address", address)
+                            .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                            .characterEncoding(StandardCharsets.UTF_8))
+                    .andExpect(status().isOk())
+                    .andDo(print());
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("요청에 주소가 없으면 BAD REQUEST를 반환한다.")
+        void findFailWithEmptyAddress(String address) throws Exception {
+            mockMvc.perform(get("/api/v1/stores")
+                            .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                            .queryParam("address", address)
+                            .characterEncoding(StandardCharsets.UTF_8))
+                    .andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("주소에 해당하는 가게가 없으면 NOT FOUND를 반환한다.")
+        void findFailWithNoResult() throws Exception {
+            String address = "부산시+송파구+올림픽로+473";
+            given(storeService.findByAddress(any(String.class))).willThrow(new FoodbowlException(STORE_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/stores")
+                            .queryParam("address", address)
+                            .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                            .characterEncoding(StandardCharsets.UTF_8))
+                    .andExpect(status().isNotFound())
+                    .andDo(print());
+        }
+    }
+
+
+    @Test
+    @DisplayName("가게를 생성한다.")
+    void createSuccess() throws Exception {
+        StoreRequest storeRequest = new StoreRequest(
+                "신천직화집",
+                "서울시 송파구 올림픽로 473",
+                "서울시",
+                "송파구",
+                "신천동",
+                "올림픽로",
+                "N",
+                "473",
+                "14층 1400호",
+                "루터회관",
+                "12345",
+                BigDecimal.valueOf(127.3435356),
+                BigDecimal.valueOf(37.12314545)
+        );
+        StoreResponse storeResponse = createResponse();
+        given(storeService.save(any(StoreRequest.class))).willReturn(storeResponse);
+
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/stores")
+                .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                .content(objectMapper.writeValueAsString(storeRequest))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8));
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(storeResponse.getId()))
+                .andExpect(jsonPath("$.storeName").value(storeResponse.getStoreName()))
+                .andExpect(jsonPath("$.addressName").value(storeResponse.getAddressName()))
+                .andExpect(jsonPath("$.region1depthName").value(storeResponse.getRegion1depthName()))
+                .andExpect(jsonPath("$.region2depthName").value(storeResponse.getRegion2depthName()))
+                .andExpect(jsonPath("$.region3depthName").value(storeResponse.getRegion3depthName()))
+                .andExpect(jsonPath("$.roadName").value(storeResponse.getRoadName()))
+                .andExpect(jsonPath("$.undergroundYN").value(storeResponse.getUndergroundYN()))
+                .andExpect(jsonPath("$.mainBuildingNo").value(storeResponse.getMainBuildingNo()))
+                .andExpect(jsonPath("$.subBuildingNo").value(storeResponse.getSubBuildingNo()))
+                .andExpect(jsonPath("$.buildingName").value(storeResponse.getBuildingName()))
+                .andExpect(jsonPath("$.zoneNo").value(storeResponse.getZoneNo()))
+                .andExpect(jsonPath("$.x").value(storeResponse.getX()))
+                .andExpect(jsonPath("$.y").value(storeResponse.getY()));
+    }
+
+    @Nested
+    @DisplayName("가게 생성 요청에")
+    class StoreWithRequest {
+
+        private final String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+        @Test
+        @DisplayName("가게 이름이 없는 경우 BAD REQUEST가 반환된다.")
+        void createByEmptyStoreName() throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    null,
+                    "서울시 송파구 올림픽로 473",
+                    "서울시",
+                    "송파구",
+                    "신천동",
+                    "올림픽로",
+                    "N",
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    BigDecimal.valueOf(127.3435356),
+                    BigDecimal.valueOf(37.12314545)
+            );
+
+            execute(storeRequest, accessToken);
+        }
+
+        @Test
+        @DisplayName("주소가 없는 경우 BAD REQUEST가 반환된다.")
+        void createByWrongAddress() throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    "신천직화집",
+                    null,
+                    "서울시",
+                    "송파구",
+                    "신천동",
+                    "올림픽로",
+                    "N",
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    BigDecimal.valueOf(127.3435356),
+                    BigDecimal.valueOf(37.12314545)
+            );
+
+            execute(storeRequest, accessToken);
+        }
+
+        @Test
+        @DisplayName("광역시 또는 도가 없는 경우 BAD REQUEST가 반환된다.")
+        void createStoreByWrongRegion1depthName() throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    "신천직화집",
+                    "서울시 송파구 올림픽로 473",
+                    null,
+                    "송파구",
+                    "신천동",
+                    "올림픽로",
+                    "N",
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    BigDecimal.valueOf(127.3435356),
+                    BigDecimal.valueOf(37.12314545)
+            );
+
+            execute(storeRequest, accessToken);
+        }
+
+        @Test
+        @DisplayName("시/군/구가 없는 경우 BAD REQUEST가 반환된다.")
+        void createStoreByWrongRegion2depthName() throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    "신천직화집",
+                    "서울시 송파구 올림픽로 473",
+                    "서울시",
+                    null,
+                    "신천동",
+                    "올림픽로",
+                    "N",
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    BigDecimal.valueOf(127.3435356),
+                    BigDecimal.valueOf(37.12314545)
+            );
+
+            execute(storeRequest, accessToken);
+        }
+
+        @Test
+        @DisplayName("읍/면/동이 없는 경우 BAD REQUEST가 반환된다.")
+        void createStoreByWrongRegion3depthName() throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    "신천직화집",
+                    "서울시 송파구 올림픽로 473",
+                    "서울시",
+                    "송파구",
+                    null,
+                    "올림픽로",
+                    "N",
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    BigDecimal.valueOf(127.3435356),
+                    BigDecimal.valueOf(37.12314545)
+            );
+
+            execute(storeRequest, accessToken);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " ", "s", "@", "y", "n", "1"})
+        @DisplayName("지하 여부가 Y or N이 아닌 경우 BAD REQUEST가 반환된다.")
+        void createStoreByWrongUnderground(String underground) throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    "신천직화집",
+                    "서울시 송파구 올림픽로 473",
+                    "서울시",
+                    "송파구",
+                    "신천동",
+                    "올림픽로",
+                    underground,
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    BigDecimal.valueOf(127.3435356),
+                    BigDecimal.valueOf(37.12314545)
+            );
+            execute(storeRequest, accessToken);
+        }
+
+        @Test
+        @DisplayName("경도가 없는 경우 BAD REQUEST가 반환된다.")
+        void createStoreByEmptyX() throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    "신천직화집",
+                    "서울시 송파구 올림픽로 473",
+                    "서울시",
+                    "송파구",
+                    "신천동",
+                    "올림픽로",
+                    "N",
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    null,
+                    BigDecimal.valueOf(37.12314545)
+            );
+            execute(storeRequest, accessToken);
+        }
+
+        @Test
+        @DisplayName("위도가 없는 경우 BAD REQUEST가 반환된다.")
+        void createStoreByEmptyY() throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    "신천직화집",
+                    "서울시 송파구 올림픽로 473",
+                    "서울시",
+                    "송파구",
+                    "신천동",
+                    "올림픽로",
+                    "N",
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    BigDecimal.valueOf(127.3435356),
+                    null
+            );
+            execute(storeRequest, accessToken);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-181", "181"})
+        @DisplayName("경도가 범위를 벗어나는 경우 BAD REQUEST가 반환된다.")
+        void createStoreByWrongX(String x) throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    "신천직화집",
+                    "서울시 송파구 올림픽로 473",
+                    "서울시",
+                    "송파구",
+                    "신천동",
+                    "올림픽로",
+                    "N",
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    new BigDecimal(x),
+                    BigDecimal.valueOf(37.12314545)
+            );
+            execute(storeRequest, accessToken);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-91", "91"})
+        @DisplayName("위도가 범위를 벗어나는 경우 BAD REQUEST가 반환된다.")
+        void createStoreByWrongY(String y) throws Exception {
+            StoreRequest storeRequest = new StoreRequest(
+                    "신천직화집",
+                    "서울시 송파구 올림픽로 473",
+                    "서울시",
+                    "송파구",
+                    "신천동",
+                    "올림픽로",
+                    "N",
+                    "473",
+                    "14층 1400호",
+                    "루터회관",
+                    "12345",
+                    BigDecimal.valueOf(127.3435356),
+                    new BigDecimal(y)
+            );
+
+            execute(storeRequest, accessToken);
+        }
+    }
+
+    private void execute(StoreRequest storeRequest, String token) throws Exception {
+        mockMvc.perform(post("/api/v1/stores")
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(storeRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    private StoreResponse createResponse() {
+        return new StoreResponse(
+                1L,
+                "신천직화집",
+                "서울시 송파구 올림픽로 473",
+                "서울시",
+                "송파구",
+                "신천동",
+                "올림픽로",
+                "N",
+                "473",
+                "14층 1400호",
+                "루터회관",
+                "12345",
+                BigDecimal.valueOf(127.3435356),
+                BigDecimal.valueOf(37.12314545)
+        );
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/api/StoreControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/api/StoreControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.domain.store.application.StoreService;
@@ -385,7 +386,9 @@ class StoreControllerTest extends MockApiTest {
                 "루터회관",
                 "12345",
                 BigDecimal.valueOf(127.3435356),
-                BigDecimal.valueOf(37.12314545)
+                BigDecimal.valueOf(37.12314545),
+                LocalDateTime.now(),
+                LocalDateTime.now()
         );
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -2,6 +2,8 @@ package org.dinosaur.foodbowl.domain.store.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.STORE_DUPLICATED;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.STORE_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.math.BigDecimal;
@@ -71,7 +73,7 @@ class StoreServiceTest extends IntegrationTest {
 
             assertThatThrownBy(() -> storeService.save(createRequest("국민연금공단 구내식당", "서울시 송파구 올림픽로 123")))
                     .isInstanceOf(FoodbowlException.class)
-                    .hasMessageContaining("이미 등록된 가게입니다.");
+                    .hasMessageContaining(STORE_DUPLICATED.getMessage());
         }
     }
 
@@ -94,7 +96,7 @@ class StoreServiceTest extends IntegrationTest {
         void findOneFail() {
             assertThatThrownBy(() -> storeService.findOne(-1L))
                     .isInstanceOf(FoodbowlException.class)
-                    .hasMessageContaining("일치하는 가게를 찾을 수 없습니다.");
+                    .hasMessageContaining(STORE_NOT_FOUND.getMessage());
         }
     }
 
@@ -104,7 +106,7 @@ class StoreServiceTest extends IntegrationTest {
 
         @Test
         @DisplayName("주소에 해당하는 가게 정보를 가져온다.")
-        void findByNameSuccess() {
+        void findByAddressSuccess() {
             Address address = createAddress();
             Store store = storeTestSupport.builder().address(address).storeName("맥도날드 잠실점").build();
 
@@ -114,6 +116,17 @@ class StoreServiceTest extends IntegrationTest {
                     () -> assertThat(findStoreResponse.getId()).isEqualTo(store.getId()),
                     () -> assertThat(findStoreResponse.getAddressName()).isEqualTo(store.getAddress().getAddressName())
             );
+        }
+
+        @Test
+        @DisplayName("주소에 해당하는 가게 정보를 가져온다.")
+        void findByAddressFail() {
+            Address address = createAddress();
+            storeTestSupport.builder().address(address).storeName("맥도날드 잠실점").build();
+
+            assertThatThrownBy(() -> storeService.findByAddress("제주시 송파구 신천동"))
+                    .isInstanceOf(FoodbowlException.class)
+                    .hasMessageContaining(STORE_NOT_FOUND.getMessage());
         }
     }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -1,11 +1,11 @@
 package org.dinosaur.foodbowl.domain.store.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.math.BigDecimal;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.dinosaur.foodbowl.IntegrationTest;
 import org.dinosaur.foodbowl.domain.store.dto.StoreRequest;
 import org.dinosaur.foodbowl.domain.store.dto.StoreResponse;
@@ -31,24 +31,6 @@ class StoreServiceTest extends IntegrationTest {
         List<StoreResponse> storeResponses = storeService.findAll();
 
         assertThat(storeResponses).hasSize(initialSize + 2);
-    }
-
-    private StoreRequest createRequest(String storeName, String addressName) {
-        return new StoreRequest(
-                storeName,
-                addressName,
-                "서울시",
-                "송파구",
-                "신천동",
-                "연금공단로",
-                "N",
-                "123",
-                "1층 101호",
-                "국민연금공단 송파지점",
-                "12345",
-                BigDecimal.valueOf(127.3435356),
-                BigDecimal.valueOf(37.12314545)
-        );
     }
 
     @Nested
@@ -85,14 +67,14 @@ class StoreServiceTest extends IntegrationTest {
         void saveFail() {
             storeService.save(createRequest("국민연금공단 구내식당", "서울시 송파구 올림픽로 123"));
 
-            Assertions.assertThatThrownBy(() -> storeService.save(createRequest("국민연금공단 구내식당", "서울시 송파구 올림픽로 123")))
+            assertThatThrownBy(() -> storeService.save(createRequest("국민연금공단 구내식당", "서울시 송파구 올림픽로 123")))
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessageContaining("이미 등록된 가게입니다.");
         }
     }
 
     @Nested
-    @DisplayName("find 메서드는")
+    @DisplayName("find 메서드는 ")
     class Find {
 
         @Test
@@ -110,9 +92,46 @@ class StoreServiceTest extends IntegrationTest {
         void findOneFail() {
             storeService.save(createRequest("국민연금공단 구내식당", "서울시 송파구 올림픽로 123"));
 
-            Assertions.assertThatThrownBy(() -> storeService.findOne(Long.MAX_VALUE))
+            assertThatThrownBy(() -> storeService.findOne(Long.MAX_VALUE))
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessageContaining("일치하는 가게를 찾을 수 없습니다.");
         }
+    }
+
+    @Nested
+    @DisplayName("findByAddress 메서드는 ")
+    class FindByName {
+
+        @Test
+        @DisplayName("주소에 해당하는 가게 정보를 가져온다.")
+        void findByNameSuccess() {
+            String address = "서울시 송파구 신천동 1542";
+            StoreResponse savedStoreResponse = storeService.save(createRequest("맥도날드 잠실점", address));
+
+            StoreResponse findStoreResponse = storeService.findByAddress(address);
+
+            assertAll(
+                    () -> assertThat(findStoreResponse.getId()).isEqualTo(savedStoreResponse.getId()),
+                    () -> assertThat(findStoreResponse.getAddressName()).isEqualTo(savedStoreResponse.getAddressName())
+            );
+        }
+    }
+
+    private StoreRequest createRequest(String storeName, String addressName) {
+        return new StoreRequest(
+                storeName,
+                addressName,
+                "서울시",
+                "송파구",
+                "신천동",
+                "연금공단로",
+                "N",
+                "123",
+                "1층 101호",
+                "국민연금공단 송파지점",
+                "12345",
+                BigDecimal.valueOf(127.3435356),
+                BigDecimal.valueOf(37.12314545)
+        );
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 import org.dinosaur.foodbowl.IntegrationTest;
 import org.dinosaur.foodbowl.domain.store.dto.StoreRequest;
 import org.dinosaur.foodbowl.domain.store.dto.StoreResponse;
+import org.dinosaur.foodbowl.domain.store.entity.Address;
+import org.dinosaur.foodbowl.domain.store.entity.Store;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -80,7 +82,7 @@ class StoreServiceTest extends IntegrationTest {
         @Test
         @DisplayName("ID에 해당하는 가게 정보를 가져온다.")
         void findOneSuccess() {
-            Long savedId = storeService.save(createRequest("국민연금공단 구내식당", "서울시 송파구 올림픽로 123")).getId();
+            Long savedId = storeTestSupport.builder().build().getId();
 
             StoreResponse findStore = storeService.findOne(savedId);
 
@@ -90,9 +92,7 @@ class StoreServiceTest extends IntegrationTest {
         @Test
         @DisplayName("ID에 해당하는 가게가 없으면 예외가 발생한다.")
         void findOneFail() {
-            storeService.save(createRequest("국민연금공단 구내식당", "서울시 송파구 올림픽로 123"));
-
-            assertThatThrownBy(() -> storeService.findOne(Long.MAX_VALUE))
+            assertThatThrownBy(() -> storeService.findOne(-1L))
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessageContaining("일치하는 가게를 찾을 수 없습니다.");
         }
@@ -105,16 +105,33 @@ class StoreServiceTest extends IntegrationTest {
         @Test
         @DisplayName("주소에 해당하는 가게 정보를 가져온다.")
         void findByNameSuccess() {
-            String address = "서울시 송파구 신천동 1542";
-            StoreResponse savedStoreResponse = storeService.save(createRequest("맥도날드 잠실점", address));
+            Address address = createAddress();
+            Store store = storeTestSupport.builder().address(address).storeName("맥도날드 잠실점").build();
 
-            StoreResponse findStoreResponse = storeService.findByAddress(address);
+            StoreResponse findStoreResponse = storeService.findByAddress(address.getAddressName());
 
             assertAll(
-                    () -> assertThat(findStoreResponse.getId()).isEqualTo(savedStoreResponse.getId()),
-                    () -> assertThat(findStoreResponse.getAddressName()).isEqualTo(savedStoreResponse.getAddressName())
+                    () -> assertThat(findStoreResponse.getId()).isEqualTo(store.getId()),
+                    () -> assertThat(findStoreResponse.getAddressName()).isEqualTo(store.getAddress().getAddressName())
             );
         }
+    }
+
+    private Address createAddress() {
+        return Address.builder()
+                .addressName("서울시 송파구 신천동 1542")
+                .region1depthName("서울시")
+                .region2depthName("송파구")
+                .region3depthName("신천동")
+                .roadName("연금공단로")
+                .undergroundYN("N")
+                .mainBuildingNo("123")
+                .subBuildingNo("1층 101호")
+                .buildingName("국민연금공단 송파지점")
+                .zoneNo("12345")
+                .x(BigDecimal.valueOf(127.3435356))
+                .y(BigDecimal.valueOf(37.12314545))
+                .build();
     }
 
     private StoreRequest createRequest(String storeName, String addressName) {

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -100,7 +100,7 @@ class StoreServiceTest extends IntegrationTest {
 
     @Nested
     @DisplayName("findByAddress 메서드는 ")
-    class FindByName {
+    class FindByAddress {
 
         @Test
         @DisplayName("주소에 해당하는 가게 정보를 가져온다.")

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/docs/StoreControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/docs/StoreControllerDocsTest.java
@@ -1,0 +1,184 @@
+package org.dinosaur.foodbowl.domain.store.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import org.dinosaur.foodbowl.MockApiTest;
+import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
+import org.dinosaur.foodbowl.domain.store.api.StoreController;
+import org.dinosaur.foodbowl.domain.store.application.StoreService;
+import org.dinosaur.foodbowl.domain.store.dto.StoreRequest;
+import org.dinosaur.foodbowl.domain.store.dto.StoreResponse;
+import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+@WebMvcTest(StoreController.class)
+public class StoreControllerDocsTest extends MockApiTest {
+
+    @MockBean
+    private StoreService storeService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("가게 조회 응답을 반환한다.")
+    void findSuccess() throws Exception {
+        String address = "서울시+송파구+올림픽로+473";
+        StoreResponse storeResponse = createResponse();
+        given(storeService.findByAddress(any(String.class))).willReturn(storeResponse);
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .queryParam("address", address)
+                        .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                        .characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("api-v1-stores-read",
+                        requestHeaders(
+                                headerWithName("Authorization").description("Foodbowl 인증 토큰")
+                        ),
+                        queryParameters(
+                                parameterWithName("address").description("주소(공백은 반드시 '+'로 치환해야 합니다.")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 ID"),
+                                fieldWithPath("storeName").type(JsonFieldType.STRING).description("가게 이름"),
+                                fieldWithPath("addressName").type(JsonFieldType.STRING).description("주소"),
+                                fieldWithPath("region1depthName").type(JsonFieldType.STRING).description("광역시 또는 도"),
+                                fieldWithPath("region2depthName").type(JsonFieldType.STRING).description("시/군/구"),
+                                fieldWithPath("region3depthName").type(JsonFieldType.STRING).description("읍/면/동"),
+                                fieldWithPath("roadName").type(JsonFieldType.STRING).description("도로명 주소"),
+                                fieldWithPath("undergroundYN").type(JsonFieldType.STRING).description("지하 여부"),
+                                fieldWithPath("mainBuildingNo").type(JsonFieldType.STRING).description("건물 번호"),
+                                fieldWithPath("subBuildingNo").type(JsonFieldType.STRING).description("동/호수"),
+                                fieldWithPath("buildingName").type(JsonFieldType.STRING).description("건물 이름"),
+                                fieldWithPath("zoneNo").type(JsonFieldType.STRING).description("우편 번호"),
+                                fieldWithPath("x").type(JsonFieldType.NUMBER).description("경도"),
+                                fieldWithPath("y").type(JsonFieldType.NUMBER).description("위도")
+                        )));
+    }
+
+    @Test
+    @DisplayName("가게를 생성한다.")
+    void createSuccess() throws Exception {
+        StoreRequest storeRequest = new StoreRequest(
+                "신천직화집",
+                "서울시 송파구 올림픽로 473",
+                "서울시",
+                "송파구",
+                "신천동",
+                "올림픽로",
+                "N",
+                "473",
+                "14층 1400호",
+                "루터회관",
+                "12345",
+                BigDecimal.valueOf(127.3435356),
+                BigDecimal.valueOf(37.12314545)
+        );
+        StoreResponse storeResponse = createResponse();
+        given(storeService.save(any(StoreRequest.class))).willReturn(storeResponse);
+
+        var headerDescriptors = new HeaderDescriptor[]{
+                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
+        };
+
+        var requestFieldDescriptors = new FieldDescriptor[]{
+                fieldWithPath("storeName").type(JsonFieldType.STRING).description("가게 이름"),
+                fieldWithPath("addressName").type(JsonFieldType.STRING).description("주소"),
+                fieldWithPath("region1depthName").type(JsonFieldType.STRING).description("광역시 또는 도"),
+                fieldWithPath("region2depthName").type(JsonFieldType.STRING).description("시/군/구"),
+                fieldWithPath("region3depthName").type(JsonFieldType.STRING).description("읍/면/동"),
+                fieldWithPath("roadName").type(JsonFieldType.STRING).description("도로명 주소").optional(),
+                fieldWithPath("undergroundYN").type(JsonFieldType.STRING).description("지하 여부").optional(),
+                fieldWithPath("mainBuildingNo").type(JsonFieldType.STRING).description("건물 번호").optional(),
+                fieldWithPath("subBuildingNo").type(JsonFieldType.STRING).description("동/호수").optional(),
+                fieldWithPath("buildingName").type(JsonFieldType.STRING).description("건물 이름").optional(),
+                fieldWithPath("zoneNo").type(JsonFieldType.STRING).description("우편 번호").optional(),
+                fieldWithPath("x").type(JsonFieldType.NUMBER).description("경도"),
+                fieldWithPath("y").type(JsonFieldType.NUMBER).description("위도")
+        };
+
+        var responseFieldDescriptors = new FieldDescriptor[]{
+                fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 ID"),
+                fieldWithPath("storeName").type(JsonFieldType.STRING).description("가게 이름"),
+                fieldWithPath("addressName").type(JsonFieldType.STRING).description("주소"),
+                fieldWithPath("region1depthName").type(JsonFieldType.STRING).description("광역시 또는 도"),
+                fieldWithPath("region2depthName").type(JsonFieldType.STRING).description("시/군/구"),
+                fieldWithPath("region3depthName").type(JsonFieldType.STRING).description("읍/면/동"),
+                fieldWithPath("roadName").type(JsonFieldType.STRING).description("도로명 주소"),
+                fieldWithPath("undergroundYN").type(JsonFieldType.STRING).description("지하 여부"),
+                fieldWithPath("mainBuildingNo").type(JsonFieldType.STRING).description("건물 번호"),
+                fieldWithPath("subBuildingNo").type(JsonFieldType.STRING).description("동/호수"),
+                fieldWithPath("buildingName").type(JsonFieldType.STRING).description("건물 이름"),
+                fieldWithPath("zoneNo").type(JsonFieldType.STRING).description("우편 번호"),
+                fieldWithPath("x").type(JsonFieldType.NUMBER).description("경도"),
+                fieldWithPath("y").type(JsonFieldType.NUMBER).description("위도")
+        };
+
+        mockMvc.perform(post("/api/v1/stores")
+                .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                .content(objectMapper.writeValueAsString(storeRequest))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("api-v1-stores-create",
+                        requestHeaders(
+                                headerDescriptors
+                        ),
+                        requestFields(
+                                requestFieldDescriptors
+                        ),
+                        responseFields(
+                                responseFieldDescriptors
+                        )));
+    }
+
+    private StoreResponse createResponse() {
+        return new StoreResponse(
+                1L,
+                "신천직화집",
+                "서울시 송파구 올림픽로 473",
+                "서울시",
+                "송파구",
+                "신천동",
+                "올림픽로",
+                "N",
+                "473",
+                "14층 1400호",
+                "루터회관",
+                "12345",
+                BigDecimal.valueOf(127.3435356),
+                BigDecimal.valueOf(37.12314545)
+        );
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/docs/StoreControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/docs/StoreControllerDocsTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.domain.store.api.StoreController;
@@ -61,9 +62,9 @@ public class StoreControllerDocsTest extends MockApiTest {
                         .characterEncoding(StandardCharsets.UTF_8))
                 .andExpect(status().isOk())
                 .andDo(print())
-                .andDo(document("api-v1-stores-read",
+                .andDo(document("api-v1-stores-find",
                         requestHeaders(
-                                headerWithName("Authorization").description("Foodbowl 인증 토큰")
+                                headerWithName("Authorization").description("서버에서 발급한 엑세스 토큰")
                         ),
                         queryParameters(
                                 parameterWithName("address").description("주소(공백은 반드시 '+'로 치환해야 합니다.")
@@ -82,7 +83,9 @@ public class StoreControllerDocsTest extends MockApiTest {
                                 fieldWithPath("buildingName").type(JsonFieldType.STRING).description("건물 이름"),
                                 fieldWithPath("zoneNo").type(JsonFieldType.STRING).description("우편 번호"),
                                 fieldWithPath("x").type(JsonFieldType.NUMBER).description("경도"),
-                                fieldWithPath("y").type(JsonFieldType.NUMBER).description("위도")
+                                fieldWithPath("y").type(JsonFieldType.NUMBER).description("위도"),
+                                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 시간"),
+                                fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("최종 수정 시간")
                         )));
     }
 
@@ -141,14 +144,16 @@ public class StoreControllerDocsTest extends MockApiTest {
                 fieldWithPath("buildingName").type(JsonFieldType.STRING).description("건물 이름"),
                 fieldWithPath("zoneNo").type(JsonFieldType.STRING).description("우편 번호"),
                 fieldWithPath("x").type(JsonFieldType.NUMBER).description("경도"),
-                fieldWithPath("y").type(JsonFieldType.NUMBER).description("위도")
+                fieldWithPath("y").type(JsonFieldType.NUMBER).description("위도"),
+                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 시간"),
+                fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("최종 수정 시간"),
         };
 
         mockMvc.perform(post("/api/v1/stores")
-                .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
-                .content(objectMapper.writeValueAsString(storeRequest))
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding(StandardCharsets.UTF_8))
+                        .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                        .content(objectMapper.writeValueAsString(storeRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andDo(document("api-v1-stores-create",
@@ -178,7 +183,9 @@ public class StoreControllerDocsTest extends MockApiTest {
                 "루터회관",
                 "12345",
                 BigDecimal.valueOf(127.3435356),
-                BigDecimal.valueOf(37.12314545)
+                BigDecimal.valueOf(37.12314545),
+                LocalDateTime.now(),
+                LocalDateTime.now()
         );
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/repository/StoreRepositoryTest.java
@@ -23,31 +23,6 @@ class StoreRepositoryTest extends RepositoryTest {
         assertThat(storeRepository.findAll()).hasSizeGreaterThanOrEqualTo(0);
     }
 
-    private Store createStore() {
-        Address address = createAddress();
-        return Store.builder()
-                .address(address)
-                .storeName("작살치킨")
-                .build();
-    }
-
-    private Address createAddress() {
-        return Address.builder()
-                .addressName("서울시 송파구 방이동 방이로 1234")
-                .region1depthName("서울시")
-                .region2depthName("송파구")
-                .region3depthName("방이동")
-                .roadName("방이로")
-                .mainBuildingNo("1234")
-                .subBuildingNo("14층 1400호")
-                .undergroundYN("N")
-                .buildingName("작살치킨 빌딩")
-                .zoneNo("12345")
-                .x(BigDecimal.valueOf(127.3437575))
-                .y(BigDecimal.valueOf(37.12567))
-                .build();
-    }
-
     @Nested
     @DisplayName("findById 메서드는")
     class FindById {
@@ -96,5 +71,55 @@ class StoreRepositoryTest extends RepositoryTest {
 
             assertThat(findStore.isEmpty()).isTrue();
         }
+    }
+
+    @Nested
+    @DisplayName("findByAddress_AddressName 메서드는")
+    class findByAddress_AddressName {
+
+        @Test
+        @DisplayName("가게 주소에 해당하는 가게 정보를 가져온다.")
+        void findByAddress_AddressNameSuccess() {
+            Store savedStore = storeRepository.save(createStore());
+
+            Optional<Store> findStore = storeRepository.findByAddress_AddressName(savedStore.getAddress().getAddressName());
+
+            assertThat(findStore.get()).isEqualTo(savedStore);
+        }
+
+        @Test
+        @DisplayName("가게 이름에 해당하는 가게가 없으면 빈 값을 반환한다.")
+        void findByStoreNameWithEmptySuccess() {
+            storeRepository.save(createStore());
+
+            Optional<Store> findStore = storeRepository.findByAddress_AddressName("부산시 금정구 장전동 부산대학로 21");
+
+            assertThat(findStore).isEmpty();
+        }
+    }
+
+    private Store createStore() {
+        Address address = createAddress();
+        return Store.builder()
+                .address(address)
+                .storeName("작살치킨")
+                .build();
+    }
+
+    private Address createAddress() {
+        return Address.builder()
+                .addressName("서울시 송파구 방이동 방이로 1234")
+                .region1depthName("서울시")
+                .region2depthName("송파구")
+                .region3depthName("방이동")
+                .roadName("방이로")
+                .mainBuildingNo("1234")
+                .subBuildingNo("14층 1400호")
+                .undergroundYN("N")
+                .buildingName("작살치킨 빌딩")
+                .zoneNo("12345")
+                .x(BigDecimal.valueOf(127.3437575))
+                .y(BigDecimal.valueOf(37.12567))
+                .build();
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #67

## 📝 작업 요약

가게 조회, 가게 등록 API 구현

## 🔎 작업 상세 설명

가게를 조회하는 경우 주소를 받아 조회합니다.
주소의 공백은 `+`로 구분되어 있으며 컨트롤러에서 공백으로 변환 후 서비스로 넘겨줍니다. 

가게 생성의 경우, status 201 대신 **200 + body**로 응답합니다.
201 Location URI로 할당할 주소가 없기 때문입니다.

## 🌟 리뷰 요구 사항

> 20분
