### PR TITLE
Feature/#91 요청 발생 시 회원을 가져오는 방법을 변경한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/application/HealthCheckService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/application/HealthCheckService.java
@@ -4,10 +4,10 @@ import org.dinosaur.foodbowl.domain.healthcheck.dto.response.HealthCheckResponse
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @Service
 public class HealthCheckService {
 
-    @Transactional(readOnly = true)
     public HealthCheckResponse healthCheck() {
         return new HealthCheckResponse("good");
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.dinosaur.foodbowl.domain.healthcheck.dto.response.HealthCheckResponse;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "헬스 체크", description = "헬스 체크 API")
@@ -11,5 +12,9 @@ public interface HealthCheckController {
 
     @Operation(summary = "서버 상태 확인", description = "서버 상태를 확인한다.")
     @ApiResponse(responseCode = "200", description = "서버 상태 확인 성공")
-    ResponseEntity<HealthCheckResponse> healthcheck();
+    ResponseEntity<HealthCheckResponse> healthCheck();
+
+    @Operation(summary = "회원 인증 확인", description = "회원 인증 과정을 확인한다.")
+    @ApiResponse(responseCode = "200", description = "회원 인증 성공")
+    ResponseEntity<HealthCheckResponse> authCheck(Member member);
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerImpl.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerImpl.java
@@ -3,6 +3,8 @@ package org.dinosaur.foodbowl.domain.healthcheck.presentation;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.healthcheck.application.HealthCheckService;
 import org.dinosaur.foodbowl.domain.healthcheck.dto.response.HealthCheckResponse;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.global.presentation.Auth;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +18,13 @@ public class HealthCheckControllerImpl implements HealthCheckController {
     private final HealthCheckService healthCheckService;
 
     @GetMapping
-    public ResponseEntity<HealthCheckResponse> healthcheck() {
+    public ResponseEntity<HealthCheckResponse> healthCheck() {
+        HealthCheckResponse response = healthCheckService.healthCheck();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/auth")
+    public ResponseEntity<HealthCheckResponse> authCheck(@Auth Member member) {
         HealthCheckResponse response = healthCheckService.healthCheck();
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
@@ -45,8 +45,8 @@ public class Member extends AuditingEntity {
     @Column(name = "nickname", unique = true, length = 45)
     private String nickname;
 
-    @Column(name = "introduce", length = 255)
-    private String introduce;
+    @Column(name = "introduction", length = 255)
+    private String introduction;
 
     @Builder
     private Member(
@@ -54,12 +54,12 @@ public class Member extends AuditingEntity {
             String socialId,
             String email,
             String nickname,
-            String introduce
+            String introduction
     ) {
         this.socialType = socialType;
         this.socialId = socialId;
         this.email = email;
         this.nickname = nickname;
-        this.introduce = introduce;
+        this.introduction = introduction;
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/exception/MemberExceptionType.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/exception/MemberExceptionType.java
@@ -1,0 +1,18 @@
+package org.dinosaur.foodbowl.domain.member.exception;
+
+import lombok.Getter;
+import org.dinosaur.foodbowl.global.exception.ExceptionType;
+
+@Getter
+public enum MemberExceptionType implements ExceptionType {
+
+    NOT_FOUND("MEMBER-100", "일치하는 회원을 찾을 수 없습니다.");
+
+    private final String errorCode;
+    private final String message;
+
+    MemberExceptionType(String errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.repository.Repository;
 public interface MemberRepository extends Repository<Member, Long> {
 
     Optional<Member> findById(Long id);
+
+    Member save(Member member);
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberRepository.java
@@ -1,7 +1,10 @@
 package org.dinosaur.foodbowl.domain.member.persistence;
 
+import java.util.Optional;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.springframework.data.repository.Repository;
 
 public interface MemberRepository extends Repository<Member, Long> {
+
+    Optional<Member> findById(Long id);
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/WebConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/WebConfig.java
@@ -2,7 +2,7 @@ package org.dinosaur.foodbowl.global.config;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.dinosaur.foodbowl.global.presentation.MemberIdArgumentResolver;
+import org.dinosaur.foodbowl.global.presentation.MemberArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -11,10 +11,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final MemberIdArgumentResolver memberIdArgumentResolver;
+    private final MemberArgumentResolver memberArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(memberIdArgumentResolver);
+        resolvers.add(memberArgumentResolver);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/presentation/Auth.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/presentation/Auth.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface MemberId {
+public @interface Auth {
 }

--- a/src/test/java/org/dinosaur/foodbowl/PersistenceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/PersistenceTest.java
@@ -1,0 +1,17 @@
+package org.dinosaur.foodbowl;
+
+import org.dinosaur.foodbowl.global.config.JpaConfig;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+@DataJpaTest(
+        includeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = JpaConfig.class
+))
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class PersistenceTest {
+}

--- a/src/test/java/org/dinosaur/foodbowl/PresentationTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/PresentationTest.java
@@ -1,0 +1,20 @@
+package org.dinosaur.foodbowl;
+
+import org.dinosaur.foodbowl.domain.auth.jwt.JwtAuthorizationExtractor;
+import org.dinosaur.foodbowl.domain.auth.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.global.config.SecurityConfig;
+import org.dinosaur.foodbowl.global.config.WebConfig;
+import org.dinosaur.foodbowl.global.config.security.CustomAccessDeniedHandler;
+import org.dinosaur.foodbowl.global.config.security.CustomAuthenticationEntryPoint;
+import org.springframework.context.annotation.Import;
+
+@Import(value = {
+        WebConfig.class,
+        SecurityConfig.class,
+        JwtTokenProvider.class,
+        JwtAuthorizationExtractor.class,
+        CustomAccessDeniedHandler.class,
+        CustomAuthenticationEntryPoint.class
+})
+public class PresentationTest {
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerTest.java
@@ -1,0 +1,75 @@
+package org.dinosaur.foodbowl.domain.healthcheck.presentation;
+
+import static org.dinosaur.foodbowl.domain.member.domain.vo.RoleType.ROLE_회원;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+import org.dinosaur.foodbowl.PresentationTest;
+import org.dinosaur.foodbowl.domain.auth.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.domain.healthcheck.application.HealthCheckService;
+import org.dinosaur.foodbowl.domain.healthcheck.dto.response.HealthCheckResponse;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
+import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@WebMvcTest(controllers = HealthCheckControllerImpl.class)
+class HealthCheckControllerTest extends PresentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private HealthCheckService healthCheckService;
+
+    @Test
+    void 서버_상태가_정상이면_200_반환() throws Exception {
+        given(healthCheckService.healthCheck())
+                .willReturn(new HealthCheckResponse("good"));
+
+        mockMvc.perform(get("/v1/health-check"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("good"))
+                .andDo(print());
+    }
+
+    @Test
+    void 사용자_인증이_정상이면_200_반환() throws Exception {
+        Member member = Member.builder()
+                .email("foodBowl@gmail.com")
+                .socialId("foodBowlId")
+                .socialType(SocialType.APPLE)
+                .nickname("foodbowl")
+                .introduce("푸드볼 서비스")
+                .build();
+        given(memberRepository.findById(anyLong()))
+                .willReturn(Optional.of(member));
+        given(healthCheckService.healthCheck())
+                .willReturn(new HealthCheckResponse("good"));
+
+        mockMvc.perform(get("/v1/health-check/auth")
+                        .header("Authorization", "Bearer " + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("good"))
+                .andDo(print());
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerTest.java
@@ -59,7 +59,7 @@ class HealthCheckControllerTest extends PresentationTest {
                 .socialId("foodBowlId")
                 .socialType(SocialType.APPLE)
                 .nickname("foodbowl")
-                .introduce("푸드볼 서비스")
+                .introduction("푸드볼 서비스")
                 .build();
         given(memberRepository.findById(anyLong()))
                 .willReturn(Optional.of(member));

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/persistence/MemberRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/persistence/MemberRepositoryTest.java
@@ -1,0 +1,50 @@
+package org.dinosaur.foodbowl.domain.member.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.PersistenceTest;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MemberRepositoryTest extends PersistenceTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 회원_저장() {
+        Member member = Member.builder()
+                .email("foodBowl@gmail.com")
+                .socialId("foodBowlId")
+                .socialType(SocialType.APPLE)
+                .nickname("foodbowl")
+                .introduction("안녕하세요")
+                .build();
+
+        Member saveMember = memberRepository.save(member);
+
+        assertThat(saveMember.getId()).isNotNull();
+    }
+
+    @Test
+    void 아이디와_일치하는_회원_조회() {
+        Member member = Member.builder()
+                .email("foodBowl@gmail.com")
+                .socialId("foodBowlId")
+                .socialType(SocialType.APPLE)
+                .nickname("foodbowl")
+                .introduction("안녕하세요")
+                .build();
+        Member saveMember = memberRepository.save(member);
+
+        Member findMember = memberRepository.findById(saveMember.getId()).get();
+
+        assertThat(findMember.getId()).isEqualTo(saveMember.getId());
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #91 

## 📝 작업 요약

- ArgumentResolver에서 Member를 반환하도록 변경했습니다.

## 🔎 작업 상세 설명

- Member 객체의 introduce 필드가 Member 테이블에는 introduction으로 설정되어 있어서 `introduction`으로 통일했습니다.
- ArgumentResolver의 정상 동작을 확인하기 위해 HealthCheckController를 테스트했습니다.
- 테스트에서 Fixture와 Support의 사용 여부가 확실하지 않아, 우선적으로 메서드 내부에서 객체를 생성했습니다.
- 각 계층별 테스트를 위한 상위 객체를 생성했습니다. 네이밍을 패키지 구조와 동일하게 가져가도록 했는데 확인 부탁해요 !
- 커밋 메세지에 이슈 번호를 잘못 남겼습니다 😂 익스큐즈 부탁해요 ㅎㅎ

## 🌟 리뷰 요구 사항

> 10분
