### PR TITLE
Feature/#120 팔로워 목록 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
@@ -3,13 +3,19 @@ package org.dinosaur.foodbowl.domain.follow.application;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.follow.domain.Follow;
+import org.dinosaur.foodbowl.domain.follow.dto.response.FollowResponse;
 import org.dinosaur.foodbowl.domain.follow.exception.FollowExceptionType;
 import org.dinosaur.foodbowl.domain.follow.persistence.FollowRepository;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.exception.MemberExceptionType;
 import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
+import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +25,15 @@ public class FollowService {
 
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
+
+    @Transactional(readOnly = true)
+    public PageResponse<FollowResponse> getFollowers(int page, int size, Member loginMember) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Slice<FollowResponse> follows = followRepository.findAllByFollowing(loginMember, pageable)
+                .map(Follow::getFollower)
+                .map(FollowResponse::from);
+        return PageResponse.from(follows);
+    }
 
     @Transactional
     public void follow(Long targetMemberId, Member loginMember) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/dto/response/FollowResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/dto/response/FollowResponse.java
@@ -1,0 +1,29 @@
+package org.dinosaur.foodbowl.domain.follow.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+
+@Schema(description = "팔로워 응답")
+public record FollowResponse(
+        @Schema(description = "회원 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "이미지 URL", example = "http://justdoeat.shop/static/images/profile.png")
+        String profileImageUrl,
+
+        @Schema(description = "닉네임", example = "coby5502")
+        String nickname,
+
+        @Schema(description = "팔로워 수", example = "20")
+        int followerCount
+) {
+
+    public static FollowResponse from(Member member) {
+        return new FollowResponse(
+                member.getId(),
+                member.getProfileImageUrl(),
+                member.getNickname(),
+                member.getFollowerCount()
+        );
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
@@ -3,11 +3,17 @@ package org.dinosaur.foodbowl.domain.follow.persistence;
 import java.util.Optional;
 import org.dinosaur.foodbowl.domain.follow.domain.Follow;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.Repository;
 
 public interface FollowRepository extends Repository<Follow, Long> {
 
     Optional<Follow> findById(Long id);
+
+    @EntityGraph(attributePaths = {"follower", "follower.memberThumbnail", "follower.memberThumbnail.thumbnail"})
+    Slice<Follow> findAllByFollowing(Member following, Pageable pageable);
 
     Optional<Follow> findByFollowingAndFollower(Member following, Member follower);
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
@@ -5,14 +5,17 @@ import org.dinosaur.foodbowl.domain.follow.domain.Follow;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface FollowRepository extends Repository<Follow, Long> {
 
     Optional<Follow> findById(Long id);
 
-    @EntityGraph(attributePaths = {"follower", "follower.memberThumbnail", "follower.memberThumbnail.thumbnail"})
+    @Query("select f from Follow f"
+            + " left join fetch f.follower.memberThumbnail.thumbnail"
+            + " where f.following = :following"
+    )
     Slice<Follow> findAllByFollowing(Member following, Pageable pageable);
 
     Optional<Follow> findByFollowingAndFollower(Member following, Member follower);

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
@@ -1,16 +1,21 @@
 package org.dinosaur.foodbowl.domain.follow.presentation;
 
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.follow.application.FollowService;
+import org.dinosaur.foodbowl.domain.follow.dto.response.FollowResponse;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.global.presentation.Auth;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -20,6 +25,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class FollowController implements FollowControllerDocs {
 
     private final FollowService followService;
+
+    @GetMapping("/followers")
+    public ResponseEntity<PageResponse<FollowResponse>> getFollowers(
+            @RequestParam(defaultValue = "0") @PositiveOrZero(message = "페이지는 0이상만 가능합니다.") int page,
+            @RequestParam(defaultValue = "15") @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.") int size,
+            @Auth Member loginMember
+    ) {
+        PageResponse<FollowResponse> response = followService.getFollowers(page, size, loginMember);
+        return ResponseEntity.ok(response);
+    }
 
     @PostMapping("/{memberId}/follow")
     public ResponseEntity<Void> follow(

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
@@ -8,12 +8,29 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import org.dinosaur.foodbowl.domain.follow.dto.response.FollowResponse;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.global.exception.ExceptionResponse;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "팔로우", description = "팔로우 API")
 public interface FollowControllerDocs {
+
+    @Operation(summary = "팔로워 목록 조회", description = "정해진 개수만큼 팔로워 목록을 조회한다.")
+    @ApiResponse(responseCode = "200", description = "팔로워 목록 조회 성공")
+    ResponseEntity<PageResponse<FollowResponse>> getFollowers(
+            @Parameter(description = "페이지", example = "0")
+            @PositiveOrZero(message = "페이지는 0이상만 가능합니다.")
+            int page,
+
+            @Parameter(description = "페이지 크기", example = "15")
+            @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.")
+            int size,
+
+            Member loginMember
+    );
 
     @Operation(summary = "팔로우", description = "다른 회원에게 팔로우를 요청한다.")
     @ApiResponses({
@@ -33,6 +50,7 @@ public interface FollowControllerDocs {
             @Parameter(description = "팔로우 대상 회원 ID", example = "1")
             @Positive(message = "ID는 양수만 가능합니다.")
             Long targetMemberId,
+
             Member loginMember
     );
 
@@ -54,6 +72,7 @@ public interface FollowControllerDocs {
             @Parameter(description = "언팔로우 회원 ID", example = "1")
             @Positive(message = "ID는 양수만 가능합니다.")
             Long targetMemberId,
+
             Member loginMember
     );
 
@@ -75,6 +94,7 @@ public interface FollowControllerDocs {
             @Parameter(description = "팔로워 삭제 회원 ID", example = "1")
             @Positive(message = "ID는 양수만 가능합니다.")
             Long targetMemberId,
+
             Member loginMember
     );
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckController.java
@@ -17,14 +17,12 @@ public class HealthCheckController implements HealthCheckControllerDocs {
 
     private final HealthCheckService healthCheckService;
 
-    @Override
     @GetMapping
     public ResponseEntity<HealthCheckResponse> healthcheck() {
         HealthCheckResponse response = healthCheckService.healthCheck();
         return ResponseEntity.ok(response);
     }
 
-    @Override
     @GetMapping("/auth")
     public ResponseEntity<HealthCheckResponse> authCheck(@Auth Member member) {
         return ResponseEntity.ok(new HealthCheckResponse("good: " + member.getNickname()));

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
@@ -5,20 +5,28 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.follow.domain.Follow;
 import org.dinosaur.foodbowl.domain.member.domain.vo.Nickname;
 import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
+import org.dinosaur.foodbowl.domain.photo.domain.Thumbnail;
 import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 
 @Getter
@@ -57,6 +65,12 @@ public class Member extends AuditingEntity {
     @Column(name = "introduction", length = 255)
     private String introduction;
 
+    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
+    private MemberThumbnail memberThumbnail;
+
+    @OneToMany(mappedBy = "following")
+    private List<Follow> followers = new ArrayList<>();
+
     @Builder
     private Member(
             SocialType socialType,
@@ -74,5 +88,16 @@ public class Member extends AuditingEntity {
 
     public String getNickname() {
         return this.nickname.getValue();
+    }
+
+    public String getProfileImageUrl() {
+        return Optional.ofNullable(memberThumbnail)
+                .map(MemberThumbnail::getThumbnail)
+                .map(Thumbnail::getPath)
+                .orElse(null);
+    }
+
+    public int getFollowerCount() {
+        return followers.size();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberThumbnailRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberThumbnailRepository.java
@@ -4,4 +4,6 @@ import org.dinosaur.foodbowl.domain.member.domain.MemberThumbnail;
 import org.springframework.data.repository.Repository;
 
 public interface MemberThumbnailRepository extends Repository<MemberThumbnail, Long> {
+
+    MemberThumbnail save(MemberThumbnail memberThumbnail);
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/persistence/ThumbnailRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/persistence/ThumbnailRepository.java
@@ -4,4 +4,6 @@ import org.dinosaur.foodbowl.domain.photo.domain.Thumbnail;
 import org.springframework.data.repository.Repository;
 
 public interface ThumbnailRepository extends Repository<Thumbnail, Long> {
+
+    Thumbnail save(Thumbnail thumbnail);
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/common/response/PageResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/common/response/PageResponse.java
@@ -1,36 +1,38 @@
 package org.dinosaur.foodbowl.global.common.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PageResponse<T> {
+@Schema(description = "페이지 응답")
+public record PageResponse<T>(
+        @Schema(description = "페이지 응답 본문 목록")
+        List<T> content,
 
-    private List<T> content;
-    private boolean first;
-    private boolean last;
-    private boolean hasNext;
-    private int currentPageIndex;
-    private int currentElementSize;
-    private int totalPage;
-    private long totalElementCount;
+        @Schema(description = "첫 페이지 여부", example = "true")
+        boolean isFirst,
 
-    public static <T> PageResponse<T> from(Page<T> page) {
+        @Schema(description = "마지막 페이지 여부", example = "false")
+        boolean isLast,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext,
+
+        @Schema(description = "현재 페이지", example = "0")
+        int currentPage,
+
+        @Schema(description = "현재 페이지 크기", example = "20")
+        int currentSize
+) {
+
+    public static <T> PageResponse<T> from(Slice<T> slice) {
         return new PageResponse<>(
-                page.getContent(),
-                page.isFirst(),
-                page.isLast(),
-                page.hasNext(),
-                page.getNumber(),
-                page.getSize(),
-                page.getTotalPages(),
-                page.getTotalElements()
+                slice.getContent(),
+                slice.isFirst(),
+                slice.isLast(),
+                slice.hasNext(),
+                slice.getNumber(),
+                slice.getSize()
         );
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
@@ -27,64 +27,34 @@ class FollowServiceTest extends IntegrationTest {
     @Autowired
     private FollowRepository followRepository;
 
-    @Nested
-    class 팔로워_목록_조회 {
+    @Test
+    void 팔로워_목록을_페이징_조회한다() {
+        Member following = memberTestPersister.memberBuilder().save();
+        Member followerA = memberTestPersister.memberBuilder().save();
+        Member followerB = memberTestPersister.memberBuilder().save();
 
-        @Test
-        void 프로필_존재하지_않는_팔로워_목록을_조회한다() {
-            Member following = memberTestPersister.memberBuilder().save();
-            Member followerA = memberTestPersister.memberBuilder().save();
-            Member followerB = memberTestPersister.memberBuilder().save();
+        Follow followA = followTestPersister.builder().following(following).follower(followerA).save();
+        Follow followB = followTestPersister.builder().following(following).follower(followerB).save();
 
-            Follow followA = followTestPersister.builder().following(following).follower(followerA).save();
-            Follow followB = followTestPersister.builder().following(following).follower(followerB).save();
+        PageResponse<FollowResponse> response = followService.getFollowers(0, 2, following);
 
-            PageResponse<FollowResponse> response = followService.getFollowers(0, 2, following);
-
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(response.content())
-                                .usingRecursiveComparison()
-                                .isEqualTo(
-                                        List.of(
-                                                FollowResponse.from(followB.getFollower()),
-                                                FollowResponse.from(followA.getFollower())
-                                        )
-                                );
-                        softly.assertThat(response.isFirst()).isTrue();
-                        softly.assertThat(response.isLast()).isTrue();
-                        softly.assertThat(response.hasNext()).isFalse();
-                        softly.assertThat(response.currentPage()).isEqualTo(0);
-                        softly.assertThat(response.currentSize()).isEqualTo(2);
-                    }
-            );
-        }
-
-        @Test
-        void 프로필_존재하는_팔로워_목록을_조회한다() {
-            Member following = memberTestPersister.memberBuilder().save();
-            Member followerA = memberTestPersister.memberBuilder().save();
-            Member followerB = memberTestPersister.memberBuilder().save();
-
-            memberTestPersister.memberThumbnailBuilder().member(followerA).save();
-            memberTestPersister.memberThumbnailBuilder().member(followerB).save();
-
-            followTestPersister.builder().following(following).follower(followerA).save();
-            followTestPersister.builder().following(following).follower(followerB).save();
-
-            PageResponse<FollowResponse> response = followService.getFollowers(0, 2, following);
-
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(response.content()).hasSize(2);
-                        softly.assertThat(response.isFirst()).isTrue();
-                        softly.assertThat(response.isLast()).isTrue();
-                        softly.assertThat(response.hasNext()).isFalse();
-                        softly.assertThat(response.currentPage()).isEqualTo(0);
-                        softly.assertThat(response.currentSize()).isEqualTo(2);
-                    }
-            );
-        }
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(response.content())
+                            .usingRecursiveComparison()
+                            .isEqualTo(
+                                    List.of(
+                                            FollowResponse.from(followB.getFollower()),
+                                            FollowResponse.from(followA.getFollower())
+                                    )
+                            );
+                    softly.assertThat(response.isFirst()).isTrue();
+                    softly.assertThat(response.isLast()).isTrue();
+                    softly.assertThat(response.hasNext()).isFalse();
+                    softly.assertThat(response.currentPage()).isEqualTo(0);
+                    softly.assertThat(response.currentSize()).isEqualTo(2);
+                }
+        );
     }
 
     @Nested

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
@@ -2,11 +2,15 @@ package org.dinosaur.foodbowl.domain.follow.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import java.util.List;
 import java.util.Optional;
 import org.dinosaur.foodbowl.domain.follow.domain.Follow;
+import org.dinosaur.foodbowl.domain.follow.dto.response.FollowResponse;
 import org.dinosaur.foodbowl.domain.follow.persistence.FollowRepository;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
 import org.dinosaur.foodbowl.test.IntegrationTest;
@@ -22,6 +26,66 @@ class FollowServiceTest extends IntegrationTest {
 
     @Autowired
     private FollowRepository followRepository;
+
+    @Nested
+    class 팔로워_목록_조회 {
+
+        @Test
+        void 프로필_존재하지_않는_팔로워_목록을_조회한다() {
+            Member following = memberTestPersister.memberBuilder().save();
+            Member followerA = memberTestPersister.memberBuilder().save();
+            Member followerB = memberTestPersister.memberBuilder().save();
+
+            Follow followA = followTestPersister.builder().following(following).follower(followerA).save();
+            Follow followB = followTestPersister.builder().following(following).follower(followerB).save();
+
+            PageResponse<FollowResponse> response = followService.getFollowers(0, 2, following);
+
+            assertSoftly(
+                    softly -> {
+                        softly.assertThat(response.content())
+                                .usingRecursiveComparison()
+                                .isEqualTo(
+                                        List.of(
+                                                FollowResponse.from(followB.getFollower()),
+                                                FollowResponse.from(followA.getFollower())
+                                        )
+                                );
+                        softly.assertThat(response.isFirst()).isTrue();
+                        softly.assertThat(response.isLast()).isTrue();
+                        softly.assertThat(response.hasNext()).isFalse();
+                        softly.assertThat(response.currentPage()).isEqualTo(0);
+                        softly.assertThat(response.currentSize()).isEqualTo(2);
+                    }
+            );
+        }
+
+        @Test
+        void 프로필_존재하는_팔로워_목록을_조회한다() {
+            Member following = memberTestPersister.memberBuilder().save();
+            Member followerA = memberTestPersister.memberBuilder().save();
+            Member followerB = memberTestPersister.memberBuilder().save();
+
+            memberTestPersister.memberThumbnailBuilder().member(followerA).save();
+            memberTestPersister.memberThumbnailBuilder().member(followerB).save();
+
+            followTestPersister.builder().following(following).follower(followerA).save();
+            followTestPersister.builder().following(following).follower(followerB).save();
+
+            PageResponse<FollowResponse> response = followService.getFollowers(0, 2, following);
+
+            assertSoftly(
+                    softly -> {
+                        softly.assertThat(response.content()).hasSize(2);
+                        softly.assertThat(response.isFirst()).isTrue();
+                        softly.assertThat(response.isLast()).isTrue();
+                        softly.assertThat(response.hasNext()).isFalse();
+                        softly.assertThat(response.currentPage()).isEqualTo(0);
+                        softly.assertThat(response.currentSize()).isEqualTo(2);
+                    }
+            );
+        }
+    }
 
     @Nested
     class 팔로우_등록 {

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepositoryTest.java
@@ -23,7 +23,7 @@ class FollowRepositoryTest extends PersistenceTest {
     private FollowRepository followRepository;
 
     @Test
-    void 팔로워_목록_페이징_조회() {
+    void 팔로워_목록을_페이징_조회한다() {
         Member following = memberTestPersister.memberBuilder().save();
         Member followerA = memberTestPersister.memberBuilder().save();
         Member followerB = memberTestPersister.memberBuilder().save();

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.dinosaur.foodbowl.domain.follow.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.Optional;
 import org.dinosaur.foodbowl.domain.follow.domain.Follow;
@@ -10,12 +11,41 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 
 @SuppressWarnings("NonAsciiCharacters")
 class FollowRepositoryTest extends PersistenceTest {
 
     @Autowired
     private FollowRepository followRepository;
+
+    @Test
+    void 팔로워_목록_페이징_조회() {
+        Member following = memberTestPersister.memberBuilder().save();
+        Member followerA = memberTestPersister.memberBuilder().save();
+        Member followerB = memberTestPersister.memberBuilder().save();
+
+        Follow followA = followTestPersister.builder().following(following).follower(followerA).save();
+        Follow followB = followTestPersister.builder().following(following).follower(followerB).save();
+
+        Pageable pageable = PageRequest.of(0, 1, Sort.by("createdAt").descending());
+        Slice<Follow> result = followRepository.findAllByFollowing(following, pageable);
+
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(result.getContent().size()).isEqualTo(1);
+                    softly.assertThat(result.getContent().get(0)).isEqualTo(followB);
+                    softly.assertThat(result.isFirst()).isTrue();
+                    softly.assertThat(result.isLast()).isFalse();
+                    softly.assertThat(result.hasNext()).isTrue();
+                    softly.assertThat(result.getNumber()).isEqualTo(0);
+                    softly.assertThat(result.getSize()).isEqualTo(1);
+                }
+        );
+    }
 
     @Nested
     class 팔로우_연관_회원으로_조회 {

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
@@ -1,19 +1,28 @@
 package org.dinosaur.foodbowl.domain.follow.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.dinosaur.foodbowl.domain.member.domain.vo.RoleType.ROLE_회원;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.follow.application.FollowService;
+import org.dinosaur.foodbowl.domain.follow.dto.response.FollowResponse;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.test.PresentationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 @SuppressWarnings("NonAsciiCharacters")
 @WebMvcTest(FollowController.class)
@@ -32,17 +42,115 @@ class FollowControllerTest extends PresentationTest {
     private MockMvc mockMvc;
 
     @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
     @MockBean
     private FollowService followService;
 
     @Nested
+    class 팔로워_목록_조회 {
+
+        @ValueSource(strings = {"가", "a", "A", "@"})
+        @ParameterizedTest
+        void 페이지가_INT_타입으로_변환하지_못하면_400_응답을_반환한다(String page) throws Exception {
+            mockMvc.perform(get("/v1/follows/followers")
+                            .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원))
+                            .param("page", page)
+                            .param("size", "1"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-102"))
+                    .andExpect(jsonPath("$.message", containsString("int 타입으로 변환할 수 없는 요청입니다.")));
+        }
+
+        @Test
+        void 페이지가_음수라면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/follows/followers")
+                            .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원))
+                            .param("page", "-1")
+                            .param("size", "1"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message", containsString("페이지는 0이상만 가능합니다.")));
+        }
+
+        @ValueSource(strings = {"가", "a", "A", "@"})
+        @ParameterizedTest
+        void 페이지_크기가_INT_타입으로_변환하지_못하면_400_응답을_반환한다(String size) throws Exception {
+            mockMvc.perform(get("/v1/follows/followers")
+                            .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원))
+                            .param("page", "1")
+                            .param("size", size))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-102"))
+                    .andExpect(jsonPath("$.message", containsString("int 타입으로 변환할 수 없는 요청입니다.")));
+        }
+
+        @Test
+        void 페이지_크기가_음수라면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/follows/followers")
+                            .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원))
+                            .param("page", "1")
+                            .param("size", "-1"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message", containsString("페이지 크기는 0이상만 가능합니다.")));
+        }
+
+        @Test
+        void 팔로우_목록을_조회하면_200_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            PageResponse<FollowResponse> response = new PageResponse<>(
+                    List.of(new FollowResponse(
+                            1L,
+                            "http://justdoeat.shop/static/images/profile.png",
+                            "coby5502",
+                            20
+                    )),
+                    true,
+                    true,
+                    false,
+                    0,
+                    1
+            );
+            given(followService.getFollowers(anyInt(), anyInt(), any(Member.class))).willReturn(response);
+
+            MvcResult mvcResult = mockMvc.perform(get("/v1/follows/followers")
+                            .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원))
+                            .param("page", "1")
+                            .param("size", "1"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String jsonResponse = mvcResult.getResponse().getContentAsString();
+            PageResponse<FollowResponse> result = objectMapper.readValue(
+                    jsonResponse,
+                    new TypeReference<PageResponse<FollowResponse>>() {
+                    }
+            );
+
+            assertThat(result).usingRecursiveComparison().isEqualTo(response);
+        }
+    }
+
+    @Nested
     class 팔로우 {
 
         @ValueSource(strings = {"가", "a", "A", "@"})
         @ParameterizedTest
-        void ID타입으로_변환하지_못하는_타입이라면_400_응답을_반환한다(String memberId) throws Exception {
+        void ID가_LONG_타입으로_변환하지_못하면_400_응답을_반환한다(String memberId) throws Exception {
             mockMvc.perform(post("/v1/follows/{memberId}/follow", memberId)
                             .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
                     .andDo(print())
@@ -82,7 +190,7 @@ class FollowControllerTest extends PresentationTest {
 
         @ValueSource(strings = {"가", "a", "A", "@"})
         @ParameterizedTest
-        void ID타입으로_변환하지_못하는_타입이라면_400_응답을_반환한다(String memberId) throws Exception {
+        void ID가_Long타입으로_변환하지_못하면_400_응답을_반환한다(String memberId) throws Exception {
             mockMvc.perform(delete("/v1/follows/{memberId}/unfollow", memberId)
                             .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
                     .andDo(print())
@@ -122,7 +230,7 @@ class FollowControllerTest extends PresentationTest {
 
         @ValueSource(strings = {"가", "a", "A", "@"})
         @ParameterizedTest
-        void ID타입으로_변환하지_못하는_타입이라면_400_응답을_반환한다(String memberId) throws Exception {
+        void ID가_Long타입으로_변환하지_못하면_400_응답을_반환한다(String memberId) throws Exception {
             mockMvc.perform(delete("/v1/follows/followers/{memberId}", memberId)
                             .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
                     .andDo(print())

--- a/src/test/java/org/dinosaur/foodbowl/test/persister/MemberTestPersister.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/persister/MemberTestPersister.java
@@ -3,17 +3,26 @@ package org.dinosaur.foodbowl.test.persister;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.domain.MemberThumbnail;
 import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
 import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
+import org.dinosaur.foodbowl.domain.member.persistence.MemberThumbnailRepository;
+import org.dinosaur.foodbowl.domain.photo.domain.Thumbnail;
 
 @RequiredArgsConstructor
 @Persister
 public class MemberTestPersister {
 
     private final MemberRepository memberRepository;
+    private final MemberThumbnailRepository memberThumbnailRepository;
+    private final ThumbnailTestPersister thumbnailTestPersister;
 
     public MemberBuilder memberBuilder() {
         return new MemberBuilder();
+    }
+
+    public MemberThumbnailBuilder memberThumbnailBuilder() {
+        return new MemberThumbnailBuilder();
     }
 
     public final class MemberBuilder {
@@ -58,6 +67,30 @@ public class MemberTestPersister {
                     .introduction(introduction)
                     .build();
             return memberRepository.save(member);
+        }
+    }
+
+    public final class MemberThumbnailBuilder {
+
+        private Member member;
+        private Thumbnail thumbnail;
+
+        public MemberThumbnailBuilder member(Member member) {
+            this.member = member;
+            return this;
+        }
+
+        public MemberThumbnailBuilder thumbnail(Thumbnail thumbnail) {
+            this.thumbnail = thumbnail;
+            return this;
+        }
+
+        public MemberThumbnail save() {
+            MemberThumbnail memberThumbnail = MemberThumbnail.builder()
+                    .member(member == null ? memberBuilder().save() : member)
+                    .thumbnail(thumbnail == null ? thumbnailTestPersister.builder().save() : thumbnail)
+                    .build();
+            return memberThumbnailRepository.save(memberThumbnail);
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/test/persister/ThumbnailTestPersister.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/persister/ThumbnailTestPersister.java
@@ -1,0 +1,47 @@
+package org.dinosaur.foodbowl.test.persister;
+
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.photo.domain.Thumbnail;
+import org.dinosaur.foodbowl.domain.photo.persistence.ThumbnailRepository;
+
+@RequiredArgsConstructor
+@Persister
+public class ThumbnailTestPersister {
+
+    private final ThumbnailRepository thumbnailRepository;
+
+    public ThumbnailBuilder builder() {
+        return new ThumbnailBuilder();
+    }
+
+    public final class ThumbnailBuilder {
+
+        private String path;
+        private Integer width;
+        private Integer height;
+
+        public ThumbnailBuilder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public ThumbnailBuilder width(Integer width) {
+            this.width = width;
+            return this;
+        }
+
+        public ThumbnailBuilder height(Integer height) {
+            this.height = height;
+            return this;
+        }
+
+        public Thumbnail save() {
+            Thumbnail thumbnail = Thumbnail.builder()
+                    .path(path == null ? "http://justdoeat.shop/static/images/thumbnail.png" : path)
+                    .width(width == null ? 100 : width)
+                    .height(height == null ? 100 : height)
+                    .build();
+            return thumbnailRepository.save(thumbnail);
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #120

## 📝 작업 요약

팔로워 목록 조회 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 팔로워 목록 조회 시 페이징을 통해 효율적인 조회를 구성하였습니다.
- `Follow` -> `Member` -> `MemberThumbnail` -> `Thumbnail` 조인을 통해 하나의 쿼리로 유저 프로필까지 가져오도록 하였습니다.

## 🌟 리뷰 요구 사항

> 30분
> 팔로우로부터 시작되는 연관관계와 `fetch join`을 따라가면서 리뷰해주시면 감사합니다 :)