### PR TITLE
Feature/#141 인증 토큰 갱신 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.application.apple.AppleOAuthUserProvider;
 import org.dinosaur.foodbowl.domain.auth.application.dto.AppleUser;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
-import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenValid;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.AppleLoginRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.RenewTokenRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.response.RenewTokenResponse;
@@ -84,10 +83,7 @@ public class AuthService {
     }
 
     private void validateRefreshToken(String savedRefreshToken, String refreshToken) {
-        JwtTokenValid refreshTokenValid = jwtTokenProvider.validateToken(refreshToken);
-        if (!refreshTokenValid.isValid()) {
-            throw new AuthenticationException(refreshTokenValid.exceptionType());
-        }
+        jwtTokenProvider.extractValidClaims(refreshToken);
         if (!Objects.equals(savedRefreshToken, refreshToken)) {
             throw new AuthenticationException(AuthExceptionType.NOT_MATCH_REFRESH_TOKEN);
         }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -84,6 +84,9 @@ public class AuthService {
 
     private void validateRefreshToken(String savedRefreshToken, String refreshToken) {
         jwtTokenProvider.extractValidClaims(refreshToken);
+        if (savedRefreshToken == null) {
+            throw new AuthenticationException(AuthExceptionType.EXPIRED_REFRESH_TONE);
+        }
         if (!Objects.equals(savedRefreshToken, refreshToken)) {
             throw new AuthenticationException(AuthExceptionType.NOT_MATCH_REFRESH_TOKEN);
         }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -73,6 +73,7 @@ public class AuthService {
         return nickname;
     }
 
+    @Transactional
     public RenewTokenResponse renewToken(RenewTokenRequest renewTokenRequest) {
         String memberId = jwtTokenProvider.extractSubject(renewTokenRequest.accessToken());
         String savedRefreshToken = (String) redisTemplate.opsForValue().get(memberId);

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenProvider.java
@@ -74,13 +74,15 @@ public class JwtTokenProvider {
 
     public String extractSubject(String token) {
         JwtTokenValid jwtTokenValid = validateToken(token);
-        if (!jwtTokenValid.isValid()) {
+        if (!jwtTokenValid.isValid() && jwtTokenValid.exceptionType() != AuthExceptionType.EXPIRED_JWT) {
             throw new AuthenticationException(jwtTokenValid.exceptionType());
         }
 
-        return jwtParser.parseClaimsJws(token)
-                .getBody()
-                .getSubject();
+        try {
+            return jwtParser.parseClaimsJws(token).getBody().getSubject();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getSubject();
+        }
     }
 
     public Optional<Claims> extractClaims(String token) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenValid.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenValid.java
@@ -1,4 +1,6 @@
 package org.dinosaur.foodbowl.domain.auth.application.jwt;
 
-public record JwtTokenValid(boolean isValid, String errorCode, String message) {
+import org.dinosaur.foodbowl.global.exception.ExceptionType;
+
+public record JwtTokenValid(boolean isValid, ExceptionType exceptionType) {
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenValid.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenValid.java
@@ -1,6 +1,0 @@
-package org.dinosaur.foodbowl.domain.auth.application.jwt;
-
-import org.dinosaur.foodbowl.global.exception.ExceptionType;
-
-public record JwtTokenValid(boolean isValid, ExceptionType exceptionType) {
-}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/reqeust/RenewTokenRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/reqeust/RenewTokenRequest.java
@@ -1,0 +1,16 @@
+package org.dinosaur.foodbowl.domain.auth.dto.reqeust;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "인증 토큰 갱신 요청")
+public record RenewTokenRequest(
+        @Schema(description = "만료된 인증 토큰", example = "A1B2C3D3")
+        @NotBlank(message = "인증 토큰이 존재하지 않습니다.")
+        String accessToken,
+
+        @Schema(description = "갱신을 위한 리프레쉬 토큰", example = "A1B2C3D3")
+        @NotBlank(message = "리프레쉬 토큰이 존재하지 않습니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/RenewTokenResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/dto/response/RenewTokenResponse.java
@@ -1,0 +1,10 @@
+package org.dinosaur.foodbowl.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "인증 토큰 갱신 응답")
+public record RenewTokenResponse(
+        @Schema(description = "갱신된 인증 토큰", example = "A1B2C3D4")
+        String accessToken
+) {
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/exception/AuthExceptionType.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/exception/AuthExceptionType.java
@@ -16,7 +16,8 @@ public enum AuthExceptionType implements ExceptionType {
     INVALID_APPLE_KEY("AUTH-107", "유효하지 않은 애플 키입니다."),
     NOT_AUTHENTICATION("AUTH-108", "인증에 실패하였습니다."),
     FORBIDDEN("AUTH-109", "권한이 없는 회원입니다."),
-    INVALID_BASE64_DECODE("AUTH-110", "Base64로 디코딩할 수 없는 값입니다.");
+    INVALID_BASE64_DECODE("AUTH-110", "Base64로 디코딩할 수 없는 값입니다."),
+    NOT_MATCH_REFRESH_TOKEN("AUTH-111", "리프레쉬 토큰이 일치하지 않습니다.");
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/exception/AuthExceptionType.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/exception/AuthExceptionType.java
@@ -17,7 +17,8 @@ public enum AuthExceptionType implements ExceptionType {
     NOT_AUTHENTICATION("AUTH-108", "인증에 실패하였습니다."),
     FORBIDDEN("AUTH-109", "권한이 없는 회원입니다."),
     INVALID_BASE64_DECODE("AUTH-110", "Base64로 디코딩할 수 없는 값입니다."),
-    NOT_MATCH_REFRESH_TOKEN("AUTH-111", "리프레쉬 토큰이 일치하지 않습니다.");
+    NOT_MATCH_REFRESH_TOKEN("AUTH-111", "리프레쉬 토큰이 일치하지 않습니다."),
+    EXPIRED_REFRESH_TONE("AUTH-112", "리프레쉬 토큰 저장이 만료되었습니다.");
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthController.java
@@ -4,6 +4,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.reqeust.RenewTokenRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.RenewTokenResponse;
 import org.dinosaur.foodbowl.domain.auth.dto.response.TokenResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,6 +23,12 @@ public class AuthController implements AuthControllerDocs {
     @PostMapping("/login/oauth/apple")
     public ResponseEntity<TokenResponse> appleLogin(@RequestBody @Valid AppleLoginRequest appleLoginRequest) {
         TokenResponse response = authService.appleLogin(appleLoginRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/token/renew")
+    public ResponseEntity<RenewTokenResponse> renewToken(@RequestBody @Valid RenewTokenRequest renewTokenRequest) {
+        RenewTokenResponse response = authService.renewToken(renewTokenRequest);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerDocs.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.reqeust.RenewTokenRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.RenewTokenResponse;
 import org.dinosaur.foodbowl.domain.auth.dto.response.TokenResponse;
 import org.dinosaur.foodbowl.global.exception.ExceptionResponse;
 import org.springframework.http.ResponseEntity;
@@ -32,4 +34,33 @@ public interface AuthControllerDocs {
             )
     })
     ResponseEntity<TokenResponse> appleLogin(AppleLoginRequest appleLoginRequest);
+
+    @Operation(summary = "인증 토큰 갱신", description = "리프레쉬 토큰을 통해 인증 토큰을 갱신한다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "인증 토큰 갱신 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.존재하지 않거나 공백의 인증 토큰 요청
+                                                        
+                            2.존재하지 않거나 공백의 리프레쉬 토큰 요청
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            1.유효하지 않은 인증 토큰
+                                                        
+                            2.유효하지 않은 리프레쉬 토큰
+                                                        
+                            3.인증 토큰에 맞지 않은 리프레쉬 토큰
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<RenewTokenResponse> renewToken(RenewTokenRequest renewTokenRequest);
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/application/HealthCheckService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/application/HealthCheckService.java
@@ -4,10 +4,10 @@ import org.dinosaur.foodbowl.domain.healthcheck.dto.response.HealthCheckResponse
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional(readOnly = true)
 @Service
 public class HealthCheckService {
 
+    @Transactional(readOnly = true)
     public HealthCheckResponse healthCheck() {
         return new HealthCheckResponse("good");
     }

--- a/src/main/java/org/dinosaur/foodbowl/global/config/SecurityConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests()
                 .requestMatchers(SWAGGER_URL).permitAll()
                 .requestMatchers("/v1/health-check").permitAll()
-                .requestMatchers("/v1/auth/login/oauth/apple").permitAll()
+                .requestMatchers("/v1/auth/login/oauth/apple", "/v1/auth/token/renew").permitAll()
                 .anyRequest().hasRole("회원")
                 .and()
                 .httpBasic().disable()

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenProviderTest.java
@@ -102,12 +102,10 @@ class JwtTokenProviderTest {
 
             JwtTokenValid result = jwtTokenProvider.validateToken(token);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(result.isValid()).isTrue();
-                        softly.assertThat(result.exceptionType()).isNull();
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(result.isValid()).isTrue();
+                softly.assertThat(result.exceptionType()).isNull();
+            });
         }
 
         @Test
@@ -125,12 +123,10 @@ class JwtTokenProviderTest {
 
             JwtTokenValid result = jwtTokenProvider.validateToken(token);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(result.isValid()).isFalse();
-                        softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.EXPIRED_JWT);
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(result.isValid()).isFalse();
+                softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.EXPIRED_JWT);
+            });
         }
 
         @Test
@@ -139,12 +135,10 @@ class JwtTokenProviderTest {
 
             JwtTokenValid result = jwtTokenProvider.validateToken(token);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(result.isValid()).isFalse();
-                        softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.MALFORMED_JWT);
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(result.isValid()).isFalse();
+                softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.MALFORMED_JWT);
+            });
         }
 
         @Test
@@ -155,12 +149,10 @@ class JwtTokenProviderTest {
 
             JwtTokenValid result = jwtTokenProvider.validateToken(token);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(result.isValid()).isFalse();
-                        softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.UNSUPPORTED_JWT);
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(result.isValid()).isFalse();
+                softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.UNSUPPORTED_JWT);
+            });
         }
 
         @Test
@@ -179,12 +171,10 @@ class JwtTokenProviderTest {
 
             JwtTokenValid result = jwtTokenProvider.validateToken(token);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(result.isValid()).isFalse();
-                        softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.SIGNATURE_JWT);
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(result.isValid()).isFalse();
+                softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.SIGNATURE_JWT);
+            });
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/application/jwt/JwtTokenProviderTest.java
@@ -1,11 +1,20 @@
 package org.dinosaur.foodbowl.domain.auth.application.jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.Optional;
