### PR TITLE
Feature/#15 프로필 정보를 가져오는 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/member/member.adoc
+++ b/src/docs/asciidoc/member/member.adoc
@@ -13,23 +13,31 @@ endif::[]
 
 link:../foodbowl.html[API 목록으로 돌아가기]
 
-== *회원 탈퇴* ==
+== *회원 프로필 정보 조회* ==
 
 === 요청
 
 === Request
 
-include::{snippets}/api-v1-members-delete/http-request.adoc[]
+include::{snippets}/api-v1-members-get-profile/http-request.adoc[]
 
 === Request Headers
 
-include::{snippets}/api-v1-members-delete/request-headers.adoc[]
+include::{snippets}/api-v1-members-get-profile/request-headers.adoc[]
+
+=== Path Parameters
+
+include::{snippets}/api-v1-members-get-profile/path-parameters.adoc[]
 
 === 응답
 
 === Response
 
-include::{snippets}/api-v1-members-delete/http-response.adoc[]
+include::{snippets}/api-v1-members-get-profile/http-response.adoc[]
+
+=== Response Fields
+
+include::{snippets}/api-v1-members-get-profile/response-fields.adoc[]
 
 == *닉네임, 소개 수정* ==
 
@@ -52,3 +60,21 @@ include::{snippets}/api-v1-members-update-profile/request-fields.adoc[]
 === Response
 
 include::{snippets}/api-v1-members-update-profile/http-response.adoc[]
+
+== *회원 탈퇴* ==
+
+=== 요청
+
+=== Request
+
+include::{snippets}/api-v1-members-delete/http-request.adoc[]
+
+=== Request Headers
+
+include::{snippets}/api-v1-members-delete/request-headers.adoc[]
+
+=== 응답
+
+=== Response
+
+include::{snippets}/api-v1-members-delete/http-response.adoc[]

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/entity/Follow.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/entity/Follow.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -44,6 +45,10 @@ public class Follow extends AuditingEntity {
     private Follow(Member following, Member follower) {
         this.following = following;
         this.follower = follower;
+    }
+
+    public boolean isFollower(Member member) {
+        return Objects.equals(follower, member);
     }
 }
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/api/MemberController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/api/MemberController.java
@@ -4,9 +4,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
 import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
