### PR TITLE
Feature/#109 팔로우 취소 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
@@ -45,6 +45,7 @@ public class FollowService {
                 });
     }
 
+    @Transactional
     public void unfollow(Long targetMemberId, Member loginMember) {
         Member targetMember = memberRepository.findById(targetMemberId)
                 .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
@@ -44,4 +44,13 @@ public class FollowService {
                     throw new BadRequestException(FollowExceptionType.DUPLICATE_FOLLOW);
                 });
     }
+
+    public void unfollow(Long targetMemberId, Member loginMember) {
+        Member targetMember = memberRepository.findById(targetMemberId)
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+
+        Follow follow = followRepository.findByFollowingAndFollower(targetMember, loginMember)
+                .orElseThrow(() -> new BadRequestException(FollowExceptionType.UNFOLLOWED));
+        followRepository.delete(follow);
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/exception/FollowExceptionType.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/exception/FollowExceptionType.java
@@ -7,7 +7,8 @@ import org.dinosaur.foodbowl.global.exception.ExceptionType;
 public enum FollowExceptionType implements ExceptionType {
 
     FOLLOW_ME("FOLLOW-100", "본인을 팔로우할 수 없습니다."),
-    DUPLICATE_FOLLOW("FOLLOW-101", "이미 팔로우한 회원입니다.");
+    DUPLICATE_FOLLOW("FOLLOW-101", "이미 팔로우한 회원입니다."),
+    UNFOLLOWED("FOLLOW-102", "팔로우 하지 않은 회원입니다.");
 
     private String errorCode;
     private String message;

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
@@ -7,7 +7,11 @@ import org.springframework.data.repository.Repository;
 
 public interface FollowRepository extends Repository<Follow, Long> {
 
-    Follow save(Follow follow);
+    Optional<Follow> findById(Long id);
 
     Optional<Follow> findByFollowingAndFollower(Member following, Member follower);
+
+    Follow save(Follow follow);
+
+    void delete(Follow follow);
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
@@ -5,6 +5,7 @@ import org.dinosaur.foodbowl.domain.follow.application.FollowService;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.presentation.Auth;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +19,20 @@ public class FollowController implements FollowControllerDocs {
     private final FollowService followService;
 
     @PostMapping("/{memberId}/follow")
-    public ResponseEntity<Void> follow(@PathVariable(name = "memberId") Long targetMemberId, @Auth Member loginMember) {
+    public ResponseEntity<Void> follow(
+            @PathVariable(name = "memberId") Long targetMemberId,
+            @Auth Member loginMember
+    ) {
         followService.follow(targetMemberId, loginMember);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{memberId}/unfollow")
+    public ResponseEntity<Void> unfollow(
+            @PathVariable(name = "memberId") Long targetMemberId,
+            @Auth Member loginMember
+    ) {
+        followService.unfollow(targetMemberId, loginMember);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
@@ -1,10 +1,12 @@
 package org.dinosaur.foodbowl.domain.follow.presentation;
 
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.follow.application.FollowService;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.presentation.Auth;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/v1/follows")
 @RestController
 public class FollowController implements FollowControllerDocs {
@@ -20,7 +23,7 @@ public class FollowController implements FollowControllerDocs {
 
     @PostMapping("/{memberId}/follow")
     public ResponseEntity<Void> follow(
-            @PathVariable(name = "memberId") Long targetMemberId,
+            @PathVariable(name = "memberId") @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
             @Auth Member loginMember
     ) {
         followService.follow(targetMemberId, loginMember);
@@ -29,7 +32,7 @@ public class FollowController implements FollowControllerDocs {
 
     @DeleteMapping("/{memberId}/unfollow")
     public ResponseEntity<Void> unfollow(
-            @PathVariable(name = "memberId") Long targetMemberId,
+            @PathVariable(name = "memberId") @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
             @Auth Member loginMember
     ) {
         followService.unfollow(targetMemberId, loginMember);

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
@@ -24,7 +24,7 @@ public interface FollowControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "등록되지 않은 회원 ID 팔로우",
+                    description = "등록되지 않은 팔로우 대상 회원 ID",
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
@@ -43,7 +43,7 @@ public interface FollowControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "등록되지 않은 회원 ID 언팔로우",
+                    description = "등록되지 않은 언팔로우 회원 ID",
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "팔로우", description = "팔로우 API")
 public interface FollowControllerDocs {
 
-    @Operation(summary = "팔로우 요청", description = "다른 회원에게 팔로우를 요청한다.")
+    @Operation(summary = "팔로우", description = "다른 회원에게 팔로우를 요청한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "팔로우 성공"),
             @ApiResponse(
@@ -28,5 +28,27 @@ public interface FollowControllerDocs {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    ResponseEntity<Void> follow(@Parameter(description = "팔로우 대상 회원 ID") Long targetMemberId, Member loginMember);
+    ResponseEntity<Void> follow(
+            @Parameter(description = "팔로우 회원 ID", example = "1") Long targetMemberId,
+            Member loginMember
+    );
+
+    @Operation(summary = "언팔로우", description = "팔로우 되어있는 회원을 언팔로우한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "언팔로우 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "팔로우하지 않은 회원 언팔로우",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "등록되지 않은 회원 ID 언팔로우",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<Void> unfollow(
+            @Parameter(description = "언팔로우 회원 ID", example = "1") Long targetMemberId,
+            Member loginMember
+    );
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.exception.ExceptionResponse;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,8 @@ public interface FollowControllerDocs {
             )
     })
     ResponseEntity<Void> follow(
-            @Parameter(description = "팔로우 회원 ID", example = "1") Long targetMemberId,
+            @Parameter(description = "팔로우 회원 ID", example = "1")
+            @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
             Member loginMember
     );
 
@@ -48,7 +50,8 @@ public interface FollowControllerDocs {
             )
     })
     ResponseEntity<Void> unfollow(
-            @Parameter(description = "언팔로우 회원 ID", example = "1") Long targetMemberId,
+            @Parameter(description = "언팔로우 회원 ID", example = "1")
+            @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
             Member loginMember
     );
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/exception/ErrorResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package org.dinosaur.foodbowl.global.exception;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "요청 검증 에러 응답")
+public record ErrorResponse(
+        @Schema(description = "검증 실패 필드", example = "id")
+        String fieldName,
+
+        @Schema(description = "검승 실패 에러 메시지", example = "ID는 양수만 가능합니다.")
+        String message
+) {
+
+    @Override
+    public String toString() {
+        return "{" +
+                "fieldName='" + fieldName + '\'' +
+                ", message='" + message + '\'' +
+                '}';
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package org.dinosaur.foodbowl.domain.auth.presentation;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -48,8 +49,8 @@ class AuthControllerTest extends PresentationTest {
                             .content(objectMapper.writeValueAsString(appleLoginRequest)))
                     .andDo(print())
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.errorCode").value("SERVER-102"))
-                    .andExpect(jsonPath("$.message").value("애플 토큰이 존재하지 않습니다."));
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
+                    .andExpect(jsonPath("$.message", containsString("애플 토큰이 존재하지 않습니다.")));
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
@@ -24,7 +24,7 @@ class FollowServiceTest extends IntegrationTest {
     private FollowRepository followRepository;
 
     @Nested
-    class 팔로우_등록_시 {
+    class 팔로우_등록 {
 
         @Test
         void 등록되지_않은_회원이라면_예외를_던진다() {
@@ -71,7 +71,7 @@ class FollowServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 팔로우_취소_시 {
+    class 팔로우_취소 {
 
         @Test
         void 등록되지_않은_회원이라면_에외를_던진다() {

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
@@ -69,4 +69,41 @@ class FollowServiceTest extends IntegrationTest {
             assertThat(follow).isPresent();
         }
     }
+
+    @Nested
+    class 팔로우_취소_시 {
+
+        @Test
+        void 등록되지_않은_회원이라면_에외를_던진다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+
+            assertThatThrownBy(() -> followService.unfollow(-1L, loginMember))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
+        void 팔로우_하지_않은_회원이라면_예외를_던진다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+            Member followMember = memberTestPersister.memberBuilder().save();
+
+            assertThatThrownBy(() -> followService.unfollow(followMember.getId(), loginMember))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("팔로우 하지 않은 회원입니다.");
+        }
+
+        @Test
+        void 유효한_상황이라면_언팔로우한다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+            Member followMember = memberTestPersister.memberBuilder().save();
+            Follow follow = followTestPersister.builder()
+                    .following(followMember)
+                    .follower(loginMember)
+                    .save();
+
+            followService.unfollow(followMember.getId(), loginMember);
+
+            assertThat(followRepository.findById(follow.getId())).isNotPresent();
+        }
+    }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
@@ -1,9 +1,9 @@
 package org.dinosaur.foodbowl.domain.follow.presentation;
 
 import static org.dinosaur.foodbowl.domain.member.domain.vo.RoleType.ROLE_회원;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Optional;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.follow.application.FollowService;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
@@ -49,13 +48,25 @@ class FollowControllerTest extends PresentationTest {
                     .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errorCode").value("CLIENT-102"))
-                    .andExpect(jsonPath("$.message").value("요청 데이터 타입이 일치하지 않습니다."));
+                    .andExpect(jsonPath("$.message",
+                            containsString(Long.class.getSimpleName() + " 타입으로 변환할 수 없는 요청입니다.")));
+        }
+
+        @Test
+        void ID가_양수가_아니라면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(post("/v1/follows/{memberId}/follow", -1L)
+                            .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message", containsString("ID는 양수만 가능합니다.")));
         }
 
         @Test
         void 팔로우를_수행하면_200_응답을_반환한다() throws Exception {
-            given(memberRepository.findById(anyLong()))
-                    .willReturn(Optional.of(member));
+            mockingAuthMemberInResolver();
             willDoNothing().given(followService)
                     .follow(anyLong(), any(Member.class));
 
@@ -77,7 +88,20 @@ class FollowControllerTest extends PresentationTest {
                     .andDo(print())
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errorCode").value("CLIENT-102"))
-                    .andExpect(jsonPath("$.message").value("요청 데이터 타입이 일치하지 않습니다."));
+                    .andExpect(jsonPath("$.message",
+                            containsString(Long.class.getSimpleName() + " 타입으로 변환할 수 없는 요청입니다.")));
+        }
+
+        @Test
+        void ID가_양수가_아니라면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(delete("/v1/follows/{memberId}/unfollow", -1L)
+                            .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message", containsString("ID는 양수만 가능합니다.")));
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -22,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @SuppressWarnings("NonAsciiCharacters")
 @WebMvcTest(FollowController.class)
@@ -43,7 +44,7 @@ class FollowControllerTest extends PresentationTest {
         @ValueSource(strings = {"가", "a", "A", "@"})
         @ParameterizedTest
         void ID타입으로_변환하지_못하는_타입이라면_400_응답을_반환한다(String memberId) throws Exception {
-            mockMvc.perform(MockMvcRequestBuilders.post("/v1/follows/{memberId}/follow", memberId)
+            mockMvc.perform(post("/v1/follows/{memberId}/follow", memberId)
                             .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
                     .andDo(print())
                     .andExpect(status().isBadRequest())
@@ -58,10 +59,37 @@ class FollowControllerTest extends PresentationTest {
             willDoNothing().given(followService)
                     .follow(anyLong(), any(Member.class));
 
-            mockMvc.perform(MockMvcRequestBuilders.post("/v1/follows/{memberId}/follow", 1L)
+            mockMvc.perform(post("/v1/follows/{memberId}/follow", 1L)
                             .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
                     .andDo(print())
                     .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    class 언팔로우 {
+
+        @ValueSource(strings = {"가", "a", "A", "@"})
+        @ParameterizedTest
+        void ID타입으로_변환하지_못하는_타입이라면_400_응답을_반환한다(String memberId) throws Exception {
+            mockMvc.perform(delete("/v1/follows/{memberId}/unfollow", memberId)
+                            .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-102"))
+                    .andExpect(jsonPath("$.message").value("요청 데이터 타입이 일치하지 않습니다."));
+        }
+
+        @Test
+        void 언팔로우를_수행하면_204_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+            willDoNothing().given(followService)
+                    .unfollow(anyLong(), any(Member.class));
+
+            mockMvc.perform(delete("/v1/follows/{memberId}/unfollow", 1L)
+                            .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerTest.java
@@ -1,14 +1,12 @@
 package org.dinosaur.foodbowl.domain.healthcheck.presentation;
 
 import static org.dinosaur.foodbowl.domain.member.domain.vo.RoleType.ROLE_회원;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Optional;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.healthcheck.application.HealthCheckService;
 import org.dinosaur.foodbowl.domain.healthcheck.dto.response.HealthCheckResponse;
@@ -45,8 +43,7 @@ class HealthCheckControllerTest extends PresentationTest {
 
     @Test
     void 사용자_인증이_정상이면_200_반환() throws Exception {
-        given(memberRepository.findById(anyLong()))
-                .willReturn(Optional.of(member));
+        mockingAuthMemberInResolver();
 
         mockMvc.perform(get("/v1/health-check/auth")
                         .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))

--- a/src/test/java/org/dinosaur/foodbowl/test/PresentationTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/PresentationTest.java
@@ -1,5 +1,9 @@
 package org.dinosaur.foodbowl.test;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
@@ -35,4 +39,9 @@ public class PresentationTest {
 
     @MockBean
     protected MemberRepository memberRepository;
+
+    protected void mockingAuthMemberInResolver() {
+        given(memberRepository.findById(anyLong()))
+                .willReturn(Optional.of(member));
+    }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #109 

## 📝 작업 요약

언팔로우 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 등록되지 않은 회원을 언팔로우하면 예외가 발생합니다.
- 팔로우하지 않은 회원을 언팔로우하면 예외가 발생합니다.
- 공통적으로 진행하고 있는 `@Auth Member mocking`을 위한 `mockingAuthMemberInResolver` 메서드를 구현하였습니다.

## 🌟 리뷰 요구 사항

> 10분
> 팔로우 기능과 거의 동일합니다 :)