+import javax.crypto.SecretKey;
+import org.dinosaur.foodbowl.domain.auth.exception.AuthExceptionType;
 import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
+import org.dinosaur.foodbowl.global.exception.AuthenticationException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -15,8 +24,9 @@ import org.junit.jupiter.api.Test;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class JwtTokenProviderTest {
 
+    private static final String secretKey = "5kA0iR3h8K5Z0cS9F6V6t2mE8J4mI1oR7iA9cH2vG5pE8H3lR7yU1tE7C8lO1aV2";
     private static final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(
-            "5kA0iR3h8K5Z0cS9F6V6t2mE8J4mI1oR7iA9cH2vG5pE8H3lR7yU1tE7C8lO1aV2",
+            secretKey,
             60000,
             300000
     );
@@ -42,6 +52,26 @@ class JwtTokenProviderTest {
     }
 
     @Nested
+    class 클레임_주제_추출 {
+
+        @Test
+        void 유효한_토큰이라면_클레임_주제를_추출해서_반환한다() {
+            String token = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+            String result = jwtTokenProvider.extractSubject(token);
+
+            assertThat(result).isEqualTo("1");
+        }
+
+        @Test
+        void 유효하지_않은_토큰이라면_예외를_던진다() {
+            assertThatThrownBy(() -> jwtTokenProvider.extractSubject("invalid token"))
+                    .isInstanceOf(AuthenticationException.class)
+                    .hasMessage("손상된 토큰입니다.");
+        }
+    }
+
+    @Nested
     class 클레임_추출 {
 
         @Test
@@ -60,6 +90,101 @@ class JwtTokenProviderTest {
             Optional<Claims> result = jwtTokenProvider.extractClaims(token);
 
             assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    class 토큰_검증 {
+
+        @Test
+        void 유효한_토큰이라면_검증결과로_true_반환한다() {
+            String token = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+            JwtTokenValid result = jwtTokenProvider.validateToken(token);
+
+            assertSoftly(
+                    softly -> {
+                        softly.assertThat(result.isValid()).isTrue();
+                        softly.assertThat(result.exceptionType()).isNull();
+                    }
+            );
+        }
+
+        @Test
+        void 유효시간이_지난_토큰이라면_검증결과로_false_반환한다() {
+            SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+            Claims claims = Jwts.claims().setSubject(String.valueOf(1L));
+            Date now = new Date();
+            Date expiredDate = new Date(now.getTime() - 10000);
+            String token = Jwts.builder()
+                    .setClaims(claims)
+                    .setIssuedAt(now)
+                    .setExpiration(expiredDate)
+                    .signWith(key, SignatureAlgorithm.HS256)
+                    .compact();
+
+            JwtTokenValid result = jwtTokenProvider.validateToken(token);
+
+            assertSoftly(
+                    softly -> {
+                        softly.assertThat(result.isValid()).isFalse();
+                        softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.EXPIRED_JWT);
+                    }
+            );
+        }
+
+        @Test
+        void 손상된_토큰이라면_검증결과로_false_반환한다() {
+            String token = "invalid token";
+
+            JwtTokenValid result = jwtTokenProvider.validateToken(token);
+
+            assertSoftly(
+                    softly -> {
+                        softly.assertThat(result.isValid()).isFalse();
+                        softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.MALFORMED_JWT);
+                    }
+            );
+        }
+
+        @Test
+        void 지원하지_않는_토큰이라면_검증결과로_false_반환한다() {
+            String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+            String[] splitToken = accessToken.split("\\.");
+            String token = splitToken[0] + "." + splitToken[1] + ".";
+
+            JwtTokenValid result = jwtTokenProvider.validateToken(token);
+
+            assertSoftly(
+                    softly -> {
+                        softly.assertThat(result.isValid()).isFalse();
+                        softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.UNSUPPORTED_JWT);
+                    }
+            );
+        }
+
+        @Test
+        void 시그니처_검증에_실패한_토큰이라면_검증결과로_false_반환한다() {
+            String otherSecretKey = "5kA0iR3h8K5Z0cS9F6V6t2mE8J4mI1oR7iA9cH2vG5pE8H3lR7yU1tE7C8lO1aV3";
+            SecretKey key = Keys.hmacShaKeyFor(otherSecretKey.getBytes(StandardCharsets.UTF_8));
+            Claims claims = Jwts.claims().setSubject(String.valueOf(1L));
+            Date now = new Date();
+            Date expiredDate = new Date(now.getTime() + 10000);
+            String token = Jwts.builder()
+                    .setClaims(claims)
+                    .setIssuedAt(now)
+                    .setExpiration(expiredDate)
+                    .signWith(key, SignatureAlgorithm.HS256)
+                    .compact();
+
+            JwtTokenValid result = jwtTokenProvider.validateToken(token);
+
+            assertSoftly(
+                    softly -> {
+                        softly.assertThat(result.isValid()).isFalse();
+                        softly.assertThat(result.exceptionType()).isEqualTo(AuthExceptionType.SIGNATURE_JWT);
+                    }
+            );
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package org.dinosaur.foodbowl.domain.auth.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -11,6 +12,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.AppleLoginRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.reqeust.RenewTokenRequest;
+import org.dinosaur.foodbowl.domain.auth.dto.response.RenewTokenResponse;
 import org.dinosaur.foodbowl.domain.auth.dto.response.TokenResponse;
 import org.dinosaur.foodbowl.test.PresentationTest;
 import org.junit.jupiter.api.Nested;
@@ -22,6 +25,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 @SuppressWarnings("NonAsciiCharacters")
 @WebMvcTest(AuthController.class)
@@ -66,6 +70,56 @@ class AuthControllerTest extends PresentationTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
                     .andExpect(jsonPath("$.message", containsString("애플 토큰이 존재하지 않습니다.")));
+        }
+    }
+
+    @Nested
+    class 인증_토큰_갱신 {
+
+        @Test
+        void 인증_토큰_갱신에_성공하면_인증_토큰과_200_응답을_반환한다() throws Exception {
+            RenewTokenRequest request = new RenewTokenRequest("AccessToken", "RefreshToken");
+            RenewTokenResponse response = new RenewTokenResponse("RenewAccessToken");
+            given(authService.renewToken(any(RenewTokenRequest.class))).willReturn(response);
+
+            MvcResult mvcResult = mockMvc.perform(post("/v1/auth/token/renew")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+            String jsonResponse = mvcResult.getResponse().getContentAsString();
+            RenewTokenResponse result = objectMapper.readValue(jsonResponse, RenewTokenResponse.class);
+
+            assertThat(result).usingRecursiveComparison().isEqualTo(response);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void 인증_토큰이_공백이거나_존재하지_않으면_400_응답을_반환한다(String accessToken) throws Exception {
+            RenewTokenRequest request = new RenewTokenRequest(accessToken, "RefreshToken");
+
+            mockMvc.perform(post("/v1/auth/token/renew")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
+                    .andExpect(jsonPath("$.message", containsString("인증 토큰이 존재하지 않습니다.")));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void 리프레쉬_토큰이_공백이거나_존재하지_않으면_400_응답을_반환한다(String refreshToken) throws Exception {
+            RenewTokenRequest request = new RenewTokenRequest("AccessToken", refreshToken);
+
+            mockMvc.perform(post("/v1/auth/token/renew")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
+                    .andExpect(jsonPath("$.message", containsString("리프레쉬 토큰이 존재하지 않습니다.")));
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
@@ -41,23 +41,21 @@ class FollowServiceTest extends IntegrationTest {
 
         PageResponse<FollowingResponse> response = followService.getFollowings(0, 2, follower);
 
-        assertSoftly(
-                softly -> {
-                    softly.assertThat(response.content())
-                            .usingRecursiveComparison()
-                            .isEqualTo(
-                                    List.of(
-                                            FollowingResponse.from(followB.getFollowing()),
-                                            FollowingResponse.from(followA.getFollowing())
-                                    )
-                            );
-                    softly.assertThat(response.isFirst()).isTrue();
-                    softly.assertThat(response.isLast()).isTrue();
-                    softly.assertThat(response.hasNext()).isFalse();
-                    softly.assertThat(response.currentPage()).isEqualTo(0);
-                    softly.assertThat(response.currentSize()).isEqualTo(2);
-                }
-        );
+        assertSoftly(softly -> {
+            softly.assertThat(response.content())
+                    .usingRecursiveComparison()
+                    .isEqualTo(
+                            List.of(
+                                    FollowingResponse.from(followB.getFollowing()),
+                                    FollowingResponse.from(followA.getFollowing())
+                            )
+                    );
+            softly.assertThat(response.isFirst()).isTrue();
+            softly.assertThat(response.isLast()).isTrue();
+            softly.assertThat(response.hasNext()).isFalse();
+            softly.assertThat(response.currentPage()).isEqualTo(0);
+            softly.assertThat(response.currentSize()).isEqualTo(2);
+        });
     }
 
     @Nested
@@ -77,22 +75,20 @@ class FollowServiceTest extends IntegrationTest {
             PageResponse<OtherUserFollowingResponse> response =
                     followService.getOtherUserFollowings(follower.getId(), 0, 2, member);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(response.content()).hasSize(2);
-                        softly.assertThat(response.content().get(0).memberId()).isEqualTo(followingB.getId());
-                        softly.assertThat(response.content().get(0).nickname()).isEqualTo(followingB.getNickname());
-                        softly.assertThat(response.content().get(0).isFollowing()).isFalse();
-                        softly.assertThat(response.content().get(1).memberId()).isEqualTo(followingA.getId());
-                        softly.assertThat(response.content().get(1).nickname()).isEqualTo(followingA.getNickname());
-                        softly.assertThat(response.content().get(1).isFollowing()).isTrue();
-                        softly.assertThat(response.isFirst()).isTrue();
-                        softly.assertThat(response.isLast()).isTrue();
-                        softly.assertThat(response.hasNext()).isFalse();
-                        softly.assertThat(response.currentPage()).isEqualTo(0);
-                        softly.assertThat(response.currentSize()).isEqualTo(2);
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(response.content()).hasSize(2);
+                softly.assertThat(response.content().get(0).memberId()).isEqualTo(followingB.getId());
+                softly.assertThat(response.content().get(0).nickname()).isEqualTo(followingB.getNickname());
+                softly.assertThat(response.content().get(0).isFollowing()).isFalse();
+                softly.assertThat(response.content().get(1).memberId()).isEqualTo(followingA.getId());
+                softly.assertThat(response.content().get(1).nickname()).isEqualTo(followingA.getNickname());
+                softly.assertThat(response.content().get(1).isFollowing()).isTrue();
+                softly.assertThat(response.isFirst()).isTrue();
+                softly.assertThat(response.isLast()).isTrue();
+                softly.assertThat(response.hasNext()).isFalse();
+                softly.assertThat(response.currentPage()).isEqualTo(0);
+                softly.assertThat(response.currentSize()).isEqualTo(2);
+            });
         }
 
         @Test
@@ -116,23 +112,21 @@ class FollowServiceTest extends IntegrationTest {
 
         PageResponse<FollowerResponse> response = followService.getFollowers(0, 2, following);
 
-        assertSoftly(
-                softly -> {
-                    softly.assertThat(response.content())
-                            .usingRecursiveComparison()
-                            .isEqualTo(
-                                    List.of(
-                                            FollowerResponse.from(followB.getFollower()),
-                                            FollowerResponse.from(followA.getFollower())
-                                    )
-                            );
-                    softly.assertThat(response.isFirst()).isTrue();
-                    softly.assertThat(response.isLast()).isTrue();
-                    softly.assertThat(response.hasNext()).isFalse();
-                    softly.assertThat(response.currentPage()).isEqualTo(0);
-                    softly.assertThat(response.currentSize()).isEqualTo(2);
-                }
-        );
+        assertSoftly(softly -> {
+            softly.assertThat(response.content())
+                    .usingRecursiveComparison()
+                    .isEqualTo(
+                            List.of(
+                                    FollowerResponse.from(followB.getFollower()),
+                                    FollowerResponse.from(followA.getFollower())
+                            )
+                    );
+            softly.assertThat(response.isFirst()).isTrue();
+            softly.assertThat(response.isLast()).isTrue();
+            softly.assertThat(response.hasNext()).isFalse();
+            softly.assertThat(response.currentPage()).isEqualTo(0);
+            softly.assertThat(response.currentSize()).isEqualTo(2);
+        });
     }
 
     @Nested
@@ -152,22 +146,20 @@ class FollowServiceTest extends IntegrationTest {
             PageResponse<OtherUserFollowerResponse> response =
                     followService.getOtherUserFollowers(following.getId(), 0, 2, member);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(response.content()).hasSize(2);
-                        softly.assertThat(response.content().get(0).memberId()).isEqualTo(followerB.getId());
-                        softly.assertThat(response.content().get(0).nickname()).isEqualTo(followerB.getNickname());
-                        softly.assertThat(response.content().get(0).isFollowing()).isFalse();
-                        softly.assertThat(response.content().get(1).memberId()).isEqualTo(followerA.getId());
-                        softly.assertThat(response.content().get(1).nickname()).isEqualTo(followerA.getNickname());
-                        softly.assertThat(response.content().get(1).isFollowing()).isTrue();
-                        softly.assertThat(response.isFirst()).isTrue();
-                        softly.assertThat(response.isLast()).isTrue();
-                        softly.assertThat(response.hasNext()).isFalse();
-                        softly.assertThat(response.currentPage()).isEqualTo(0);
-                        softly.assertThat(response.currentSize()).isEqualTo(2);
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(response.content()).hasSize(2);
+                softly.assertThat(response.content().get(0).memberId()).isEqualTo(followerB.getId());
+                softly.assertThat(response.content().get(0).nickname()).isEqualTo(followerB.getNickname());
+                softly.assertThat(response.content().get(0).isFollowing()).isFalse();
+                softly.assertThat(response.content().get(1).memberId()).isEqualTo(followerA.getId());
+                softly.assertThat(response.content().get(1).nickname()).isEqualTo(followerA.getNickname());
+                softly.assertThat(response.content().get(1).isFollowing()).isTrue();
+                softly.assertThat(response.isFirst()).isTrue();
+                softly.assertThat(response.isLast()).isTrue();
+                softly.assertThat(response.hasNext()).isFalse();
+                softly.assertThat(response.currentPage()).isEqualTo(0);
+                softly.assertThat(response.currentSize()).isEqualTo(2);
+            });
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepositoryTest.java
@@ -34,17 +34,15 @@ class FollowRepositoryTest extends PersistenceTest {
         Pageable pageable = PageRequest.of(0, 1, Sort.by("createdAt").descending());
         Slice<Follow> result = followRepository.findAllByFollower(follower, pageable);
 
-        assertSoftly(
-                softly -> {
-                    softly.assertThat(result.getContent().size()).isEqualTo(1);
-                    softly.assertThat(result.getContent().get(0)).isEqualTo(followB);
-                    softly.assertThat(result.isFirst()).isTrue();
-                    softly.assertThat(result.isLast()).isFalse();
-                    softly.assertThat(result.hasNext()).isTrue();
-                    softly.assertThat(result.getNumber()).isEqualTo(0);
-                    softly.assertThat(result.getSize()).isEqualTo(1);
-                }
-        );
+        assertSoftly(softly -> {
+            softly.assertThat(result.getContent().size()).isEqualTo(1);
+            softly.assertThat(result.getContent().get(0)).isEqualTo(followB);
+            softly.assertThat(result.isFirst()).isTrue();
+            softly.assertThat(result.isLast()).isFalse();
+            softly.assertThat(result.hasNext()).isTrue();
+            softly.assertThat(result.getNumber()).isEqualTo(0);
+            softly.assertThat(result.getSize()).isEqualTo(1);
+        });
     }
 
     @Test
@@ -59,17 +57,15 @@ class FollowRepositoryTest extends PersistenceTest {
         Pageable pageable = PageRequest.of(0, 1, Sort.by("createdAt").descending());
         Slice<Follow> result = followRepository.findAllByFollowing(following, pageable);
 
-        assertSoftly(
-                softly -> {
-                    softly.assertThat(result.getContent().size()).isEqualTo(1);
-                    softly.assertThat(result.getContent().get(0)).isEqualTo(followB);
-                    softly.assertThat(result.isFirst()).isTrue();
-                    softly.assertThat(result.isLast()).isFalse();
-                    softly.assertThat(result.hasNext()).isTrue();
-                    softly.assertThat(result.getNumber()).isEqualTo(0);
-                    softly.assertThat(result.getSize()).isEqualTo(1);
-                }
-        );
+        assertSoftly(softly -> {
+            softly.assertThat(result.getContent().size()).isEqualTo(1);
+            softly.assertThat(result.getContent().get(0)).isEqualTo(followB);
+            softly.assertThat(result.isFirst()).isTrue();
+            softly.assertThat(result.isLast()).isFalse();
+            softly.assertThat(result.hasNext()).isTrue();
+            softly.assertThat(result.getNumber()).isEqualTo(0);
+            softly.assertThat(result.getSize()).isEqualTo(1);
+        });
     }
 
     @Nested

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
@@ -26,15 +26,13 @@ class MemberServiceTest extends IntegrationTest {
 
             MemberProfileResponse response = memberService.getProfile(loginMember.getId(), loginMember);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(response.id()).isEqualTo(loginMember.getId());
-                        softly.assertThat(response.nickname()).isEqualTo(loginMember.getNickname());
-                        softly.assertThat(response.introduction()).isEqualTo(loginMember.getIntroduction());
-                        softly.assertThat(response.isMyProfile()).isTrue();
-                        softly.assertThat(response.isFollowing()).isFalse();
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(response.id()).isEqualTo(loginMember.getId());
+                softly.assertThat(response.nickname()).isEqualTo(loginMember.getNickname());
+                softly.assertThat(response.introduction()).isEqualTo(loginMember.getIntroduction());
+                softly.assertThat(response.isMyProfile()).isTrue();
+                softly.assertThat(response.isFollowing()).isFalse();
+            });
         }
 
         @Test
@@ -45,15 +43,13 @@ class MemberServiceTest extends IntegrationTest {
 
             MemberProfileResponse response = memberService.getProfile(profileTargetMember.getId(), loginMember);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(response.id()).isEqualTo(profileTargetMember.getId());
-                        softly.assertThat(response.nickname()).isEqualTo(profileTargetMember.getNickname());
-                        softly.assertThat(response.introduction()).isEqualTo(profileTargetMember.getIntroduction());
-                        softly.assertThat(response.isMyProfile()).isFalse();
-                        softly.assertThat(response.isFollowing()).isTrue();
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(response.id()).isEqualTo(profileTargetMember.getId());
+                softly.assertThat(response.nickname()).isEqualTo(profileTargetMember.getNickname());
+                softly.assertThat(response.introduction()).isEqualTo(profileTargetMember.getIntroduction());
+                softly.assertThat(response.isMyProfile()).isFalse();
+                softly.assertThat(response.isFollowing()).isTrue();
+            });
         }
 
         @Test
