### PR TITLE
Feature/#47 검색 탭 게시글 피드 목록 조회 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -13,6 +13,32 @@ endif::[]
 
 link:../foodbowl.html[API 목록으로 돌아가기]
 
+== *최근 게시글 썸네일 목록 조회* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-posts-thumbnails-latest/http-request.adoc[]
+
+=== Request Headers
+
+include::{snippets}/api-v1-posts-thumbnails-latest/request-headers.adoc[]
+
+=== Query Parameters
+
+include::{snippets}/api-v1-posts-thumbnails-latest/query-parameters.adoc[]
+
+=== 응답
+
+=== Response
+
+include::{snippets}/api-v1-posts-thumbnails-latest/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/api-v1-posts-thumbnails-latest/response-fields.adoc[]
+
 == *프로필 게시글 썸네일 목록 조회* ==
 
 === 요청

--- a/src/docs/asciidoc/store/store.adoc
+++ b/src/docs/asciidoc/store/store.adoc
@@ -39,7 +39,6 @@ include::{snippets}/api-v1-stores-find/http-response.adoc[]
 
 include::{snippets}/api-v1-stores-find/response-fields.adoc[]
 
-
 == *가게 생성* ==
 
 === 요청

--- a/src/main/java/org/dinosaur/foodbowl/domain/comment/application/CommentService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/comment/application/CommentService.java
@@ -1,6 +1,7 @@
 package org.dinosaur.foodbowl.domain.comment.application;
 
