### PR TITLE
Feature/#37 댓글 목록 조회 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/comment/comment.adoc
+++ b/src/docs/asciidoc/comment/comment.adoc
@@ -89,20 +89,20 @@ include::{snippets}/api-v1-comments-delete/http-response.adoc[]
 
 === Request
 
-include::{snippets}/api-v1-comments-findAll/http-request.adoc[]
+include::{snippets}/api-v1-comments-findAllInPost/http-request.adoc[]
 
 === Request Headers
 
-include::{snippets}/api-v1-comments-findAll/request-headers.adoc[]
+include::{snippets}/api-v1-comments-findAllInPost/request-headers.adoc[]
 
 === Query Parameters
 
-include::{snippets}/api-v1-comments-findAll/query-parameters.adoc[]
+include::{snippets}/api-v1-comments-findAllInPost/query-parameters.adoc[]
 
 === Response
 
-include::{snippets}/api-v1-comments-findAll/http-response.adoc[]
+include::{snippets}/api-v1-comments-findAllInPost/http-response.adoc[]
 
 === Response Fields
 
-include::{snippets}/api-v1-comments-findAll/response-fields.adoc[]
+include::{snippets}/api-v1-comments-findAllInPost/response-fields.adoc[]

--- a/src/docs/asciidoc/comment/comment.adoc
+++ b/src/docs/asciidoc/comment/comment.adoc
@@ -89,20 +89,20 @@ include::{snippets}/api-v1-comments-delete/http-response.adoc[]
 
 === Request
 
-include::{snippets}/api-v1-comments-findAllInPost/http-request.adoc[]
+include::{snippets}/api-v1-comments-find-all-in-post/http-request.adoc[]
 
 === Request Headers
 
-include::{snippets}/api-v1-comments-findAllInPost/request-headers.adoc[]
+include::{snippets}/api-v1-comments-find-all-in-post/request-headers.adoc[]
 
 === Query Parameters
 
-include::{snippets}/api-v1-comments-findAllInPost/query-parameters.adoc[]
+include::{snippets}/api-v1-comments-find-all-in-post/query-parameters.adoc[]
 
 === Response
 
-include::{snippets}/api-v1-comments-findAllInPost/http-response.adoc[]
+include::{snippets}/api-v1-comments-find-all-in-post/http-response.adoc[]
 
 === Response Fields
 
-include::{snippets}/api-v1-comments-findAllInPost/response-fields.adoc[]
+include::{snippets}/api-v1-comments-find-all-in-post/response-fields.adoc[]

--- a/src/docs/asciidoc/comment/comment.adoc
+++ b/src/docs/asciidoc/comment/comment.adoc
@@ -82,3 +82,27 @@ include::{snippets}/api-v1-comments-delete/path-parameters.adoc[]
 === Response
 
 include::{snippets}/api-v1-comments-delete/http-response.adoc[]
+
+== *게시글 댓글 조회* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-comments-findAll/http-request.adoc[]
+
+=== Request Headers
+
+include::{snippets}/api-v1-comments-findAll/request-headers.adoc[]
+
+=== Query Parameters
+
+include::{snippets}/api-v1-comments-findAll/query-parameters.adoc[]
+
+=== Response
+
+include::{snippets}/api-v1-comments-findAll/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/api-v1-comments-findAll/response-fields.adoc[]

--- a/src/main/java/org/dinosaur/foodbowl/domain/comment/api/CommentController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/comment/api/CommentController.java
@@ -6,16 +6,23 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.comment.application.CommentService;
 import org.dinosaur.foodbowl.domain.comment.dto.CommentCreateRequest;
+import org.dinosaur.foodbowl.domain.comment.dto.CommentResponse;
 import org.dinosaur.foodbowl.domain.comment.dto.CommentUpdateRequest;