@@ -63,15 +59,13 @@ class MemberServiceTest extends IntegrationTest {
 
             MemberProfileResponse response = memberService.getProfile(profileTargetMember.getId(), loginMember);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(response.id()).isEqualTo(profileTargetMember.getId());
-                        softly.assertThat(response.nickname()).isEqualTo(profileTargetMember.getNickname());
-                        softly.assertThat(response.introduction()).isEqualTo(profileTargetMember.getIntroduction());
-                        softly.assertThat(response.isMyProfile()).isFalse();
-                        softly.assertThat(response.isFollowing()).isFalse();
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(response.id()).isEqualTo(profileTargetMember.getId());
+                softly.assertThat(response.nickname()).isEqualTo(profileTargetMember.getNickname());
+                softly.assertThat(response.introduction()).isEqualTo(profileTargetMember.getIntroduction());
+                softly.assertThat(response.isMyProfile()).isFalse();
+                softly.assertThat(response.isFollowing()).isFalse();
+            });
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/photo/persistence/ReviewPhotoRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/photo/persistence/ReviewPhotoRepositoryTest.java
@@ -26,12 +26,10 @@ class ReviewPhotoRepositoryTest extends PersistenceTest {
 
         ReviewPhoto savedReviewPhoto = reviewPhotoRepository.save(reviewPhoto);
 
-        assertSoftly(
-                softly -> {
-                    softly.assertThat(savedReviewPhoto.getId()).isNotNull();
-                    softly.assertThat(savedReviewPhoto.getReview()).isEqualTo(review);
-                    softly.assertThat(savedReviewPhoto.getPhoto()).isEqualTo(photo);
-                }
-        );
+        assertSoftly(softly -> {
+            softly.assertThat(savedReviewPhoto.getId()).isNotNull();
+            softly.assertThat(savedReviewPhoto.getReview()).isEqualTo(review);
+            softly.assertThat(savedReviewPhoto.getPhoto()).isEqualTo(photo);
+        });
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -51,15 +51,13 @@ class StoreServiceTest extends IntegrationTest {
 
             Store store = storeService.create(storeCreateDtoWithoutSchool);
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(store.getId()).isNotNull();
-                        softly.assertThat(store.getLocationId()).isEqualTo(storeCreateDtoWithoutSchool.locationId());
-                        softly.assertThat(store.getStoreName()).isEqualTo(storeCreateDtoWithoutSchool.storeName());
-                        softly.assertThat(store.getCategory().getCategoryType().name()).isEqualTo(
-                                storeCreateDtoWithoutSchool.category());
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(store.getId()).isNotNull();
+                softly.assertThat(store.getLocationId()).isEqualTo(storeCreateDtoWithoutSchool.locationId());
+                softly.assertThat(store.getStoreName()).isEqualTo(storeCreateDtoWithoutSchool.storeName());
+                softly.assertThat(store.getCategory().getCategoryType().name())
+                        .isEqualTo(storeCreateDtoWithoutSchool.category());
+            });
         }
 
         @Test
