### PR TITLE
Feature/#138 타인의 팔로잉 목록 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/dto/response/OtherUserFollowingResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/dto/response/OtherUserFollowingResponse.java
@@ -1,0 +1,33 @@
+package org.dinosaur.foodbowl.domain.follow.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+
+@Schema(description = "다른 회원 팔로잉 응답")
+public record OtherUserFollowingResponse(
+        @Schema(description = "회원 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "이미지 URL", example = "http://justdoeat.shop/static/images/profile.png")
+        String profileImageUrl,
+
+        @Schema(description = "닉네임", example = "coby5502")
+        String nickname,
+
+        @Schema(description = "팔로워 수", example = "20")
+        int followerCount,
+
+        @Schema(description = "팔로잉 여부", example = "true")
+        boolean isFollowing
+) {
+
+    public static OtherUserFollowingResponse of(Member following, boolean isFollowing) {
+        return new OtherUserFollowingResponse(
+                following.getId(),
+                following.getProfileImageUrl(),
+                following.getNickname(),
+                following.getFollowerCount(),
+                isFollowing
+        );
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
@@ -7,6 +7,7 @@ import org.dinosaur.foodbowl.domain.follow.application.FollowService;
 import org.dinosaur.foodbowl.domain.follow.dto.response.FollowerResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.FollowingResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowerResponse;
+import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowingResponse;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.global.presentation.Auth;
@@ -35,6 +36,18 @@ public class FollowController implements FollowControllerDocs {
             @Auth Member loginMember
     ) {
         PageResponse<FollowingResponse> response = followService.getFollowings(page, size, loginMember);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{memberId}/followings")
+    public ResponseEntity<PageResponse<OtherUserFollowingResponse>> getOtherUserFollowings(
+            @PathVariable("memberId") @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
+            @RequestParam(defaultValue = "0") @PositiveOrZero(message = "페이지는 0이상만 가능합니다.") int page,
+            @RequestParam(defaultValue = "15") @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.") int size,
+            @Auth Member loginMember
+    ) {
+        PageResponse<OtherUserFollowingResponse> response =
+                followService.getOtherUserFollowings(targetMemberId, page, size, loginMember);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import org.dinosaur.foodbowl.domain.follow.dto.response.FollowerResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.FollowingResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowerResponse;
+import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowingResponse;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.global.exception.ExceptionResponse;
@@ -43,6 +44,48 @@ public interface FollowControllerDocs {
             )
     })
     ResponseEntity<PageResponse<FollowingResponse>> getFollowings(
+            @Parameter(description = "페이지", example = "0")
+            @PositiveOrZero(message = "페이지는 0이상만 가능합니다.")
+            int page,
+
+            @Parameter(description = "페이지 크기", example = "15")
+            @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.")
+            int size,
+
+            Member loginMember
+    );
+
+    @Operation(summary = "다른 회원 팔로잉 목록 조회", description = "정해진 개수만큼 다른 회원의 팔로잉 목록을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "다른 회원 팔로잉 목록 조회 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.올바르지 않은 멤버 ID 타입
+                                                        
+                            2.양수가 아닌 멤버 ID
+                                                        
+                            3.올바르지 않은 페이지 타입
+                                                        
+                            4.음수 페이지
+                                                        
+                            5.올바르지 않은 페이지 크기 타입
+                                                        
+                            6.음수 페이지 크기
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "등록되지 않은 다른 회원 ID",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+    })
+    ResponseEntity<PageResponse<OtherUserFollowingResponse>> getOtherUserFollowings(
+            @Parameter(description = "다른 회원 ID", example = "1")
+            @Positive(message = "ID는 양수만 가능합니다.")
+            Long targetMemberId,
+
             @Parameter(description = "페이지", example = "0")
             @PositiveOrZero(message = "페이지는 0이상만 가능합니다.")
             int page,

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/application/PhotoLocalUploader.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/application/PhotoLocalUploader.java
@@ -55,7 +55,6 @@ public class PhotoLocalUploader implements PhotoUploader {
 
             File uploadPath = new File(directory, saveFileName);
             transferFile(multipartFile, uploadPath);
-            System.out.println(uploadPath.getPath());
             filePaths.add(getImageFullPath(workingDirectory, saveFileName));
         }
         return filePaths;

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/application/PhotoLocalUploader.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/application/PhotoLocalUploader.java
@@ -27,6 +27,7 @@ public class PhotoLocalUploader implements PhotoUploader {
     private static final String SLASH = File.separator;
     private static final String UNDER_BAR = "_";
     private static final String DOT = ".";
+    private static final String SYSTEM_PATH = System.getProperty("user.dir");
 
     private final String url;
     private final String fileDirectory;
@@ -40,8 +41,7 @@ public class PhotoLocalUploader implements PhotoUploader {
     }
 
     public List<String> upload(List<MultipartFile> files, String workingDirectory) {
-        File directory =
-                loadDirectory(System.getProperty("user.dir") + SLASH + fileDirectory + SLASH + workingDirectory);
+        File directory = loadDirectory(getImageStorePath(workingDirectory));
 
         List<String> filePaths = new ArrayList<>();
         for (MultipartFile multipartFile : files) {
@@ -55,9 +55,18 @@ public class PhotoLocalUploader implements PhotoUploader {
 
             File uploadPath = new File(directory, saveFileName);
             transferFile(multipartFile, uploadPath);
-            filePaths.add(getImageFullPath(uploadPath.getPath()));
+            System.out.println(uploadPath.getPath());
+            filePaths.add(getImageFullPath(workingDirectory, saveFileName));
         }
         return filePaths;
+    }
+
+    private String getImageStorePath(String workingDirectory) {
+        return SYSTEM_PATH + SLASH + fileDirectory + SLASH + workingDirectory;
+    }
+
+    private String getImageFullPath(String workingDirectory, String fileName) {
+        return url + SLASH + fileDirectory + SLASH + workingDirectory + SLASH + fileName;
     }
 
     private File loadDirectory(String directoryLocation) {
@@ -112,9 +121,5 @@ public class PhotoLocalUploader implements PhotoUploader {
         } catch (IOException e) {
             throw new FileException(FILE_TRANSFER_ERROR, e);
         }
-    }
-
-    private String getImageFullPath(String imageLocalPath) {
-        return url + SLASH + imageLocalPath;
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #138

## 📝 작업 요약

타인의 팔로잉 목록 조회 기능을 구현하였습니다.

## 🔎 작업 상세 설명

1. 등록되지 않은 회원의 팔로잉 목록을 조회하면 예외가 발생합니다.
2. 팔로잉 목록 조회 시 내가 그 회원을 팔로잉하고 있는지 여부를 보여줍니다.

## 🌟 리뷰 요구 사항

> 10분
> 이전 팔로워 목록 조회와 거의 동일합니다 :)