### PR TITLE
Feature/#89 Jacoco를 이용해 테스트 커버리지를 측정한다.

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -81,6 +81,16 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
+      - name: 테스트 커버리지 리포트 등록
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          title: 🪄 테스트 커버리지 리포트
+          paths: ${{ github.workspace }}/**/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ github.token }}
+          min-coverage-overall: 75
+          min-coverage-changed-files: 75
+
       - name: 테스트 성공 여부 Slack 알림
         if: always()
         uses: 8398a7/action-slack@v3

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }
 
 //Start Querydsl
@@ -84,12 +85,90 @@ jacoco {
 }
 
 jacocoTestReport {
+    dependsOn test
+
     reports {
         html.enabled true
         xml.enabled false
         csv.enabled false
+        html.destination(file("build/jacoco/reports"))
     }
 
-    dependsOn test
+    def Qdomains = []
+
+    for (qPattern in "**/QA".."**/QZ") {
+        Qdomains.add(qPattern + "*")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            '**/*Application*',
+                            '**/*Docs*',
+                            '**/*Request*',
+                            '**/*Response*',
+                            '**/*Responses*',
+                            '**/*Dto*',
+                            '**/*User.class',
+                            '**/AuditingEntity.class',
+                            '**/*Exception*',
+                            '**/*ExceptionType*',
+                            '**/*Config*',
+                            '**/*Filter*',
+                            '**/*ArgumentResolver*',
+                            '**/*Handler*',
+                            '**/*EntryPoint*'
+                    ] + Qdomains)
+                })
+        )
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    def Qdomains = []
+
+    for (qPattern in '*.QA'..'*.QZ') {
+        Qdomains.add(qPattern + '*')
+    }
+
+    violationRules {
+        rule {
+            enabled = true
+            element = "CLASS"
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            excludes = [
+                    '*.*Application',
+                    '*.*Docs',
+                    '*.*Request',
+                    '*.*Response',
+                    '*.*Responses',
+                    '*.*Dto',
+                    '*.*User',
+                    '*.*AuditingEntity',
+                    '*.*Exception',
+                    '*.*ExceptionType',
+                    '*.*Config',
+                    '*.*Filter',
+                    '*.*ArgumentResolver',
+                    '*.*Handler',
+                    '*.*EntryPoint'
+            ] + Qdomains
+        }
+    }
 }
 //End JaCoCo