@@ -76,15 +74,13 @@ class StoreServiceTest extends IntegrationTest {
                     .map(StoreSchool::getStore)
                     .toList();
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(store.getId()).isNotNull();
-                        softly.assertThat(store.getStoreName()).isEqualTo(storeCreateDtoWithSchool.storeName());
-                        softly.assertThat(store.getCategory().getCategoryType().name())
-                                .isEqualTo(storeCreateDtoWithSchool.category());
-                        softly.assertThat(stores).contains(store);
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(store.getId()).isNotNull();
+                softly.assertThat(store.getStoreName()).isEqualTo(storeCreateDtoWithSchool.storeName());
+                softly.assertThat(store.getCategory().getCategoryType().name())
+                        .isEqualTo(storeCreateDtoWithSchool.category());
+                softly.assertThat(stores).contains(store);
+            });
         }
 
         @Test
@@ -114,12 +110,10 @@ class StoreServiceTest extends IntegrationTest {
                     .map(StoreSchool::getStore)
                     .toList();
 
-            assertSoftly(
-                    softly -> {
-                        softly.assertThat(stores).contains(store1, store2);
-                        softly.assertThat(stores).hasSize(2);
-                    }
-            );
+            assertSoftly(softly -> {
+                softly.assertThat(stores).contains(store1, store2);
+                softly.assertThat(stores).hasSize(2);
+            });
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/vo/CoordinateTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/vo/CoordinateTest.java
@@ -22,12 +22,10 @@ class CoordinateTest {
 
         Coordinate coordinate = new Coordinate(x, y);
 
-        assertSoftly(
-                softly -> {
-                    softly.assertThat(coordinate.getX()).isEqualTo(x);
-                    softly.assertThat(coordinate.getY()).isEqualTo(y);
-                }
-        );
+        assertSoftly(softly -> {
+            softly.assertThat(coordinate.getX()).isEqualTo(x);
+            softly.assertThat(coordinate.getY()).isEqualTo(y);
+        });
     }
 
     @ParameterizedTest

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/SchoolRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/SchoolRepositoryTest.java
@@ -21,12 +21,10 @@ class SchoolRepositoryTest extends PersistenceTest {
 
         School saveSchool = schoolRepository.save(school);
 
-        assertSoftly(
-                softly -> {
-                    softly.assertThat(saveSchool.getId()).isNotNull();
-                    softly.assertThat(saveSchool.getName()).isEqualTo(school.getName());
-                }
-        );
+        assertSoftly(softly -> {
+            softly.assertThat(saveSchool.getId()).isNotNull();
+            softly.assertThat(saveSchool.getName()).isEqualTo(school.getName());
+        });
     }
 
     @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreSchoolRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreSchoolRepositoryTest.java
@@ -28,13 +28,11 @@ class StoreSchoolRepositoryTest extends PersistenceTest {
 
         StoreSchool saveStoreSchool = storeSchoolRepository.save(storeSchool);
 
-        assertSoftly(
-                softly -> {
-                    softly.assertThat(saveStoreSchool.getId()).isNotNull();
-                    softly.assertThat(saveStoreSchool.getStore()).isEqualTo(store);
-                    softly.assertThat(saveStoreSchool.getSchool()).isEqualTo(school);
-                }
-        );
+        assertSoftly(softly -> {
+            softly.assertThat(saveStoreSchool.getId()).isNotNull();
+            softly.assertThat(saveStoreSchool.getStore()).isEqualTo(store);
+            softly.assertThat(saveStoreSchool.getSchool()).isEqualTo(school);
+        });
     }
 
     @Test


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #141

## 📝 작업 요약

인증 토큰 갱신 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 인증 토큰, 리프레쉬 토큰에 대한 유효성 검사를 수행합니다.
- 인증 토큰은 만료되었을 때 갱신 가능한 상태로 처리합니다.
- 캐시 저장소에 저장되어 있는 리프레쉬 토큰과 요청의 리프레쉬 토큰이 일치하는지 비교합니다.
- 위의 조건이 모두 만족하면 인증 토큰을 재발급합니다.

## 🌟 리뷰 요구 사항

> 30분
> 갱신 되는 과정을 꼼꼼히 확인해주시면 감사합니다 :)