### PR TITLE
Feature/#143 사진 로컬 이미지 경로를 설정한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/application/PhotoLocalUploader.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/application/PhotoLocalUploader.java
@@ -39,9 +39,9 @@ public class PhotoLocalUploader implements PhotoUploader {
         this.fileDirectory = fileDirectory;
     }
 
-    public List<String> upload(List<MultipartFile> files, String parentDirectory) {
+    public List<String> upload(List<MultipartFile> files, String workingDirectory) {
         File directory =
-                loadDirectory(System.getProperty("user.dir") + SLASH + fileDirectory + SLASH + parentDirectory);
+                loadDirectory(System.getProperty("user.dir") + SLASH + fileDirectory + SLASH + workingDirectory);
 
         List<String> filePaths = new ArrayList<>();
         for (MultipartFile multipartFile : files) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/application/PhotoLocalUploader.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/application/PhotoLocalUploader.java
@@ -28,15 +28,20 @@ public class PhotoLocalUploader implements PhotoUploader {
     private static final String UNDER_BAR = "_";
     private static final String DOT = ".";
 
+    private final String url;
     private final String fileDirectory;
 
-    public PhotoLocalUploader(@Value("${file.dir}") String fileDirectory) {
+    public PhotoLocalUploader(
+            @Value("${openapi.dev_url}") String url,
+            @Value("${file.dir}") String fileDirectory
+    ) {
+        this.url = url;
         this.fileDirectory = fileDirectory;
     }
 
     public List<String> upload(List<MultipartFile> files, String parentDirectory) {
-        File directory = loadDirectory(
-                System.getProperty("user.dir") + SLASH + fileDirectory + SLASH + parentDirectory);
+        File directory =
+                loadDirectory(System.getProperty("user.dir") + SLASH + fileDirectory + SLASH + parentDirectory);
 
         List<String> filePaths = new ArrayList<>();
         for (MultipartFile multipartFile : files) {
@@ -50,7 +55,7 @@ public class PhotoLocalUploader implements PhotoUploader {
 
             File uploadPath = new File(directory, saveFileName);
             transferFile(multipartFile, uploadPath);
-            filePaths.add(uploadPath.getPath());
+            filePaths.add(getImageFullPath(uploadPath.getPath()));
         }
         return filePaths;
     }
@@ -81,7 +86,7 @@ public class PhotoLocalUploader implements PhotoUploader {
         if (lastIndex < 0) {
             throw new FileException(FILE_FORMAT_ERROR);
         }
-        String fileBaseName = UUID.randomUUID().toString().substring(0, 7);
+        String fileBaseName = UUID.randomUUID().toString().substring(0, 8);
         String extension = originalFilename.substring(lastIndex + 1);
         validateFileName(fileBaseName);
         validateExtension(extension);
@@ -107,5 +112,9 @@ public class PhotoLocalUploader implements PhotoUploader {
         } catch (IOException e) {
             throw new FileException(FILE_TRANSFER_ERROR, e);
         }
+    }
+
+    private String getImageFullPath(String imageLocalPath) {
+        return url + SLASH + imageLocalPath;
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -8,6 +8,7 @@ import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.ReviewService;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,7 +25,7 @@ public class ReviewController implements ReviewControllerDocs {
 
     private final ReviewService reviewService;
 
-    @PostMapping
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<Void> create(
             @RequestPart(name = "request") @Valid ReviewCreateRequest reviewCreateRequest,
             @RequestPart(name = "images", required = false)


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #143

## 📝 작업 요약

사진 로컬 이미지 경로를 설정하였습니다.

## 🔎 작업 상세 설명

- `S3`를 사용하면 아마존 `URL`이 앞에 붙듯 로컬에서는 개발서버의 `URL`을 디렉토리 경로 앞에 붙여 저장되도록 하였습니다.
- 노션의 `application.yml` 페이지를 업데이트하였습니다! 확인 후 로컬에서도 변경해주시면 감사합니다 :)
- 노션의 `CICD` 페이지에서
  - `.env.app`에 `FILE_PATH`를 추가하였습니다.
  - `docker-compose.yml`에서 `volume`을 사용하여 nginx, app, 물리 서버의 `CDN`을 구축하였습니다.
  - `default.conf`에서 요청이 이미지 경로 요청인 경우 정적 이미지를 반환하도록 라우팅하였습니다.

## 🌟 리뷰 요구 사항

> 10분
> 궁금한 점이나 개선할 부분은 언제든 말해주세요 :)