--- a/build.gradle
+++ b/build.gradle
@@ -89,9 +89,8 @@ jacocoTestReport {
 
     reports {
         html.enabled true
-        xml.enabled false
+        xml.enabled true
         csv.enabled false
-        html.destination(file("build/jacoco/reports"))
     }
 
     def Qdomains = []

--- a/build.gradle
+++ b/build.gradle
@@ -142,13 +142,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.80
-            }
-
-            limit {
-                counter = 'BRANCH'
-                value = 'COVEREDRATIO'
-                minimum = 0.80
+                minimum = 0.75
             }
 
             excludes = [

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/NicknameGenerator.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/NicknameGenerator.java
@@ -1,7 +1,10 @@
 package org.dinosaur.foodbowl.domain.auth.application;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NicknameGenerator {
 
     private static final int RANDOM_NICKNAME_LENGTH = 7;

--- a/src/main/java/org/dinosaur/foodbowl/global/util/EncryptUtils.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/util/EncryptUtils.java
@@ -3,9 +3,12 @@ package org.dinosaur.foodbowl.global.util;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.global.exception.ServerException;
 import org.dinosaur.foodbowl.global.exception.ServerExceptionType;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class EncryptUtils {
 
     private static final String ENCRYPT_ALGORITHM = "SHA-256";

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/application/apple/AppleTokenParserTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/application/apple/AppleTokenParserTest.java
@@ -13,6 +13,7 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
@@ -49,6 +50,16 @@ class AppleTokenParserTest {
             Map<String, String> headers = appleTokenParser.extractHeaders(appleToken);
 
             assertThat(headers).containsKeys("alg", "kid");
+        }
+
+        @Test
+        void 유효하지_않은_헤더를_가진_토큰을_파싱하면_예외를_던진다() {
+            String invalidHeader = Base64.getUrlEncoder().encodeToString("invalid json".getBytes());
+            String appleToken = invalidHeader + ".payload.signature";
+
+            assertThatThrownBy(() -> appleTokenParser.extractHeaders(appleToken))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("헤더가 유효하지 않은 토큰입니다.");
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/domain/BlameTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/domain/BlameTest.java
@@ -1,0 +1,33 @@
+package org.dinosaur.foodbowl.domain.blame.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BlameTest {
+
+    @Test
+    void 신고를_생성한다() {
+        Member member = Member.builder()
+                .socialType(SocialType.APPLE)
+                .socialId("1")
+                .email("email@email.com")
+                .nickname("hello")
+                .introduction("hello world")
+                .build();
+        Blame blame = Blame.builder()
+                .member(member)
+                .targetId(1L)
+                .blameTarget(BlameTarget.MEMBER)
+                .build();
+
+        assertThat(blame.getMember()).isEqualTo(member);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/application/HealthCheckServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/application/HealthCheckServiceTest.java
@@ -1,0 +1,22 @@
+package org.dinosaur.foodbowl.domain.healthcheck.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.healthcheck.dto.response.HealthCheckResponse;
+import org.dinosaur.foodbowl.test.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+class HealthCheckServiceTest extends IntegrationTest {
+
+    @Autowired
+    private HealthCheckService healthCheckService;
+
+    @Test
+    void 헬스_체크를_수행한다() {
+        HealthCheckResponse response = healthCheckService.healthCheck();
+
+        assertThat(response.status()).isEqualTo("good");
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/domain/BookmarkTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/domain/BookmarkTest.java
@@ -1,0 +1,36 @@
+package org.dinosaur.foodbowl.domain.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BookmarkTest {
+
+    @Test
+    void 북마크를_생성한다() {
+        Member member = Member.builder()
+                .socialType(SocialType.APPLE)
+                .socialId("1")
+                .email("email@email.com")
+                .nickname("hello")
+                .introduction("hello world")
+                .build();
+        Store store = Store.builder()
+                .storeName("농민백암순대")
+                .storeUrl("http://foodbowl.com")
+                .phone("02-123-4567")
+                .build();
+        Bookmark bookmark = Bookmark.builder()
+                .member(member)
+                .store(store)
+                .build();
+
+        assertThat(bookmark.getStore()).isEqualTo(store);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberRoleTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberRoleTest.java
@@ -1,0 +1,35 @@
+package org.dinosaur.foodbowl.domain.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
+import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MemberRoleTest {
+
+    @Test
+    void 멤버_역할을_생성한다() {
+        Member member = Member.builder()
+                .socialType(SocialType.APPLE)
+                .socialId("1")
+                .email("email@email.com")
+                .nickname("hello")
+                .introduction("hello world")
+                .build();
+        Role role = Role.builder()
+                .id(1L)
+                .roleType(RoleType.ROLE_회원)
+                .build();
+        MemberRole memberRole = MemberRole.builder()
+                .member(member)
+                .role(role)
+                .build();
+
+        assertThat(memberRole.getMember()).isEqualTo(member);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberThumbnailTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberThumbnailTest.java
@@ -1,0 +1,36 @@
+package org.dinosaur.foodbowl.domain.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
+import org.dinosaur.foodbowl.domain.photo.domain.Thumbnail;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MemberThumbnailTest {
+
+    @Test
+    void 멤버_썸네일을_생성한다() {
+        Member member = Member.builder()
+                .socialType(SocialType.APPLE)
+                .socialId("1")
+                .email("email@email.com")
+                .nickname("hello")
+                .introduction("hello world")
+                .build();
+        Thumbnail thumbnail = Thumbnail.builder()
+                .path("http://foodbowl.com/static/images/image.png")
+                .width(100)
+                .height(100)
+                .build();
+        MemberThumbnail memberThumbnail = MemberThumbnail.builder()
+                .member(member)
+                .thumbnail(thumbnail)
+                .build();
+
+        assertThat(memberThumbnail.getMember()).isEqualTo(member);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/domain/RoleTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/domain/RoleTest.java
@@ -1,0 +1,23 @@
+package org.dinosaur.foodbowl.domain.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RoleTest {
+
+    @Test
+    void 역할을_생성한다() {
+        Role role = Role.builder()
+                .id(1L)
+                .roleType(RoleType.ROLE_회원)
+                .build();
+
+        assertThat(role.getRoleType()).isEqualTo(RoleType.ROLE_회원);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/photo/domain/ReviewPhotoTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/photo/domain/ReviewPhotoTest.java
@@ -1,0 +1,29 @@
+package org.dinosaur.foodbowl.domain.photo.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.review.domain.Review;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ReviewPhotoTest {
+
+    @Test
+    void 리뷰_사진을_생성한다() {
+        Photo photo = Photo.builder()
+                .path("http://foodbowl.com/static/images/image.png")
+                .build();
+        Review review = Review.builder()
+                .content("맛있어요")
+                .build();
+        ReviewPhoto reviewPhoto = ReviewPhoto.builder()
+                .photo(photo)
+                .review(review)
+                .build();
+
+        assertThat(reviewPhoto.getReview()).isEqualTo(review);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/photo/domain/ThumbnailTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/photo/domain/ThumbnailTest.java
@@ -1,0 +1,23 @@
+package org.dinosaur.foodbowl.domain.photo.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ThumbnailTest {
+
+    @Test
+    void 썸네일을_생성한다() {
+        Thumbnail thumbnail = Thumbnail.builder()
+                .path("http://foodbowl.com/static/images/image.png")
+                .width(100)
+                .height(100)
+                .build();
+
+        assertThat(thumbnail.getPath()).isEqualTo("http://foodbowl.com/static/images/image.png");
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/domain/ReviewTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/domain/ReviewTest.java
@@ -1,0 +1,38 @@
+package org.dinosaur.foodbowl.domain.review.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ReviewTest {
+
+    @Test
+    void 리뷰를_생성한다() {
+        Member member = Member.builder()
+                .socialType(SocialType.APPLE)
+                .socialId("1")
+                .email("email@email.com")
+                .nickname("hello")
+                .introduction("hello world")
+                .build();
+        Store store = Store.builder()
+                .storeName("농민백암순대")
+                .storeUrl("http://foodbowl.com")
+                .phone("02-123-4567")
+                .build();
+        Review review = Review.builder()
+                .member(member)
+                .store(store)
+                .content("맛있어요")
+                .build();
+
+        assertThat(review.getContent()).isEqualTo("맛있어요");
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -1,0 +1,22 @@
+package org.dinosaur.foodbowl.domain.store.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.store.dto.response.CategoryResponses;
+import org.dinosaur.foodbowl.test.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+class StoreServiceTest extends IntegrationTest {
+
+    @Autowired
+    private StoreService storeService;
+
+    @Test
+    void 카테고리_목록을_조회한다() {
+        CategoryResponses response = storeService.getCategories();
+
+        assertThat(response.categories()).hasSize(11);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/CategoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/CategoryTest.java
@@ -1,0 +1,23 @@
+package org.dinosaur.foodbowl.domain.store.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dinosaur.foodbowl.domain.store.domain.vo.CategoryType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CategoryTest {
+
+    @Test
+    void 카테고리를_생성한다() {
+        Category category = Category.builder()
+                .id(1L)
+                .categoryType(CategoryType.카페)
+                .build();
+
+        assertThat(category.getName()).isEqualTo("카페");
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/SchoolTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/SchoolTest.java
@@ -1,0 +1,24 @@
+package org.dinosaur.foodbowl.domain.store.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SchoolTest {
+
+    @Test
+    void 학교를_생성한다() {
+        School school = School.builder()
+                .name("부산대학교")
+                .x(BigDecimal.valueOf(124.1234))
+                .y(BigDecimal.valueOf(34.545))
+                .build();
+
+        assertThat(school.getName()).isEqualTo("부산대학교");
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/StoreSchoolTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/StoreSchoolTest.java
@@ -1,0 +1,33 @@
+package org.dinosaur.foodbowl.domain.store.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StoreSchoolTest {
+
+    @Test
+    void 가게_학교_정보를_생성한다() {
+        Store store = Store.builder()
+                .storeName("농민백암순대")
+                .storeUrl("http://foodbowl.com")
+                .phone("02-123-4567")
+                .build();
+        School school = School.builder()
+                .name("부산대학교")
+                .x(BigDecimal.valueOf(124.1234))
+                .y(BigDecimal.valueOf(34.545))
+                .build();
+        StoreSchool storeSchool = StoreSchool.builder()
+                .store(store)
+                .school(school)
+                .build();
+
+        assertThat(storeSchool.getSchool()).isEqualTo(school);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/StoreTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/StoreTest.java
@@ -1,0 +1,41 @@
+package org.dinosaur.foodbowl.domain.store.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.dinosaur.foodbowl.domain.store.domain.vo.Address;
+import org.dinosaur.foodbowl.domain.store.domain.vo.CategoryType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StoreTest {
+
+    @Test
+    void 가게를_생성한다() {
+        Category category = Category.builder()
+                .id(1L)
+                .categoryType(CategoryType.카페)
+                .build();
+        Address address = Address.builder()
+                .addressName("서울시 강남구 선릉로 14번길 245")
+                .region1depthName("서울시")
+                .region2depthName("강남구")
+                .region3depthName("선릉로")
+                .roadName("14번길 245")
+                .x(BigDecimal.valueOf(123.124))
+                .y(BigDecimal.valueOf(37.4545))
+                .build();
+        Store store = Store.builder()
+                .category(category)
+                .storeName("농민백암순대")
+                .address(address)
+                .storeUrl("http://foodbowl.com")
+                .phone("02-123-4567")
+                .build();
+
+        assertThat(store.getStoreName()).isEqualTo("농민백암순대");
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #89

## 📝 작업 요약

Jacoco를 이용해 테스트 커버리지 측정하도록 구현하였습니다.

## 🔎 작업 상세 설명

현재 각 클래스의 라인 테스트 커버리지가 `75%`는 되어야 통과되도록 구현하였습니다.
- `75%`로 설정한 이유는 `3/4` 정도의 라인을 테스트함을 의미하기에 충분할 것 같기도 하고, 몇몇 발생하지 않는 `Exception`으로 인해 `80%`를 억지로 채워야 하는 클래스들이 존재해서 `75%`로 설정하게 되었는데 이 부분에 대해서도 같이 리뷰하면서 얘기해주시면 감사하겠습니다 :)

## 🌟 리뷰 요구 사항

> 10분
> 라인외에도 구분(분기에 대한) 커버리지도 설정할 수 있는데 추가적으로 커버리지 측정이 필요한 부분이 있다면 얘기해주세요 ㅎㅎ