+import org.dinosaur.foodbowl.global.dto.PageResponse;
 import org.dinosaur.foodbowl.global.resolver.MemberId;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -33,6 +40,15 @@ public class CommentController {
     ) {
         commentService.save(memberId, commentCreateRequest);
         return ResponseEntity.created(URI.create("/api/v1/posts/" + commentCreateRequest.getPostId())).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<CommentResponse>> findAllComments(
+            @RequestParam @Positive(message = "게시글 ID는 양수만 가능합니다.") Long postId,
+            @PageableDefault(page = 0, size = 18, sort = "createdAt", direction = Direction.ASC) Pageable pageable
+    ) {
+        PageResponse<CommentResponse> commentResponses = commentService.findAllCommentsInPost(postId, pageable);
+        return ResponseEntity.ok(commentResponses);
     }
 
     @PutMapping("/{commentId}")

--- a/src/main/java/org/dinosaur/foodbowl/domain/comment/application/CommentService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/comment/application/CommentService.java
@@ -7,6 +7,7 @@ import static org.dinosaur.foodbowl.global.exception.ErrorStatus.POST_NOT_FOUND;
 
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.comment.dto.CommentCreateRequest;
+import org.dinosaur.foodbowl.domain.comment.dto.CommentResponse;
 import org.dinosaur.foodbowl.domain.comment.dto.CommentUpdateRequest;
 import org.dinosaur.foodbowl.domain.comment.entity.Comment;
 import org.dinosaur.foodbowl.domain.comment.repository.CommentRepository;
@@ -14,7 +15,10 @@ import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.dinosaur.foodbowl.domain.post.repository.PostRepository;
+import org.dinosaur.foodbowl.global.dto.PageResponse;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +46,15 @@ public class CommentService {
                 .build();
         Comment savedComment = commentRepository.save(comment);
         return savedComment.getId();
+    }
+
+    public PageResponse<CommentResponse> findAllCommentsInPost(Long postId, Pageable pageable) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new FoodbowlException(POST_NOT_FOUND));
+
+        Page<CommentResponse> commentResponses = commentRepository.findAllByPost(post, pageable)
+                .map(comment -> CommentResponse.from(comment, post));
+        return PageResponse.from(commentResponses);
     }
 
     @Transactional