-import static org.dinosaur.foodbowl.global.exception.ErrorStatus.*;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.COMMENT_NOT_FOUND;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.COMMENT_UNAUTHORIZED;
 import static org.dinosaur.foodbowl.global.exception.ErrorStatus.MEMBER_NOT_FOUND;
 import static org.dinosaur.foodbowl.global.exception.ErrorStatus.POST_NOT_FOUND;
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/api/PostController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/api/PostController.java
@@ -23,9 +23,15 @@ public class PostController {
     @GetMapping("/thumbnails")
     public ResponseEntity<PageResponse<PostThumbnailResponse>> findThumbnailsInProfile(
             @RequestParam Long memberId,
-            @PageableDefault(size = 18, page = 0, sort = "createdAt", direction = Direction.DESC) Pageable pageable
-    ) {
+            @PageableDefault(page = 0, size = 18, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
         PageResponse<PostThumbnailResponse> response = postService.findThumbnailsInProfile(memberId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/thumbnails/latest")
+    public ResponseEntity<PageResponse<PostThumbnailResponse>> findLatestThumbnails(
+            @PageableDefault(page = 0, size = 18, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        PageResponse<PostThumbnailResponse> response = postService.findLatestThumbnails(pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/application/PostService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/application/PostService.java
@@ -30,4 +30,10 @@ public class PostService {
                 .map(PostThumbnailResponse::from);
         return PageResponse.from(pageOfResponse);
     }
+
+    public PageResponse<PostThumbnailResponse> findLatestThumbnails(Pageable pageable) {
+        Page<PostThumbnailResponse> pageOfResponse = postRepository.findAll(pageable)
+                .map(PostThumbnailResponse::from);
+        return PageResponse.from(pageOfResponse);
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostRepository.java
@@ -18,6 +18,9 @@ public interface PostRepository extends Repository<Post, Long> {
 
     List<Post> findAll();
 
+    @EntityGraph(attributePaths = "thumbnail")
+    Page<Post> findAll(Pageable pageable);
+
     Post save(Post post);
 
     void delete(Post post);

--- a/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/post/repository/PostRepository.java
@@ -2,7 +2,6 @@ package org.dinosaur.foodbowl.domain.post.repository;
 
 import java.util.List;
 import java.util.Optional;
-
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.springframework.data.domain.Page;

--- a/src/main/java/org/dinosaur/foodbowl/global/dto/PageResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/dto/PageResponse.java
@@ -16,10 +16,10 @@ public class PageResponse<T> {
     private boolean first;
     private boolean last;
     private boolean hasNext;
-    private int currentPage;
+    private int currentPageIndex;
     private int currentElementSize;
     private int totalPage;
-    private long totalElementSize;
+    private long totalElementCount;
 
     public static <T> PageResponse<T> from(final Page<T> page) {
         return new PageResponse<>(

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/docs/BookmarkControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/docs/BookmarkControllerDocsTest.java
@@ -77,10 +77,10 @@ class BookmarkControllerDocsTest extends MockApiTest {
                 fieldWithPath("first").description("첫 페이지 여부"),
                 fieldWithPath("last").description("마지막 페이지 여부"),
                 fieldWithPath("hasNext").description("다음 페이지 존재 여부"),
-                fieldWithPath("currentPage").description("현재 페이지 인덱스"),
+                fieldWithPath("currentPageIndex").description("현재 페이지 인덱스"),
                 fieldWithPath("currentElementSize").description("현재 데이터 개수"),
                 fieldWithPath("totalPage").description("전체 페이지 숫자"),
-                fieldWithPath("totalElementSize").description("전체 데이터 개수"),
+                fieldWithPath("totalElementCount").description("전체 데이터 개수"),
         };
 
         mockMvc.perform(get("/api/v1/bookmarks/thumbnails")

--- a/src/test/java/org/dinosaur/foodbowl/domain/comment/api/CommentControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/comment/api/CommentControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.comment.application.CommentService;
@@ -30,6 +31,9 @@ class CommentControllerTest extends MockApiTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Nested
     @DisplayName("댓글 추가는 ")

--- a/src/test/java/org/dinosaur/foodbowl/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/comment/application/CommentServiceTest.java
@@ -3,8 +3,8 @@ package org.dinosaur.foodbowl.domain.comment.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.dinosaur.foodbowl.global.exception.ErrorStatus.COMMENT_NOT_FOUND;
-import static org.dinosaur.foodbowl.global.exception.ErrorStatus.MEMBER_NOT_FOUND;
 import static org.dinosaur.foodbowl.global.exception.ErrorStatus.COMMENT_UNAUTHORIZED;
+import static org.dinosaur.foodbowl.global.exception.ErrorStatus.MEMBER_NOT_FOUND;
 import static org.dinosaur.foodbowl.global.exception.ErrorStatus.POST_NOT_FOUND;
 
 import jakarta.persistence.EntityManager;

--- a/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
@@ -11,6 +11,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.comment.api.CommentController;
@@ -36,6 +37,9 @@ public class CommentControllerDocsTest extends MockApiTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("댓글 등록을 문서화한다.")

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
 import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
@@ -35,6 +36,9 @@ class MemberControllerTest extends MockApiTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("회원 탈퇴 요청 시 회원을 탈퇴시킨다.")

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/docs/MemberControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/docs/MemberControllerDocsTest.java
@@ -13,6 +13,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.member.api.MemberController;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
@@ -37,6 +38,9 @@ public class MemberControllerDocsTest extends MockApiTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("회원 탈퇴를 문서화한다.")

--- a/src/test/java/org/dinosaur/foodbowl/domain/post/api/PostControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/post/api/PostControllerTest.java
@@ -1,14 +1,16 @@
 package org.dinosaur.foodbowl.domain.post.api;
 
-import static org.hamcrest.Matchers.hasSize;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.Charset;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.dinosaur.foodbowl.MockApiTest;
@@ -24,12 +26,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(PostController.class)
 class PostControllerTest extends MockApiTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockBean
     private PostService postService;
@@ -55,28 +61,26 @@ class PostControllerTest extends MockApiTest {
             );
             given(postService.findThumbnailsInProfile(anyLong(), any(Pageable.class))).willReturn(response);
 
-            mockMvc.perform(get("/api/v1/posts/thumbnails")
+            MvcResult mvcResult = mockMvc.perform(get("/api/v1/posts/thumbnails")
                             .header("Authorization", "Bearer " + accessToken)
-                            .queryParam("memberId", String.valueOf(1L)))
+                            .queryParam("memberId", String.valueOf(1L))
+                    )
                     .andDo(print())
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.content", hasSize(1)))
-                    .andExpect(jsonPath("$.content[0].postId").value(1L))
-                    .andExpect(jsonPath("$.content[0].thumbnailPath").value("path"))
-                    .andExpect(jsonPath("$.first").value(true))
-                    .andExpect(jsonPath("$.last").value(true))
-                    .andExpect(jsonPath("$.hasNext").value(false))
-                    .andExpect(jsonPath("$.currentPage").value(0))
-                    .andExpect(jsonPath("$.currentElementSize").value(1))
-                    .andExpect(jsonPath("$.totalPage").value(1))
-                    .andExpect(jsonPath("$.totalElementSize").value(1));
+                    .andReturn();
+            String jsonResponse = mvcResult.getResponse().getContentAsString(Charset.forName("UTF-8"));
+            PageResponse<PostThumbnailResponse> result =
+                    objectMapper.readValue(jsonResponse, new TypeReference<PageResponse<PostThumbnailResponse>>() {
+                    });
+            assertThat(result).usingRecursiveComparison().isEqualTo(response);
         }
 
         @Test
         @DisplayName("멤버 ID를 파라미터로 전달하지 않으면 400 상태를 반환한다.")
         void findThumbnailsInProfileWithEmptyParam() throws Exception {
             mockMvc.perform(get("/api/v1/posts/thumbnails")
-                            .header("Authorization", "Bearer " + accessToken))
+                            .header("Authorization", "Bearer " + accessToken)
+                    )
                     .andDo(print())
                     .andExpect(status().isBadRequest());
         }
@@ -86,9 +90,41 @@ class PostControllerTest extends MockApiTest {
         void findThumbnailsInProfileWithInvalidType() throws Exception {
             mockMvc.perform(get("/api/v1/posts/thumbnails")
                             .header("Authorization", "Bearer " + accessToken)
-                            .queryParam("memberId", "id"))
+                            .queryParam("memberId", "id")
+                    )
                     .andDo(print())
                     .andExpect(status().isBadRequest());
         }
+    }
+
+    @Test
+    @DisplayName("최근 게시글 썸네일 목록을 조회한다.")
+    void findLatestThumbnails() throws Exception {
+        PageResponse<PostThumbnailResponse> response = new PageResponse<>(
+                List.of(
+                        new PostThumbnailResponse(1L, "path", LocalDateTime.now()),
+                        new PostThumbnailResponse(2L, "path", LocalDateTime.now())
+                ),
+                true,
+                true,
+                false,
+                0,
+                1,
+                1,
+                1
+        );
+        given(postService.findLatestThumbnails(any(Pageable.class))).willReturn(response);
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/posts/thumbnails/latest")
+                        .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+        String jsonResponse = mvcResult.getResponse().getContentAsString(Charset.forName("UTF-8"));
+        PageResponse<PostThumbnailResponse> result =
+                objectMapper.readValue(jsonResponse, new TypeReference<PageResponse<PostThumbnailResponse>>() {
+                });
+        assertThat(result).usingRecursiveComparison().isEqualTo(response);
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/post/api/PostControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/post/api/PostControllerTest.java
@@ -40,6 +40,37 @@ class PostControllerTest extends MockApiTest {
     @MockBean
     private PostService postService;
 
+    @Test
+    @DisplayName("최근 게시글 썸네일 목록을 조회한다.")
+    void findLatestThumbnails() throws Exception {
+        PageResponse<PostThumbnailResponse> response = new PageResponse<>(
+                List.of(
+                        new PostThumbnailResponse(1L, "path", LocalDateTime.now()),
+                        new PostThumbnailResponse(2L, "path", LocalDateTime.now())
+                ),
+                true,
+                true,
+                false,
+                0,
+                1,
+                1,
+                1
+        );
+        given(postService.findLatestThumbnails(any(Pageable.class))).willReturn(response);
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/posts/thumbnails/latest")
+                        .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+        String jsonResponse = mvcResult.getResponse().getContentAsString(Charset.forName("UTF-8"));
+        PageResponse<PostThumbnailResponse> result =
+                objectMapper.readValue(jsonResponse, new TypeReference<PageResponse<PostThumbnailResponse>>() {
+                });
+        assertThat(result).usingRecursiveComparison().isEqualTo(response);
+    }
+
     @Nested
     @DisplayName("프로필 게시글 목록 조회 시 ")
     class FindThumbnailsInProfile {
@@ -95,36 +126,5 @@ class PostControllerTest extends MockApiTest {
                     .andDo(print())
                     .andExpect(status().isBadRequest());
         }
-    }
-
-    @Test
-    @DisplayName("최근 게시글 썸네일 목록을 조회한다.")
-    void findLatestThumbnails() throws Exception {
-        PageResponse<PostThumbnailResponse> response = new PageResponse<>(
-                List.of(
-                        new PostThumbnailResponse(1L, "path", LocalDateTime.now()),
-                        new PostThumbnailResponse(2L, "path", LocalDateTime.now())
-                ),
-                true,
-                true,
-                false,
-                0,
-                1,
-                1,
-                1
-        );
-        given(postService.findLatestThumbnails(any(Pageable.class))).willReturn(response);
-
-        MvcResult mvcResult = mockMvc.perform(get("/api/v1/posts/thumbnails/latest")
-                        .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
-                )
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andReturn();
-        String jsonResponse = mvcResult.getResponse().getContentAsString(Charset.forName("UTF-8"));
-        PageResponse<PostThumbnailResponse> result =
-                objectMapper.readValue(jsonResponse, new TypeReference<PageResponse<PostThumbnailResponse>>() {
-                });
-        assertThat(result).usingRecursiveComparison().isEqualTo(response);
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
@@ -25,6 +25,32 @@ class PostServiceTest extends IntegrationTest {
     @Autowired
     private PostService postService;
 
+    @Test
+    @DisplayName("최근 게시글 썸네일 목록을 조회한다.")
+    void findLatestThumbnails() {
+        Post postA = postTestSupport.postBuilder().build();
+        Post postB = postTestSupport.postBuilder().build();
+        Post postC = postTestSupport.postBuilder().build();
+
+        Pageable pageable = PageRequest.of(0, 5, Sort.by(Direction.DESC, "id"));
+        PageResponse<PostThumbnailResponse> result = postService.findLatestThumbnails(pageable);
+
+        List<PostThumbnailResponse> response = result.getContent();
+        assertAll(
+                () -> assertThat(response).hasSize(3),
+                () -> assertThat(response.get(0).getPostId()).isEqualTo(postC.getId()),
+                () -> assertThat(response.get(1).getPostId()).isEqualTo(postB.getId()),
+                () -> assertThat(response.get(2).getPostId()).isEqualTo(postA.getId()),
+                () -> assertThat(result.isFirst()).isTrue(),
+                () -> assertThat(result.isLast()).isTrue(),
+                () -> assertThat(result.isHasNext()).isFalse(),
+                () -> assertThat(result.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(result.getCurrentElementSize()).isEqualTo(5),
+                () -> assertThat(result.getTotalPage()).isEqualTo(1),
+                () -> assertThat(result.getTotalElementSize()).isEqualTo(3)
+        );
+    }
+
     @Nested
     @DisplayName("findThumbnailsInProfile 메서드는 ")
     class FindThumbnailsInProfile {
@@ -52,31 +78,5 @@ class PostServiceTest extends IntegrationTest {
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
-    }
-
-    @Test
-    @DisplayName("최근 게시글 썸네일 목록을 조회한다.")
-    void findLatestThumbnails() {
-        Post postA = postTestSupport.postBuilder().build();
-        Post postB = postTestSupport.postBuilder().build();
-        Post postC = postTestSupport.postBuilder().build();
-
-        Pageable pageable = PageRequest.of(0, 5, Sort.by(Direction.DESC, "id"));
-        PageResponse<PostThumbnailResponse> result = postService.findLatestThumbnails(pageable);
-
-        List<PostThumbnailResponse> response = result.getContent();
-        assertAll(
-                () -> assertThat(response).hasSize(3),
-                () -> assertThat(response.get(0).getPostId()).isEqualTo(postC.getId()),
-                () -> assertThat(response.get(1).getPostId()).isEqualTo(postB.getId()),
-                () -> assertThat(response.get(2).getPostId()).isEqualTo(postA.getId()),
-                () -> assertThat(result.isFirst()).isTrue(),
-                () -> assertThat(result.isLast()).isTrue(),
-                () -> assertThat(result.isHasNext()).isFalse(),
-                () -> assertThat(result.getCurrentPage()).isEqualTo(0),
-                () -> assertThat(result.getCurrentElementSize()).isEqualTo(5),
-                () -> assertThat(result.getTotalPage()).isEqualTo(1),
-                () -> assertThat(result.getTotalElementSize()).isEqualTo(3)
-        );
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
@@ -44,10 +44,10 @@ class PostServiceTest extends IntegrationTest {
                 () -> assertThat(result.isFirst()).isTrue(),
                 () -> assertThat(result.isLast()).isTrue(),
                 () -> assertThat(result.isHasNext()).isFalse(),
-                () -> assertThat(result.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(result.getCurrentPageIndex()).isEqualTo(0),
                 () -> assertThat(result.getCurrentElementSize()).isEqualTo(5),
                 () -> assertThat(result.getTotalPage()).isEqualTo(1),
-                () -> assertThat(result.getTotalElementSize()).isEqualTo(3)
+                () -> assertThat(result.getTotalElementCount()).isEqualTo(3)
         );
     }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.List;
 import org.dinosaur.foodbowl.IntegrationTest;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.post.dto.response.PostThumbnailResponse;
@@ -51,5 +52,31 @@ class PostServiceTest extends IntegrationTest {
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
+    }
+
+    @Test
+    @DisplayName("최근 게시글 썸네일 목록을 조회한다.")
+    void findLatestThumbnails() {
+        Post postA = postTestSupport.postBuilder().build();
+        Post postB = postTestSupport.postBuilder().build();
+        Post postC = postTestSupport.postBuilder().build();
+
+        Pageable pageable = PageRequest.of(0, 5, Sort.by(Direction.DESC, "id"));
+        PageResponse<PostThumbnailResponse> result = postService.findLatestThumbnails(pageable);
+
+        List<PostThumbnailResponse> response = result.getContent();
+        assertAll(
+                () -> assertThat(response).hasSize(3),
+                () -> assertThat(response.get(0).getPostId()).isEqualTo(postC.getId()),
+                () -> assertThat(response.get(1).getPostId()).isEqualTo(postB.getId()),
+                () -> assertThat(response.get(2).getPostId()).isEqualTo(postA.getId()),
+                () -> assertThat(result.isFirst()).isTrue(),
+                () -> assertThat(result.isLast()).isTrue(),
+                () -> assertThat(result.isHasNext()).isFalse(),
+                () -> assertThat(result.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(result.getCurrentElementSize()).isEqualTo(5),
+                () -> assertThat(result.getTotalPage()).isEqualTo(1),
+                () -> assertThat(result.getTotalElementSize()).isEqualTo(3)
+        );
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/post/docs/PostControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/post/docs/PostControllerDocsTest.java
@@ -37,7 +37,7 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.request.ParameterDescriptor;
 
 @WebMvcTest(PostController.class)
-public class PostControllerDocsTest extends MockApiTest {
+class PostControllerDocsTest extends MockApiTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
@@ -79,7 +79,7 @@ public class PostControllerDocsTest extends MockApiTest {
                 fieldWithPath("last").description("마지막 페이지 여부"),
                 fieldWithPath("hasNext").description("다음 페이지 존재 여부"),
                 fieldWithPath("currentPage").description("현재 페이지 인덱스"),
-                fieldWithPath("currentElementSize").description("현재 데이터 개수"),
+                fieldWithPath("currentElementSize").description("현재 페이징 크기"),
                 fieldWithPath("totalPage").description("전체 페이지 숫자"),
                 fieldWithPath("totalElementSize").description("전체 데이터 개수"),
         };
@@ -102,6 +102,66 @@ public class PostControllerDocsTest extends MockApiTest {
                 .andExpect(jsonPath("$.totalPage").value(1))
                 .andExpect(jsonPath("$.totalElementSize").value(1))
                 .andDo(document("api-v1-posts-thumbnails",
+                        requestHeaders(
+                                headerDescriptors
+                        ),
+                        queryParameters(
+                                parameterDescriptors
+                        ),
+                        responseFields(
+                                responseFieldDescriptors
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("최근 게시글 썸네일 목록 조회를 문서화한다.")
+    void findLatestThumbnails() throws Exception {
+        PageResponse<PostThumbnailResponse> response = new PageResponse<>(
+                List.of(
+                        new PostThumbnailResponse(1L, "path", LocalDateTime.now()),
+                        new PostThumbnailResponse(2L, "path", LocalDateTime.now())
+                ),
+                true,
+                true,
+                false,
+                0,
+                5,
+                1,
+                2
+        );
+        given(postService.findLatestThumbnails(any(Pageable.class))).willReturn(response);
+
+        var headerDescriptors = new HeaderDescriptor[]{
+                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
+        };
+
+        var parameterDescriptors = new ParameterDescriptor[]{
+                parameterWithName("page").optional().description("최근 게시글 썸네일 목록 페이지 숫자 (입력하지 않으면, default = 0)"),
+                parameterWithName("size").optional().description("최근 게시글 썸네일 목록 데이터 개수 (입력하지 않으면, default = 18)")
+        };
+
+        var responseFieldDescriptors = new FieldDescriptor[]{
+                fieldWithPath("content").description("최근 게시글 썸네일 정보 목록"),
+                fieldWithPath("content[].postId").description("게시글 ID"),
+                fieldWithPath("content[].thumbnailPath").description("썸네일 경로"),
+                fieldWithPath("content[].createdAt").description("게시글 작성 시간"),
+                fieldWithPath("first").description("첫 페이지 여부"),
+                fieldWithPath("last").description("마지막 페이지 여부"),
+                fieldWithPath("hasNext").description("다음 페이지 존재 여부"),
+                fieldWithPath("currentPage").description("현재 페이지 인덱스"),
+                fieldWithPath("currentElementSize").description("현재 페이징 크기"),
+                fieldWithPath("totalPage").description("전체 페이지 숫자"),
+                fieldWithPath("totalElementSize").description("전체 데이터 개수"),
+        };
+
+        mockMvc.perform(get("/api/v1/posts/thumbnails/latest")
+                        .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                        .queryParam("page", String.valueOf(0))
+                        .queryParam("size", String.valueOf(5)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("api-v1-posts-thumbnails-latest",
                         requestHeaders(
                                 headerDescriptors
                         ),

--- a/src/test/java/org/dinosaur/foodbowl/domain/post/docs/PostControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/post/docs/PostControllerDocsTest.java
@@ -78,10 +78,10 @@ class PostControllerDocsTest extends MockApiTest {
                 fieldWithPath("first").description("첫 페이지 여부"),
                 fieldWithPath("last").description("마지막 페이지 여부"),
                 fieldWithPath("hasNext").description("다음 페이지 존재 여부"),
-                fieldWithPath("currentPage").description("현재 페이지 인덱스"),
+                fieldWithPath("currentPageIndex").description("현재 페이지 인덱스"),
                 fieldWithPath("currentElementSize").description("현재 페이징 크기"),
                 fieldWithPath("totalPage").description("전체 페이지 숫자"),
-                fieldWithPath("totalElementSize").description("전체 데이터 개수"),
+                fieldWithPath("totalElementCount").description("전체 데이터 개수"),
         };
 
         mockMvc.perform(get("/api/v1/posts/thumbnails")
@@ -97,10 +97,10 @@ class PostControllerDocsTest extends MockApiTest {
                 .andExpect(jsonPath("$.first").value(true))
                 .andExpect(jsonPath("$.last").value(true))
                 .andExpect(jsonPath("$.hasNext").value(false))
-                .andExpect(jsonPath("$.currentPage").value(0))
+                .andExpect(jsonPath("$.currentPageIndex").value(0))
                 .andExpect(jsonPath("$.currentElementSize").value(1))
                 .andExpect(jsonPath("$.totalPage").value(1))
-                .andExpect(jsonPath("$.totalElementSize").value(1))
+                .andExpect(jsonPath("$.totalElementCount").value(1))
                 .andDo(document("api-v1-posts-thumbnails",
                         requestHeaders(
                                 headerDescriptors
@@ -149,10 +149,10 @@ class PostControllerDocsTest extends MockApiTest {
                 fieldWithPath("first").description("첫 페이지 여부"),
                 fieldWithPath("last").description("마지막 페이지 여부"),
                 fieldWithPath("hasNext").description("다음 페이지 존재 여부"),
-                fieldWithPath("currentPage").description("현재 페이지 인덱스"),
+                fieldWithPath("currentPageIndex").description("현재 페이지 인덱스"),
                 fieldWithPath("currentElementSize").description("현재 페이징 크기"),
                 fieldWithPath("totalPage").description("전체 페이지 숫자"),
-                fieldWithPath("totalElementSize").description("전체 데이터 개수"),
+                fieldWithPath("totalElementCount").description("전체 데이터 개수"),
         };
 
         mockMvc.perform(get("/api/v1/posts/thumbnails/latest")

--- a/src/test/java/org/dinosaur/foodbowl/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/post/repository/PostRepositoryTest.java
@@ -72,4 +72,42 @@ class PostRepositoryTest extends RepositoryTest {
             );
         }
     }
+
+    @Nested
+    @DisplayName("findAll - pageable 메서드는 ")
+    class FindAllPageable {
+
+        @Test
+        @DisplayName("전체 게시글을 조회한다.")
+        void findAllPageable() {
+            Post oldPost = postTestSupport.postBuilder().build();
+            Post newPost = postTestSupport.postBuilder().build();
+
+            Pageable pageable = PageRequest.of(0, 5, Sort.by(Direction.DESC, "id"));
+            Page<Post> result = postRepository.findAll(pageable);
+
+            List<Post> posts = result.getContent();
+            assertAll(
+                    () -> assertThat(posts).hasSize(2),
+                    () -> assertThat(posts.get(0)).isEqualTo(newPost),
+                    () -> assertThat(posts.get(1)).isEqualTo(oldPost)
+            );
+        }
+
+        @Test
+        @DisplayName("페이징 설정만큼 게시글을 조회한다.")
+        void findAllPageableByPaging() {
+            postTestSupport.postBuilder().build();
+            Post newPost = postTestSupport.postBuilder().build();
+
+            Pageable pageable = PageRequest.of(0, 1, Sort.by(Direction.DESC, "id"));
+            Page<Post> result = postRepository.findAll(pageable);
+
+            List<Post> posts = result.getContent();
+            assertAll(
+                    () -> assertThat(posts).hasSize(1),
+                    () -> assertThat(posts.get(0)).isEqualTo(newPost)
+            );
+        }
+    }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/api/StoreControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/api/StoreControllerTest.java
@@ -44,6 +44,81 @@ class StoreControllerTest extends MockApiTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
+    @Test
+    @DisplayName("가게를 생성한다.")
+    void createSuccess() throws Exception {
+        StoreRequest storeRequest = new StoreRequest(
+                "신천직화집",
+                "서울시 송파구 올림픽로 473",
+                "서울시",
+                "송파구",
+                "신천동",
+                "올림픽로",
+                "N",
+                "473",
+                "14층 1400호",
+                "루터회관",
+                "12345",
+                BigDecimal.valueOf(127.3435356),
+                BigDecimal.valueOf(37.12314545)
+        );
+        StoreResponse storeResponse = createResponse();
+        given(storeService.save(any(StoreRequest.class))).willReturn(storeResponse);
+
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/stores")
+                .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                .content(objectMapper.writeValueAsString(storeRequest))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8));
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(storeResponse.getId()))
+                .andExpect(jsonPath("$.storeName").value(storeResponse.getStoreName()))
+                .andExpect(jsonPath("$.addressName").value(storeResponse.getAddressName()))
+                .andExpect(jsonPath("$.region1depthName").value(storeResponse.getRegion1depthName()))
+                .andExpect(jsonPath("$.region2depthName").value(storeResponse.getRegion2depthName()))
+                .andExpect(jsonPath("$.region3depthName").value(storeResponse.getRegion3depthName()))
+                .andExpect(jsonPath("$.roadName").value(storeResponse.getRoadName()))
+                .andExpect(jsonPath("$.undergroundYN").value(storeResponse.getUndergroundYN()))
+                .andExpect(jsonPath("$.mainBuildingNo").value(storeResponse.getMainBuildingNo()))
+                .andExpect(jsonPath("$.subBuildingNo").value(storeResponse.getSubBuildingNo()))
+                .andExpect(jsonPath("$.buildingName").value(storeResponse.getBuildingName()))
+                .andExpect(jsonPath("$.zoneNo").value(storeResponse.getZoneNo()))
+                .andExpect(jsonPath("$.x").value(storeResponse.getX()))
+                .andExpect(jsonPath("$.y").value(storeResponse.getY()));
+    }
+
+    private void execute(StoreRequest storeRequest, String token) throws Exception {
+        mockMvc.perform(post("/api/v1/stores")
+                        .header("Authorization", "Bearer " + token)
+                        .content(objectMapper.writeValueAsString(storeRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    private StoreResponse createResponse() {
+        return new StoreResponse(
+                1L,
+                "신천직화집",
+                "서울시 송파구 올림픽로 473",
+                "서울시",
+                "송파구",
+                "신천동",
+                "올림픽로",
+                "N",
+                "473",
+                "14층 1400호",
+                "루터회관",
+                "12345",
+                BigDecimal.valueOf(127.3435356),
+                BigDecimal.valueOf(37.12314545),
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
     @Nested
     @DisplayName("가게를 조회할 때 ")
     class FindStore {
@@ -88,51 +163,6 @@ class StoreControllerTest extends MockApiTest {
                     .andExpect(status().isNotFound())
                     .andDo(print());
         }
-    }
-
-
-    @Test
-    @DisplayName("가게를 생성한다.")
-    void createSuccess() throws Exception {
-        StoreRequest storeRequest = new StoreRequest(
-                "신천직화집",
-                "서울시 송파구 올림픽로 473",
-                "서울시",
-                "송파구",
-                "신천동",
-                "올림픽로",
-                "N",
-                "473",
-                "14층 1400호",
-                "루터회관",
-                "12345",
-                BigDecimal.valueOf(127.3435356),
-                BigDecimal.valueOf(37.12314545)
-        );
-        StoreResponse storeResponse = createResponse();
-        given(storeService.save(any(StoreRequest.class))).willReturn(storeResponse);
-
-        ResultActions resultActions = mockMvc.perform(post("/api/v1/stores")
-                .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
-                .content(objectMapper.writeValueAsString(storeRequest))
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding(StandardCharsets.UTF_8));
-
-        resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(storeResponse.getId()))
-                .andExpect(jsonPath("$.storeName").value(storeResponse.getStoreName()))
-                .andExpect(jsonPath("$.addressName").value(storeResponse.getAddressName()))
-                .andExpect(jsonPath("$.region1depthName").value(storeResponse.getRegion1depthName()))
-                .andExpect(jsonPath("$.region2depthName").value(storeResponse.getRegion2depthName()))
-                .andExpect(jsonPath("$.region3depthName").value(storeResponse.getRegion3depthName()))
-                .andExpect(jsonPath("$.roadName").value(storeResponse.getRoadName()))
-                .andExpect(jsonPath("$.undergroundYN").value(storeResponse.getUndergroundYN()))
-                .andExpect(jsonPath("$.mainBuildingNo").value(storeResponse.getMainBuildingNo()))
-                .andExpect(jsonPath("$.subBuildingNo").value(storeResponse.getSubBuildingNo()))
-                .andExpect(jsonPath("$.buildingName").value(storeResponse.getBuildingName()))
-                .andExpect(jsonPath("$.zoneNo").value(storeResponse.getZoneNo()))
-                .andExpect(jsonPath("$.x").value(storeResponse.getX()))
-                .andExpect(jsonPath("$.y").value(storeResponse.getY()));
     }
 
     @Nested
@@ -359,36 +389,5 @@ class StoreControllerTest extends MockApiTest {
 
             execute(storeRequest, accessToken);
         }
-    }
-
-    private void execute(StoreRequest storeRequest, String token) throws Exception {
-        mockMvc.perform(post("/api/v1/stores")
-                        .header("Authorization", "Bearer " + token)
-                        .content(objectMapper.writeValueAsString(storeRequest))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .characterEncoding(StandardCharsets.UTF_8))
-                .andDo(print())
-                .andExpect(status().isBadRequest());
-    }
-
-    private StoreResponse createResponse() {
-        return new StoreResponse(
-                1L,
-                "신천직화집",
-                "서울시 송파구 올림픽로 473",
-                "서울시",
-                "송파구",
-                "신천동",
-                "올림픽로",
-                "N",
-                "473",
-                "14층 1400호",
-                "루터회관",
-                "12345",
-                BigDecimal.valueOf(127.3435356),
-                BigDecimal.valueOf(37.12314545),
-                LocalDateTime.now(),
-                LocalDateTime.now()
-        );
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -37,6 +37,41 @@ class StoreServiceTest extends IntegrationTest {
         assertThat(storeResponses).hasSize(initialSize + 2);
     }
 
+    private Address createAddress() {
+        return Address.builder()
+                .addressName("서울시 송파구 신천동 1542")
+                .region1depthName("서울시")
+                .region2depthName("송파구")
+                .region3depthName("신천동")
+                .roadName("연금공단로")
+                .undergroundYN("N")
+                .mainBuildingNo("123")
+                .subBuildingNo("1층 101호")
+                .buildingName("국민연금공단 송파지점")
+                .zoneNo("12345")
+                .x(BigDecimal.valueOf(127.3435356))
+                .y(BigDecimal.valueOf(37.12314545))
+                .build();
+    }
+
+    private StoreRequest createRequest(String storeName, String addressName) {
+        return new StoreRequest(
+                storeName,
+                addressName,
+                "서울시",
+                "송파구",
+                "신천동",
+                "연금공단로",
+                "N",
+                "123",
+                "1층 101호",
+                "국민연금공단 송파지점",
+                "12345",
+                BigDecimal.valueOf(127.3435356),
+                BigDecimal.valueOf(37.12314545)
+        );
+    }
+
     @Nested
     @DisplayName("save 메서드는 ")
     class Save {
@@ -128,40 +163,5 @@ class StoreServiceTest extends IntegrationTest {
                     .isInstanceOf(FoodbowlException.class)
                     .hasMessageContaining(STORE_NOT_FOUND.getMessage());
         }
-    }
-
-    private Address createAddress() {
-        return Address.builder()
-                .addressName("서울시 송파구 신천동 1542")
-                .region1depthName("서울시")
-                .region2depthName("송파구")
-                .region3depthName("신천동")
-                .roadName("연금공단로")
-                .undergroundYN("N")
-                .mainBuildingNo("123")
-                .subBuildingNo("1층 101호")
-                .buildingName("국민연금공단 송파지점")
-                .zoneNo("12345")
-                .x(BigDecimal.valueOf(127.3435356))
-                .y(BigDecimal.valueOf(37.12314545))
-                .build();
-    }
-
-    private StoreRequest createRequest(String storeName, String addressName) {
-        return new StoreRequest(
-                storeName,
-                addressName,
-                "서울시",
-                "송파구",
-                "신천동",
-                "연금공단로",
-                "N",
-                "123",
-                "1층 101호",
-                "국민연금공단 송파지점",
-                "12345",
-                BigDecimal.valueOf(127.3435356),
-                BigDecimal.valueOf(37.12314545)
-        );
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/repository/StoreRepositoryTest.java
@@ -23,6 +23,31 @@ class StoreRepositoryTest extends RepositoryTest {
         assertThat(storeRepository.findAll()).hasSizeGreaterThanOrEqualTo(0);
     }
 
+    private Store createStore() {
+        Address address = createAddress();
+        return Store.builder()
+                .address(address)
+                .storeName("작살치킨")
+                .build();
+    }
+
+    private Address createAddress() {
+        return Address.builder()
+                .addressName("서울시 송파구 방이동 방이로 1234")
+                .region1depthName("서울시")
+                .region2depthName("송파구")
+                .region3depthName("방이동")
+                .roadName("방이로")
+                .mainBuildingNo("1234")
+                .subBuildingNo("14층 1400호")
+                .undergroundYN("N")
+                .buildingName("작살치킨 빌딩")
+                .zoneNo("12345")
+                .x(BigDecimal.valueOf(127.3437575))
+                .y(BigDecimal.valueOf(37.12567))
+                .build();
+    }
+
     @Nested
     @DisplayName("findById 메서드는")
     class FindById {
@@ -96,30 +121,5 @@ class StoreRepositoryTest extends RepositoryTest {
 
             assertThat(findStore).isEmpty();
         }
-    }
-
-    private Store createStore() {
-        Address address = createAddress();
-        return Store.builder()
-                .address(address)
-                .storeName("작살치킨")
-                .build();
-    }
-
-    private Address createAddress() {
-        return Address.builder()
-                .addressName("서울시 송파구 방이동 방이로 1234")
-                .region1depthName("서울시")
-                .region2depthName("송파구")
-                .region3depthName("방이동")
-                .roadName("방이로")
-                .mainBuildingNo("1234")
-                .subBuildingNo("14층 1400호")
-                .undergroundYN("N")
-                .buildingName("작살치킨 빌딩")
-                .zoneNo("12345")
-                .x(BigDecimal.valueOf(127.3437575))
-                .y(BigDecimal.valueOf(37.12567))
-                .build();
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #47

## 📝 작업 요약

검색 탭의 게시글 썸네일 목록을 조회하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 검색 탭 게시글을 보여주는 초기 알고리즘은 최신순으로 보여주는 것으로 정하였습니다.
- 추후에 게시글이 쌓인다면 검색 탭 게시글을 보여주기 위한 알고리즘을 고민해봐도 좋을 것 같습니다.

## 🌟 리뷰 요구 사항

> 10분