+import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.global.resolver.MemberId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,17 +22,27 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @DeleteMapping
-    public ResponseEntity<Void> withDraw(@MemberId Long memberId) {
-        memberService.withDraw(memberId);
-        return ResponseEntity.noContent().build();
+    @GetMapping("/{id}/profile")
+    public ResponseEntity<MemberProfileResponse> getMemberProfile(
+            @PathVariable(name = "id") Long profileMemberId,
+            @MemberId Long memberId
+    ) {
+        MemberProfileResponse response = memberService.getMemberProfile(profileMemberId, memberId);
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping
     public ResponseEntity<Void> updateProfile(
             @MemberId Long memberId,
-            @Valid @RequestBody ProfileUpdateRequest profileUpdateRequest) {
+            @Valid @RequestBody ProfileUpdateRequest profileUpdateRequest
+    ) {
         memberService.updateProfile(memberId, profileUpdateRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> withDraw(@MemberId Long memberId) {
+        memberService.withDraw(memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
@@ -7,8 +7,10 @@ import org.dinosaur.foodbowl.domain.blame.entity.Blame.BlameTarget;
 import org.dinosaur.foodbowl.domain.blame.repository.BlameRepository;
 import org.dinosaur.foodbowl.domain.bookmark.repository.BookmarkRepository;
 import org.dinosaur.foodbowl.domain.comment.repository.CommentRepository;
+import org.dinosaur.foodbowl.domain.follow.entity.Follow;
 import org.dinosaur.foodbowl.domain.follow.repository.FollowRepository;
 import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
+import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Member;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRepository;
 import org.dinosaur.foodbowl.domain.member.repository.MemberRoleRepository;
@@ -22,7 +24,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Service
 public class MemberService {
 
@@ -36,6 +37,41 @@ public class MemberService {
     private final CommentRepository commentRepository;
     private final BookmarkRepository bookmarkRepository;
     private final BlameRepository blameRepository;
+
+    @Transactional(readOnly = true)
+    public MemberProfileResponse getMemberProfile(Long profileMemberId, Long memberId) {
+        Member profileMember = memberRepository.findById(profileMemberId)
+                .orElseThrow(() -> new FoodbowlException(MEMBER_NOT_FOUND));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FoodbowlException(MEMBER_NOT_FOUND));
+
+        boolean isSelfProfile = profileMember == member;
+
+        return new MemberProfileResponse(
+                profileMember.getNickname(),
+                profileMember.getThumbnailPath(),
+                profileMember.getFollowers().size(),
+                profileMember.getFollowings().size(),
+                isSelfProfile,
+                isFollowed(profileMember, member)
+        );
+    }
+
+    private boolean isFollowed(Member profileMember, Member member) {
+        boolean isFollowed = false;
+        for (Follow follower : profileMember.getFollowers()) {
+            isFollowed = isFollowed || follower.getFollower().getId().equals(member.getId());
+        }
+        return isFollowed;
+    }
+
+    @Transactional
+    public void updateProfile(Long memberId, ProfileUpdateRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FoodbowlException(MEMBER_NOT_FOUND));
+
+        member.updateProfile(request.getNickname(), request.getIntroduction());
+    }
 
     @Transactional
     public void withDraw(Long memberId) {
@@ -58,13 +94,5 @@ public class MemberService {
         }
         memberRepository.delete(member);
         thumbnailRepository.delete(member.getThumbnail());
-    }
-
-    @Transactional
-    public void updateProfile(Long memberId, ProfileUpdateRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new FoodbowlException(MEMBER_NOT_FOUND));
-
-        member.updateProfile(request.getNickname(), request.getIntroduction());
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
@@ -2,12 +2,12 @@ package org.dinosaur.foodbowl.domain.member.application;
 
 import static org.dinosaur.foodbowl.global.exception.ErrorStatus.MEMBER_NOT_FOUND;
 
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.blame.entity.Blame.BlameTarget;
 import org.dinosaur.foodbowl.domain.blame.repository.BlameRepository;
 import org.dinosaur.foodbowl.domain.bookmark.repository.BookmarkRepository;
 import org.dinosaur.foodbowl.domain.comment.repository.CommentRepository;
-import org.dinosaur.foodbowl.domain.follow.entity.Follow;
 import org.dinosaur.foodbowl.domain.follow.repository.FollowRepository;
 import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
@@ -45,7 +45,10 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FoodbowlException(MEMBER_NOT_FOUND));
 
-        boolean isSelfProfile = profileMember == member;
+        boolean isSelfProfile = Objects.equals(profileMember, member);
+        boolean isFollowed = profileMember.getFollowers()
+                .stream()
+                .anyMatch(follow -> follow.isFollower(member));
 
         return new MemberProfileResponse(
                 profileMember.getNickname(),
@@ -53,16 +56,8 @@ public class MemberService {
                 profileMember.getFollowers().size(),
                 profileMember.getFollowings().size(),
                 isSelfProfile,
-                isFollowed(profileMember, member)
+                isFollowed
         );
-    }
-
-    private boolean isFollowed(Member profileMember, Member member) {
-        boolean isFollowed = false;
-        for (Follow follower : profileMember.getFollowers()) {
-            isFollowed = isFollowed || follower.getFollower().getId().equals(member.getId());
-        }
-        return isFollowed;
     }
 
     @Transactional

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/dto/response/MemberProfileResponse.java
@@ -1,0 +1,19 @@
+package org.dinosaur.foodbowl.domain.member.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberProfileResponse {
+
+    private String nickname;
+    private String thumbnailPath;
+    private int numberOfFollower;
+    private int numberOfFollowing;
+    private Boolean isSelfProfile;
+    private Boolean isFollowed;
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/entity/Member.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.follow.entity.Follow;
 import org.dinosaur.foodbowl.domain.photo.entity.Thumbnail;
 import org.dinosaur.foodbowl.domain.post.entity.Post;
 import org.dinosaur.foodbowl.global.entity.AuditingEntity;
@@ -68,6 +69,12 @@ public class Member extends AuditingEntity {
     @OneToMany(mappedBy = "member")
     private List<Post> posts = new ArrayList<>();
 
+    @OneToMany(mappedBy = "following")
+    private List<Follow> followers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "follower")
+    private List<Follow> followings = new ArrayList<>();
+
     @Builder
     private Member(
             Thumbnail thumbnail, SocialType socialType, String socialId, String email, String nickname,
@@ -86,6 +93,10 @@ public class Member extends AuditingEntity {
     public void updateProfile(final String nickname, final String introduction) {
         this.nickname = nickname;
         this.introduction = introduction;
+    }
+
+    public String getThumbnailPath() {
+        return thumbnail != null ? thumbnail.getPath() : null;
     }
 
     public enum SocialType {

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/repository/MemberRepository.java
@@ -9,16 +9,15 @@ import org.springframework.data.repository.Repository;
 
 public interface MemberRepository extends Repository<Member, Long> {
 
+    Member save(Member member);
+
     Optional<Member> findById(Long memberId);
 
     Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
     List<Member> findAll();
 
-    Member save(Member member);
-
     boolean existsByNickname(String nickname);
 
     void delete(Member member);
-
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/api/StoreController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/api/StoreController.java
@@ -28,8 +28,10 @@ public class StoreController {
 
     @GetMapping
     public ResponseEntity<StoreResponse> findStore(
-            @RequestParam @NotBlank(message = "주소는 반드시 포함되어야 합니다.") String address) {
-        StoreResponse storeResponse = storeService.findByAddress(address.replace(ADDRESS_REQUEST_DELIMITER, ADDRESS_DELIMITER));
+            @RequestParam @NotBlank(message = "주소는 반드시 포함되어야 합니다.") String address
+    ) {
+        String searchAddress = address.replace(ADDRESS_REQUEST_DELIMITER, ADDRESS_DELIMITER);
+        StoreResponse storeResponse = storeService.findByAddress(searchAddress);
         return ResponseEntity.ok(storeResponse);
     }
 

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAccessDeniedHandler.java
@@ -12,7 +12,9 @@ import org.springframework.stereotype.Component;
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response,
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
             AccessDeniedException accessDeniedException) throws IOException, ServletException {
         response.sendError(HttpServletResponse.SC_FORBIDDEN);
     }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/security/CustomAuthenticationEntryPoint.java
@@ -12,7 +12,9 @@ import org.springframework.stereotype.Component;
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response,
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
             AuthenticationException authException) throws IOException, ServletException {
         response.getWriter().write("인증에 실패하였습니다.");
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED);

--- a/src/main/java/org/dinosaur/foodbowl/global/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/exception/GlobalExceptionAdvice.java
@@ -31,7 +31,10 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
 
     @Override
     public ResponseEntity<Object> handleMethodArgumentNotValid(
-            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request
     ) {
         BindingResult bindingResult = ex.getBindingResult();
         StringBuilder stringBuilder = new StringBuilder();
@@ -52,8 +55,7 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<FoodbowlErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
-        Iterator<ConstraintViolation<?>> iterator =
-                ex.getConstraintViolations().iterator();
+        Iterator<ConstraintViolation<?>> iterator = ex.getConstraintViolations().iterator();
 
         StringBuilder stringBuilder = new StringBuilder();
         while (iterator.hasNext()) {
@@ -65,10 +67,13 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<FoodbowlErrorResponse> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex) {
+    public ResponseEntity<FoodbowlErrorResponse> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException ex
+    ) {
         String parameterName = ex.getParameter().getParameterName();
         logger.warn(ex.getMessage());
-        return ResponseEntity.badRequest().body(new FoodbowlErrorResponse(parameterName + FIELD_TYPE_ERROR_MESSAGE, -1002));
+        return ResponseEntity.badRequest()
+                .body(new FoodbowlErrorResponse(parameterName + FIELD_TYPE_ERROR_MESSAGE, -1002));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/dinosaur/foodbowl/global/resolver/MemberIdArgumentResolver.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/resolver/MemberIdArgumentResolver.java
@@ -26,8 +26,11 @@ public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (!authentication.isAuthenticated()) {

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/api/MemberControllerTest.java
@@ -1,19 +1,24 @@
 package org.dinosaur.foodbowl.domain.member.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dinosaur.foodbowl.MockApiTest;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
 import org.dinosaur.foodbowl.domain.member.dto.request.ProfileUpdateRequest;
+import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.entity.Role.RoleType;
 import org.dinosaur.foodbowl.global.config.security.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +32,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(controllers = MemberController.class)
 class MemberControllerTest extends MockApiTest {
@@ -52,6 +58,50 @@ class MemberControllerTest extends MockApiTest {
                 .andDo(print())
                 .andExpect(status().isNoContent());
 
+    }
+
+    @Nested
+    @DisplayName("회원 프로필 정보 조회 요청 시 ")
+    class GetMemberProfile {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"a", "가", "@"})
+        @DisplayName("정수로 변환할 수 없는 타입의 ID라면 400 상태를 반환한다.")
+        void return400WhenFailToConvertToLong(String id) throws Exception {
+            mockMvc.perform(get("/api/v1/members/{id}/profile", id)
+                            .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(containsString("타입이 잘못되었습니다.")))
+                    .andExpect(jsonPath("$.code").value(-1002));
+        }
+
+        @Test
+        @DisplayName("요청에 성공한다면 200 상태를 반환한다.")
+        void return200WhenRequestSuccess() throws Exception {
+            String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+            MemberProfileResponse response = new MemberProfileResponse(
+                    "dazzle",
+                    "http://foodbowl/thumbnail/1",
+                    176,
+                    124,
+                    false,
+                    true
+            );
+
+            given(memberService.getMemberProfile(anyLong(), anyLong())).willReturn(response);
+
+            MvcResult mvcResult = mockMvc.perform(get("/api/v1/members/{id}/profile", 2L)
+                            .header("Authorization", "Bearer " + accessToken)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+            String jsonResponse = mvcResult.getResponse().getContentAsString();
+            MemberProfileResponse result = objectMapper.readValue(jsonResponse, MemberProfileResponse.class);
+
+            assertThat(result).usingRecursiveComparison().isEqualTo(response);
+        }
     }
 
     @Nested

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/repository/StoreRepositoryTest.java
@@ -107,7 +107,8 @@ class StoreRepositoryTest extends RepositoryTest {
         void findByAddress_AddressNameSuccess() {
             Store savedStore = storeRepository.save(createStore());
 
-            Optional<Store> findStore = storeRepository.findByAddress_AddressName(savedStore.getAddress().getAddressName());
+            String addressName = savedStore.getAddress().getAddressName();
+            Optional<Store> findStore = storeRepository.findByAddress_AddressName(addressName);
 
             assertThat(findStore.get()).isEqualTo(savedStore);
         }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #15

## 📝 작업 요약

회원 프로필 정보 조회 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 팔로워, 팔로우 수를 구하기 위해 양방향 연관관계를 설정하였습니다.
- 지연 로딩을 사용하더라도 `ID`만 조회한다면 해당 엔티티를 조회하기 위한 추가적인 쿼리가 나가지 않습니다.

## 🌟 리뷰 요구 사항

> 15분