--- a/src/main/java/org/dinosaur/foodbowl/domain/comment/application/CommentService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/comment/application/CommentService.java
@@ -53,7 +53,7 @@ public class CommentService {
                 .orElseThrow(() -> new FoodbowlException(POST_NOT_FOUND));
 
         Page<CommentResponse> commentResponses = commentRepository.findAllByPost(post, pageable)
-                .map(comment -> CommentResponse.from(comment, post));
+                .map(comment -> CommentResponse.of(comment, post));
         return PageResponse.from(commentResponses);
     }
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/comment/dto/CommentResponse.java
@@ -22,7 +22,7 @@ public class CommentResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static CommentResponse from(Comment comment, Post post) {
+    public static CommentResponse of(Comment comment, Post post) {
         return new CommentResponse(
                 comment.getId(),
                 post.getId(),

--- a/src/main/java/org/dinosaur/foodbowl/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/comment/dto/CommentResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.comment.entity.Comment;
+import org.dinosaur.foodbowl.domain.post.entity.Post;
 
 @Getter
 @AllArgsConstructor
@@ -14,14 +15,20 @@ public class CommentResponse {
 
     private Long commentId;
     private Long postId;
+    private Long memberId;
+    private String memberNickname;
+    private String memberThumbnailPath;
     private String message;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static CommentResponse from(Comment comment) {
+    public static CommentResponse from(Comment comment, Post post) {
         return new CommentResponse(
                 comment.getId(),
-                comment.getPost().getId(),
+                post.getId(),
+                comment.getMember().getId(),
+                comment.getMember().getNickname(),
+                comment.getMember().getThumbnail().getPath(),
                 comment.getMessage(),
                 comment.getCreatedAt(),
                 comment.getUpdatedAt()

--- a/src/main/java/org/dinosaur/foodbowl/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/comment/repository/CommentRepository.java
@@ -5,6 +5,9 @@ import java.util.Optional;
 import org.dinosaur.foodbowl.domain.comment.entity.Comment;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.Repository;
 
 public interface CommentRepository extends Repository<Comment, Long> {
@@ -14,6 +17,9 @@ public interface CommentRepository extends Repository<Comment, Long> {
     List<Comment> findAllByMember(Member member);
 
     List<Comment> findAllByPost(Post post);
+
+    @EntityGraph(attributePaths = {"member", "member.thumbnail"})
+    Page<Comment> findAllByPost(Post post, Pageable pageable);
 
     Comment save(Comment comment);
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/comment/application/CommentServiceTest.java
@@ -16,6 +16,7 @@ import org.dinosaur.foodbowl.domain.comment.dto.CommentUpdateRequest;
 import org.dinosaur.foodbowl.domain.comment.entity.Comment;
 import org.dinosaur.foodbowl.domain.comment.repository.CommentRepository;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
+import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.dinosaur.foodbowl.global.dto.PageResponse;
 import org.dinosaur.foodbowl.global.exception.FoodbowlException;
@@ -205,8 +206,10 @@ class CommentServiceTest extends IntegrationTest {
         @Test
         @DisplayName("작성된 순서대로 조회한다.")
         void findAllCommentsInPostSuccess() throws InterruptedException {
-            Member gray = memberTestSupport.memberBuilder().nickname("gray").build();
-            Member hoy = memberTestSupport.memberBuilder().nickname("hoy").build();
+            Thumbnail grayThumbnail = thumbnailTestSupport.builder().build();
+            Thumbnail hoyThumbnail = thumbnailTestSupport.builder().build();
+            Member gray = memberTestSupport.memberBuilder().nickname("gray").thumbnail(grayThumbnail).build();
+            Member hoy = memberTestSupport.memberBuilder().nickname("hoy").thumbnail(hoyThumbnail).build();
             Post post = postTestSupport.postBuilder().build();
             commentTestSupport.builder().post(post).member(gray).message("그레이 댓글").build();
             Thread.sleep(1000);

--- a/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
@@ -168,14 +168,12 @@ public class CommentControllerDocsTest extends MockApiTest {
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
                         ),
-                        pathParameters(
+                        queryParameters(
+                                parameterWithName("postId").description("댓글을 조회하는 게시글 ID"),
                                 parameterWithName("page").optional()
                                         .description("게시글에 존재하는 댓글 페이지 숫자 (입력하지 않으면, default = 0)"),
                                 parameterWithName("size").optional()
                                         .description("게시글에 존재하는 댓글 데이터 개수 (입력하지 않으면, default = 18)")
-                        ),
-                        queryParameters(
-                                parameterWithName("postId").description("댓글을 조회하는 게시글 ID")
                         ),
                         responseFields(
                                 responseFieldDescriptors

--- a/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
@@ -8,31 +8,40 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.comment.api.CommentController;
 import org.dinosaur.foodbowl.domain.comment.application.CommentService;
 import org.dinosaur.foodbowl.domain.comment.dto.CommentCreateRequest;
+import org.dinosaur.foodbowl.domain.comment.dto.CommentResponse;
 import org.dinosaur.foodbowl.domain.comment.dto.CommentUpdateRequest;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.global.dto.PageResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 @WebMvcTest(controllers = CommentController.class)
@@ -113,6 +122,64 @@ public class CommentControllerDocsTest extends MockApiTest {
                                 parameterWithName("commentId").description("삭제할 댓글 ID")
                         )
                 ));
+    }
 
+    @Test
+    @DisplayName("게시글에 있는 모든 댓글 조회를 문서화한다.")
+    void findAllCommentsInPost() throws Exception {
+        PageResponse<CommentResponse> commentResponses = new PageResponse<>(
+                List.of(new CommentResponse(1L, 1L, 1L, "gray",
+                        "http://image.url/gray.jpg", "그레이 댓글입니다.", LocalDateTime.now(), LocalDateTime.now())),
+                true,
+                true,
+                false,
+                1,
+                1,
+                1,
+                1
+        );
+        given(commentService.findAllCommentsInPost(anyLong(), any(Pageable.class))).willReturn(commentResponses);
+
+        var responseFieldDescriptors = new FieldDescriptor[]{
+                fieldWithPath("content").description("게시글 댓글 목록"),
+                fieldWithPath("content[].commentId").description("댓글 ID"),
+                fieldWithPath("content[].postId").description("게시글 ID"),
+                fieldWithPath("content[].memberId").description("댓글 작성 회원 ID"),
+                fieldWithPath("content[].memberNickname").description("댓글 작성 회원 닉네임"),
+                fieldWithPath("content[].memberThumbnailPath").description("댓글 작성 회원 프로필 썸네일 Path"),
+                fieldWithPath("content[].message").description("댓글 내용"),
+                fieldWithPath("content[].createdAt").description("댓글 작성 시간"),
+                fieldWithPath("content[].updatedAt").description("댓글 최종 수정 시간"),
+                fieldWithPath("first").description("첫 페이지 여부"),
+                fieldWithPath("last").description("마지막 페이지 여부"),
+                fieldWithPath("hasNext").description("다음 페이지 존재 여부"),
+                fieldWithPath("currentPageIndex").description("현재 페이지 인덱스"),
+                fieldWithPath("currentElementSize").description("현재 데이터 개수"),
+                fieldWithPath("totalPage").description("전체 페이지 숫자"),
+                fieldWithPath("totalElementCount").description("전체 데이터 개수"),
+        };
+
+        mockMvc.perform(get("/api/v1/comments")
+                        .queryParam("postId", "1")
+                        .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
+                        .characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isOk())
+                .andDo(document("api-v1-comments-findAll",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("page").optional()
+                                        .description("게시글에 존재하는 댓글 페이지 숫자 (입력하지 않으면, default = 0)"),
+                                parameterWithName("size").optional()
+                                        .description("게시글에 존재하는 댓글 데이터 개수 (입력하지 않으면, default = 18)")
+                        ),
+                        queryParameters(
+                                parameterWithName("postId").description("댓글을 조회하는 게시글 ID")
+                        ),
+                        responseFields(
+                                responseFieldDescriptors
+                        )
+                ));
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
@@ -164,7 +164,7 @@ public class CommentControllerDocsTest extends MockApiTest {
                         .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
                         .characterEncoding(StandardCharsets.UTF_8))
                 .andExpect(status().isOk())
-                .andDo(document("api-v1-comments-findAll",
+                .andDo(document("api-v1-comments-findAllInPost",
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
                         ),

--- a/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/comment/docs/CommentControllerDocsTest.java
@@ -164,7 +164,7 @@ public class CommentControllerDocsTest extends MockApiTest {
                         .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원))
                         .characterEncoding(StandardCharsets.UTF_8))
                 .andExpect(status().isOk())
-                .andDo(document("api-v1-comments-findAllInPost",
+                .andDo(document("api-v1-comments-find-all-in-post",
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
                         ),

--- a/src/test/java/org/dinosaur/foodbowl/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/comment/repository/CommentRepositoryTest.java
@@ -10,6 +10,10 @@ import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 
 class CommentRepositoryTest extends RepositoryTest {
 
@@ -69,5 +73,25 @@ class CommentRepositoryTest extends RepositoryTest {
         commentRepository.deleteAllByPost(post);
 
         assertThat(commentRepository.findAllByPost(post)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("엔티티 그래프, 멤버, 페이징 정보를 바탕으로 댓글을 조회한다.")
+    void findAllByPost() {
+        Member gray = memberTestSupport.memberBuilder().nickname("gray").build();
+        Member dazzle = memberTestSupport.memberBuilder().nickname("dazzle").build();
+        Post post = postTestSupport.postBuilder().build();
+        commentTestSupport.builder().post(post).member(gray).message("그레이 댓글").build();
+        commentTestSupport.builder().post(post).member(dazzle).message("다즐 댓글").build();
+
+        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(Direction.ASC, "createdAt"));
+        Page<Comment> findComment = commentRepository.findAllByPost(post, pageRequest);
+
+        assertAll(
+                () -> assertThat(findComment.getContent()).hasSize(1),
+                () -> assertThat(findComment.hasNext()).isTrue(),
+                () -> assertThat(findComment.getTotalElements()).isEqualTo(2),
+                () -> assertThat(findComment.getTotalPages()).isEqualTo(2)
+        );
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/testsupport/MemberTestSupport.java
+++ b/src/test/java/org/dinosaur/foodbowl/testsupport/MemberTestSupport.java
@@ -18,7 +18,6 @@ public class MemberTestSupport {
 
     private final MemberRepository memberRepository;
     private final MemberRoleRepository memberRoleRepository;
-    private final ThumbnailTestSupport thumbnailTestSupport;
 
     public MemberBuilder memberBuilder() {
         return new MemberBuilder();
@@ -82,7 +81,7 @@ public class MemberTestSupport {
         public Member build() {
             return memberRepository.save(
                     Member.builder()
-                            .thumbnail(thumbnail == null ? thumbnailTestSupport.builder().build() : thumbnail)
+                            .thumbnail(thumbnail)
                             .socialType(socialType == null ? SocialType.APPLE : socialType)
                             .socialId(socialId == null ? "a1b2c3d4" : socialId)
                             .email(email)

--- a/src/test/java/org/dinosaur/foodbowl/testsupport/MemberTestSupport.java
+++ b/src/test/java/org/dinosaur/foodbowl/testsupport/MemberTestSupport.java
@@ -18,6 +18,7 @@ public class MemberTestSupport {
 
     private final MemberRepository memberRepository;
     private final MemberRoleRepository memberRoleRepository;
+    private final ThumbnailTestSupport thumbnailTestSupport;
 
     public MemberBuilder memberBuilder() {
         return new MemberBuilder();
@@ -81,7 +82,7 @@ public class MemberTestSupport {
         public Member build() {
             return memberRepository.save(
                     Member.builder()
-                            .thumbnail(thumbnail)
+                            .thumbnail(thumbnail == null ? thumbnailTestSupport.builder().build() : thumbnail)
                             .socialType(socialType == null ? SocialType.APPLE : socialType)
                             .socialId(socialId == null ? "a1b2c3d4" : socialId)
                             .email(email)


### PR DESCRIPTION
## 🔥 연관 이슈

close: #37 

## 📝 작업 요약

게시글에 존재하는 댓글을 조회하는 기능을 구현했습니다.

## 🔎 작업 상세 설명

페이징 처리를 하여 댓글을 조회합니다.

댓글을 조회한 결과로 memberId도 함께 반환하는 이유는
**댓글 신고**와 **댓글에서 회원 프로필로 조회**를 염두에 두고 반환했습니다 ~

## 🌟 리뷰 요구 사항

> 15분
