### PR TITLE
Feature/#149 프로필 정보를 수정하는 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
@@ -6,11 +6,14 @@ import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.follow.domain.Follow;
 import org.dinosaur.foodbowl.domain.follow.persistence.FollowRepository;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.domain.vo.Introduction;
 import org.dinosaur.foodbowl.domain.member.domain.vo.Nickname;
+import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
 import org.dinosaur.foodbowl.domain.member.exception.MemberExceptionType;
 import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
+import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,5 +43,18 @@ public class MemberService {
     public NicknameExistResponse checkNicknameExist(String nickname) {
         boolean isExist = memberRepository.existsByNickname(new Nickname(nickname));
         return new NicknameExistResponse(isExist);
+    }
+
+    @Transactional
+    public void updateProfile(UpdateProfileRequest updateProfileRequest, Member loginMember) {
+        Nickname nickname = new Nickname(updateProfileRequest.nickname());
+        Introduction introduction = new Introduction(updateProfileRequest.introduction());
+
+        boolean nicknameExist = memberRepository.existsByNickname(nickname);
+        if (nicknameExist) {
+            throw new BadRequestException(MemberExceptionType.DUPLICATE_NICKNAME);
+        }
+
+        loginMember.updateProfile(nickname, introduction);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
@@ -50,11 +50,16 @@ public class MemberService {
         Nickname nickname = new Nickname(updateProfileRequest.nickname());
         Introduction introduction = new Introduction(updateProfileRequest.introduction());
 
+        if (!loginMember.hasNickname(nickname)) {
+            validateExistNickname(nickname);
+        }
+        loginMember.updateProfile(nickname, introduction);
+    }
+
+    private void validateExistNickname(Nickname nickname) {
         boolean nicknameExist = memberRepository.existsByNickname(nickname);
         if (nicknameExist) {
             throw new BadRequestException(MemberExceptionType.DUPLICATE_NICKNAME);
         }
-
-        loginMember.updateProfile(nickname, introduction);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -89,6 +90,10 @@ public class Member extends AuditingEntity {
     public void updateProfile(Nickname nickname, Introduction introduction) {
         this.nickname = nickname;
         this.introduction = introduction;
+    }
+
+    public boolean hasNickname(Nickname nickname) {
+        return Objects.equals(this.nickname, nickname);
     }
 
     public String getNickname() {

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
@@ -21,6 +21,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.member.domain.vo.Introduction;
 import org.dinosaur.foodbowl.domain.member.domain.vo.Nickname;
 import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
 import org.dinosaur.foodbowl.domain.photo.domain.Thumbnail;
@@ -61,8 +62,8 @@ public class Member extends AuditingEntity {
     @Embedded
     private Nickname nickname;
 
-    @Column(name = "introduction", length = 255)
-    private String introduction;
+    @Embedded
+    private Introduction introduction;
 
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
     private MemberThumbnail memberThumbnail;
@@ -82,11 +83,20 @@ public class Member extends AuditingEntity {
         this.socialId = socialId;
         this.email = email;
         this.nickname = new Nickname(nickname);
+        this.introduction = new Introduction(introduction);
+    }
+
+    public void updateProfile(Nickname nickname, Introduction introduction) {
+        this.nickname = nickname;
         this.introduction = introduction;
     }
 
     public String getNickname() {
         return this.nickname.getValue();
+    }
+
+    public String getIntroduction() {
+        return this.introduction.getValue();
     }
 
     public String getProfileImageUrl() {

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Introduction.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Introduction.java
@@ -1,0 +1,34 @@
+package org.dinosaur.foodbowl.domain.member.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.member.exception.MemberExceptionType;
+import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Introduction {
+
+    private static final Pattern INTRODUCTION_PATTERN = Pattern.compile("^[가-힣a-zA-Z]{1,100}$");
+
+    @Column(name = "introduction", length = 255)
+    private String value;
+
+    public Introduction(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(String value) {
+        Matcher matcher = INTRODUCTION_PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            throw new InvalidArgumentException(MemberExceptionType.INVALID_INTRODUCTION);
+        }
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Introduction.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Introduction.java
@@ -20,7 +20,7 @@ public class Introduction {
 
     public Introduction(String value) {
         validate(value);
-        this.value = value;
+        this.value = convertWhenEmpty(value);
     }
 
     private void validate(String value) {
@@ -34,5 +34,12 @@ public class Introduction {
 
     private boolean isNullOrEmpty(String value) {
         return value == null || value.isEmpty();
+    }
+
+    private String convertWhenEmpty(String value) {
+        if (isNullOrEmpty(value)) {
+            return null;
+        }
+        return value;
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Introduction.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Introduction.java
@@ -2,8 +2,6 @@ package org.dinosaur.foodbowl.domain.member.domain.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +13,7 @@ import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 @Embeddable
 public class Introduction {
 
-    private static final Pattern INTRODUCTION_PATTERN = Pattern.compile("^[가-힣a-zA-Z]{1,100}$");
+    private static final int MAXIMUM_LENGTH = 100;
 
     @Column(name = "introduction", length = 255)
     private String value;
@@ -26,9 +24,15 @@ public class Introduction {
     }
 
     private void validate(String value) {
-        Matcher matcher = INTRODUCTION_PATTERN.matcher(value);
-        if (!matcher.matches()) {
+        if (isNullOrEmpty(value)) {
+            return;
+        }
+        if (value.isBlank() || value.length() > MAXIMUM_LENGTH) {
             throw new InvalidArgumentException(MemberExceptionType.INVALID_INTRODUCTION);
         }
+    }
+
+    private boolean isNullOrEmpty(String value) {
+        return value == null || value.isEmpty();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Nickname.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Nickname.java
@@ -6,12 +6,14 @@ import jakarta.validation.constraints.NotNull;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.exception.MemberExceptionType;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 
 @Getter
+@EqualsAndHashCode(of = {"value"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class Nickname {

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Nickname.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/vo/Nickname.java
@@ -16,7 +16,7 @@ import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 @Embeddable
 public class Nickname {
 
-    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z]{1,10}$");
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{1,10}$");
 
     @NotNull
     @Column(name = "nickname", unique = true, length = 45)

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,16 @@
+package org.dinosaur.foodbowl.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "프로필 수정 요청")
+public record UpdateProfileRequest(
+        @Schema(description = "닉네임", example = "coby5502")
+        @NotBlank(message = "닉네임이 공백이거나 존재하지 않습니다.")
+        String nickname,
+
+        @Schema(description = "한 줄 소개", example = "동네 맛집 탐험을 좋아하는 아저씨에요.")
+        @NotBlank(message = "한 줄 소개가 공백이거나 존재하지 않습니다.")
+        String introduction
+) {
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/dto/request/UpdateProfileRequest.java
@@ -10,7 +10,6 @@ public record UpdateProfileRequest(
         String nickname,
 
         @Schema(description = "한 줄 소개", example = "동네 맛집 탐험을 좋아하는 아저씨에요.")
-        @NotBlank(message = "한 줄 소개가 공백이거나 존재하지 않습니다.")
         String introduction
 ) {
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/exception/MemberExceptionType.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/exception/MemberExceptionType.java
@@ -7,7 +7,9 @@ import org.dinosaur.foodbowl.global.exception.type.ExceptionType;
 public enum MemberExceptionType implements ExceptionType {
 
     NOT_FOUND("MEMBER-100", "등록되지 않은 회원입니다."),
-    INVALID_NICKNAME("MEMBER-101", "한글, 영어로 구성된 1글자 이상, 10글자 이하의 닉네임이 아닙니다.");
+    INVALID_NICKNAME("MEMBER-101", "한글, 영어로 구성된 1글자 이상, 10글자 이하의 닉네임이 아닙니다."),
+    INVALID_INTRODUCTION("MEMBER-102", "한글, 영어로 구성된 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다."),
+    DUPLICATE_NICKNAME("MEMBER-103", "이미 존재하는 닉네임입니다.");
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/exception/MemberExceptionType.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/exception/MemberExceptionType.java
@@ -7,8 +7,8 @@ import org.dinosaur.foodbowl.global.exception.type.ExceptionType;
 public enum MemberExceptionType implements ExceptionType {
 
     NOT_FOUND("MEMBER-100", "등록되지 않은 회원입니다."),
-    INVALID_NICKNAME("MEMBER-101", "한글, 영어로 구성된 1글자 이상, 10글자 이하의 닉네임이 아닙니다."),
-    INVALID_INTRODUCTION("MEMBER-102", "한글, 영어로 구성된 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다."),
+    INVALID_NICKNAME("MEMBER-101", "한글, 영어, 숫자로 구성된 1글자 이상, 10글자 이하의 닉네임이 아닙니다."),
+    INVALID_INTRODUCTION("MEMBER-102", "공백만으로 이루어지지 않은 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다."),
     DUPLICATE_NICKNAME("MEMBER-103", "이미 존재하는 닉네임입니다.");
 
     private final String errorCode;

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
@@ -51,6 +51,6 @@ public class MemberController implements MemberControllerDocs {
             @Auth Member loginMember
     ) {
         memberService.updateProfile(updateProfileRequest, loginMember);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
@@ -13,8 +13,8 @@ import org.dinosaur.foodbowl.global.presentation.Auth;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,7 +45,7 @@ public class MemberController implements MemberControllerDocs {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/profile")
+    @PatchMapping("/profile")
     public ResponseEntity<Void> updateProfile(
             @RequestBody @Valid UpdateProfileRequest updateProfileRequest,
             @Auth Member loginMember

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
@@ -1,10 +1,12 @@
 package org.dinosaur.foodbowl.domain.member.presentation;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
 import org.dinosaur.foodbowl.global.presentation.Auth;
@@ -12,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,5 +43,14 @@ public class MemberController implements MemberControllerDocs {
     ) {
         NicknameExistResponse response = memberService.checkNicknameExist(nickname);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<Void> updateProfile(
+            @RequestBody @Valid UpdateProfileRequest updateProfileRequest,
+            @Auth Member loginMember
+    ) {
+        memberService.updateProfile(updateProfileRequest, loginMember);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
@@ -82,13 +82,11 @@ public interface MemberControllerDocs {
                     description = """
                             1.공백이거나 존재하지 않는 닉네임 요청
                                                         
-                            2.공백이거나 존재하지 않는 한 줄 소개 요청
+                            2.제약사항에 맞지 않는 닉네임
                                                         
-                            3.제약사항에 맞지 않는 닉네임
+                            3.제약사항에 맞지 않는 한 줄 소개
                                                         
-                            4.제약사항에 맞지 않는 한 줄 소개
-                                                        
-                            5.이미 존재하는 닉네임
+                            4.이미 존재하는 닉네임
                             """,
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
@@ -7,9 +7,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
@@ -68,4 +70,28 @@ public interface MemberControllerDocs {
             @NotBlank(message = "닉네임 파라미터 값이 존재하지 않습니다.")
             String nickname
     );
+
+    @Operation(summary = "프로필 정보 수정", description = "닉네임, 한 줄 소개를 수정한다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 정보 수정 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.공백이거나 존재하지 않는 닉네임 요청
+                                                        
+                            2.공백이거나 존재하지 않는 한 줄 소개 요청
+                                                        
+                            3.제약사항에 맞지 않는 닉네임
+                                                        
+                            4.제약사항에 맞지 않는 한 줄 소개
+                                                        
+                            5.이미 존재하는 닉네임
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<Void> updateProfile(@Valid UpdateProfileRequest updateProfileRequest, Member loginMember);
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
@@ -5,8 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
+import org.dinosaur.foodbowl.global.exception.BadRequestException;
+import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.junit.jupiter.api.Nested;
@@ -103,6 +106,54 @@ class MemberServiceTest extends IntegrationTest {
             NicknameExistResponse response = memberService.checkNicknameExist("hello");
 
             assertThat(response.isExist()).isFalse();
+        }
+    }
+
+    @Nested
+    class 프로필_정보_수정 {
+
+        @Test
+        void 유효한_요청이라면_프로필_정보를_수정한다() {
+            Member member = memberTestPersister.memberBuilder().save();
+            UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("hello", "friend");
+
+            memberService.updateProfile(updateProfileRequest, member);
+
+            assertSoftly(softly -> {
+                softly.assertThat(member.getNickname()).isEqualTo("hello");
+                softly.assertThat(member.getIntroduction()).isEqualTo("friend");
+            });
+        }
+
+        @Test
+        void 유효하지_않은_닉네임이라면_예외를_던진다() {
+            Member member = memberTestPersister.memberBuilder().save();
+            UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("하 이", "friend");
+
+            assertThatThrownBy(() -> memberService.updateProfile(updateProfileRequest, member))
+                    .isInstanceOf(InvalidArgumentException.class)
+                    .hasMessage("한글, 영어, 숫자로 구성된 1글자 이상, 10글자 이하의 닉네임이 아닙니다.");
+        }
+
+        @Test
+        void 유효하지_않은_한_줄_소개라면_예외를_던진다() {
+            Member member = memberTestPersister.memberBuilder().save();
+            UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("hello", "  ");
+
+            assertThatThrownBy(() -> memberService.updateProfile(updateProfileRequest, member))
+                    .isInstanceOf(InvalidArgumentException.class)
+                    .hasMessage("공백만으로 이루어지지 않은 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다.");
+        }
+
+        @Test
+        void 존재하는_닉네임이라면_예외를_던진다() {
+            memberTestPersister.memberBuilder().nickname("hello").save();
+            Member member = memberTestPersister.memberBuilder().save();
+            UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("hello", "friend");
+
+            assertThatThrownBy(() -> memberService.updateProfile(updateProfileRequest, member))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("이미 존재하는 닉네임입니다.");
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
@@ -126,6 +126,19 @@ class MemberServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 변경_닉네임이_현재_닉네임이라면_프로필_정보를_수정한다() {
+            Member member = memberTestPersister.memberBuilder().nickname("hello").save();
+            UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("hello", "friend");
+
+            memberService.updateProfile(updateProfileRequest, member);
+
+            assertSoftly(softly -> {
+                softly.assertThat(member.getNickname()).isEqualTo("hello");
+                softly.assertThat(member.getIntroduction()).isEqualTo("friend");
+            });
+        }
+
+        @Test
         void 유효하지_않은_닉네임이라면_예외를_던진다() {
             Member member = memberTestPersister.memberBuilder().save();
             UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("하 이", "friend");
@@ -146,7 +159,7 @@ class MemberServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 존재하는_닉네임이라면_예외를_던진다() {
+        void 변경_닉네임이_현재_닉네임이_아니고_존재하는_닉네임이라면_예외를_던진다() {
             memberTestPersister.memberBuilder().nickname("hello").save();
             Member member = memberTestPersister.memberBuilder().save();
             UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("hello", "friend");

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberTest.java
@@ -1,5 +1,6 @@
 package org.dinosaur.foodbowl.domain.member.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -9,6 +10,7 @@ import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -84,5 +86,41 @@ class MemberTest {
             softly.assertThat(member.getNickname()).isEqualTo("NewName");
             softly.assertThat(member.getIntroduction()).isEqualTo("NewIntroduction");
         });
+    }
+
+    @Nested
+    class 현재_닉네임_확인 {
+
+        @Test
+        void 닉네임이_현재_닉네임이라면_true_반환한다() {
+            Member member = Member.builder()
+                    .socialType(SocialType.APPLE)
+                    .socialId("A1B2C3D4")
+                    .email("email@email.com")
+                    .nickname("nickname")
+                    .introduction("introduction")
+                    .build();
+            Nickname nickname = new Nickname("nickname");
+
+            boolean result = member.hasNickname(nickname);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 닉네임이_현재_닉네임이_아니라면_false_반환한다() {
+            Member member = Member.builder()
+                    .socialType(SocialType.APPLE)
+                    .socialId("A1B2C3D4")
+                    .email("email@email.com")
+                    .nickname("nickname")
+                    .introduction("introduction")
+                    .build();
+            Nickname nickname = new Nickname("hello");
+
+            boolean result = member.hasNickname(nickname);
+
+            assertThat(result).isFalse();
+        }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 class MemberTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"", " ", "a@", "안 녕", "hi2", "가나다라마바사아자차카"})
-    void 한글_영어로_구성된_1글자_이상_10글자_이하의_닉네임이_아니라면_예외를_던진다(String nickname) {
+    @ValueSource(strings = {"", " ", "a@", "안 녕", " 안녕", "안녕 ", "가나다라마바사아자차카"})
+    void 한글_영어_숫자로_구성된_1글자_이상_10글자_이하의_닉네임이_아니라면_예외를_던진다(String nickname) {
         assertThatThrownBy(
                 () -> Member.builder()
                         .socialType(SocialType.APPLE)
@@ -30,12 +30,12 @@ class MemberTest {
                         .build()
         )
                 .isInstanceOf(InvalidArgumentException.class)
-                .hasMessage("한글, 영어로 구성된 1글자 이상, 10글자 이하의 닉네임이 아닙니다.");
+                .hasMessage("한글, 영어, 숫자로 구성된 1글자 이상, 10글자 이하의 닉네임이 아닙니다.");
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", " ", "a@", "안 녕", "hi2"})
-    void 한글_영어로_구성된_한_줄_소개가_아니라면_예외를_던진다(String introduction) {
+    @ValueSource(strings = {" ", "  ", "   "})
+    void 공백만으로_이루어진_한_줄_소개라면_예외를_던진다(String introduction) {
         assertThatThrownBy(
                 () -> Member.builder()
                         .socialType(SocialType.APPLE)
@@ -46,11 +46,11 @@ class MemberTest {
                         .build()
         )
                 .isInstanceOf(InvalidArgumentException.class)
-                .hasMessage("한글, 영어로 구성된 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다.");
+                .hasMessage("공백만으로 이루어지지 않은 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다.");
     }
 
     @Test
-    void 한글_영어로_구성된_100글자_이하의_한_줄_소개가_아니라면_예외를_던진다() {
+    void 총_길이가_100글자_초과의_한_줄_소개라면_예외를_던진다() {
         String introduction = "가".repeat(101);
 
         assertThatThrownBy(
@@ -63,7 +63,7 @@ class MemberTest {
                         .build()
         )
                 .isInstanceOf(InvalidArgumentException.class)
-                .hasMessage("한글, 영어로 구성된 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다.");
+                .hasMessage("공백만으로 이루어지지 않은 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다.");
     }
 
     @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberTest.java
@@ -1,11 +1,15 @@
 package org.dinosaur.foodbowl.domain.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import org.dinosaur.foodbowl.domain.member.domain.vo.Introduction;
+import org.dinosaur.foodbowl.domain.member.domain.vo.Nickname;
 import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -27,5 +31,58 @@ class MemberTest {
         )
                 .isInstanceOf(InvalidArgumentException.class)
                 .hasMessage("한글, 영어로 구성된 1글자 이상, 10글자 이하의 닉네임이 아닙니다.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "a@", "안 녕", "hi2"})
+    void 한글_영어로_구성된_한_줄_소개가_아니라면_예외를_던진다(String introduction) {
+        assertThatThrownBy(
+                () -> Member.builder()
+                        .socialType(SocialType.APPLE)
+                        .socialId("A1B2C3D4")
+                        .email("email@email.com")
+                        .nickname("hello")
+                        .introduction(introduction)
+                        .build()
+        )
+                .isInstanceOf(InvalidArgumentException.class)
+                .hasMessage("한글, 영어로 구성된 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다.");
+    }
+
+    @Test
+    void 한글_영어로_구성된_100글자_이하의_한_줄_소개가_아니라면_예외를_던진다() {
+        String introduction = "가".repeat(101);
+
+        assertThatThrownBy(
+                () -> Member.builder()
+                        .socialType(SocialType.APPLE)
+                        .socialId("A1B2C3D4")
+                        .email("email@email.com")
+                        .nickname("hello")
+                        .introduction(introduction)
+                        .build()
+        )
+                .isInstanceOf(InvalidArgumentException.class)
+                .hasMessage("한글, 영어로 구성된 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다.");
+    }
+
+    @Test
+    void 프로필_정보를_수정한다() {
+        Member member = Member.builder()
+                .socialType(SocialType.APPLE)
+                .socialId("A1B2C3D4")
+                .email("email@email.com")
+                .nickname("nickname")
+                .introduction("introduction")
+                .build();
+        Nickname nickname = new Nickname("NewName");
+        Introduction introduction = new Introduction("NewIntroduction");
+
+        member.updateProfile(nickname, introduction);
+
+        assertSoftly(softly -> {
+            softly.assertThat(member.getNickname()).isEqualTo("NewName");
+            softly.assertThat(member.getIntroduction()).isEqualTo("NewIntroduction");
+        });
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/domain/vo/IntroductionTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/domain/vo/IntroductionTest.java
@@ -1,0 +1,34 @@
+package org.dinosaur.foodbowl.domain.member.domain.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class IntroductionTest {
+
+    @Nested
+    class 빈값_변환 {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void 빈값이거나_null이라면_null로_변환한다(String value) {
+            Introduction introduction = new Introduction(value);
+
+            assertThat(introduction.getValue()).isNull();
+        }
+
+        @Test
+        void 빈값이거나_null이_아니라면_값을_유지한다() {
+            Introduction introduction = new Introduction("hello");
+
+            assertThat(introduction.getValue()).isEqualTo("hello");
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
@@ -6,7 +6,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,6 +19,7 @@ import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
+import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
 import org.dinosaur.foodbowl.test.PresentationTest;
@@ -24,11 +27,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -148,6 +153,54 @@ class MemberControllerTest extends PresentationTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errorCode").value("CLIENT-101"))
                     .andExpect(jsonPath("$.message", containsString("닉네임 파라미터 값이 존재하지 않습니다.")));
+        }
+    }
+
+    @Nested
+    class 프로필_정보_수정 {
+
+        private final String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+        @Test
+        void 프로필_정보를_수정하면_200_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+            UpdateProfileRequest request = new UpdateProfileRequest("coby5502", "동네 맛집 탐험을 좋아하는 아저씨에요.");
+            willDoNothing().given(memberService).updateProfile(any(UpdateProfileRequest.class), any(Member.class));
+
+            mockMvc.perform(put("/v1/members/profile")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void 닉네임이_공백이거나_존재하지_않으면_400_응답을_반환한다(String nickname) throws Exception {
+            UpdateProfileRequest request = new UpdateProfileRequest(nickname, "동네 맛집 탐험을 좋아하는 아저씨에요.");
+
+            mockMvc.perform(put("/v1/members/profile")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
+                    .andExpect(jsonPath("$.message", containsString("닉네임이 공백이거나 존재하지 않습니다.")));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void 한_줄_소개가_공백이거나_존재하지_않으면_400_응답을_반환한다(String introduction) throws Exception {
+            UpdateProfileRequest request = new UpdateProfileRequest("coby5502", introduction);
+
+            mockMvc.perform(put("/v1/members/profile")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
+                    .andExpect(jsonPath("$.message", containsString("한 줄 소개가 공백이거나 존재하지 않습니다.")));
         }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
@@ -162,7 +162,7 @@ class MemberControllerTest extends PresentationTest {
         private final String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
 
         @Test
-        void 프로필_정보를_수정하면_200_응답을_반환한다() throws Exception {
+        void 프로필_정보를_수정하면_204_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             UpdateProfileRequest request = new UpdateProfileRequest("coby5502", "동네 맛집 탐험을 좋아하는 아저씨에요.");
             willDoNothing().given(memberService).updateProfile(any(UpdateProfileRequest.class), any(Member.class));
@@ -172,7 +172,7 @@ class MemberControllerTest extends PresentationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
-                    .andExpect(status().isOk());
+                    .andExpect(status().isNoContent());
         }
 
         @ParameterizedTest

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
@@ -188,19 +188,5 @@ class MemberControllerTest extends PresentationTest {
                     .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
                     .andExpect(jsonPath("$.message", containsString("닉네임이 공백이거나 존재하지 않습니다.")));
         }
-
-        @ParameterizedTest
-        @NullAndEmptySource
-        void 한_줄_소개가_공백이거나_존재하지_않으면_400_응답을_반환한다(String introduction) throws Exception {
-            UpdateProfileRequest request = new UpdateProfileRequest("coby5502", introduction);
-
-            mockMvc.perform(patch("/v1/members/profile")
-                            .header(AUTHORIZATION, BEARER + accessToken)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andDo(print())
-                    .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
-                    .andExpect(jsonPath("$.message", containsString("한 줄 소개가 공백이거나 존재하지 않습니다.")));
-        }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -167,7 +167,7 @@ class MemberControllerTest extends PresentationTest {
             UpdateProfileRequest request = new UpdateProfileRequest("coby5502", "동네 맛집 탐험을 좋아하는 아저씨에요.");
             willDoNothing().given(memberService).updateProfile(any(UpdateProfileRequest.class), any(Member.class));
 
-            mockMvc.perform(put("/v1/members/profile")
+            mockMvc.perform(patch("/v1/members/profile")
                             .header(AUTHORIZATION, BEARER + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -180,7 +180,7 @@ class MemberControllerTest extends PresentationTest {
         void 닉네임이_공백이거나_존재하지_않으면_400_응답을_반환한다(String nickname) throws Exception {
             UpdateProfileRequest request = new UpdateProfileRequest(nickname, "동네 맛집 탐험을 좋아하는 아저씨에요.");
 
-            mockMvc.perform(put("/v1/members/profile")
+            mockMvc.perform(patch("/v1/members/profile")
                             .header(AUTHORIZATION, BEARER + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -194,7 +194,7 @@ class MemberControllerTest extends PresentationTest {
         void 한_줄_소개가_공백이거나_존재하지_않으면_400_응답을_반환한다(String introduction) throws Exception {
             UpdateProfileRequest request = new UpdateProfileRequest("coby5502", introduction);
 
-            mockMvc.perform(put("/v1/members/profile")
+            mockMvc.perform(patch("/v1/members/profile")
                             .header(AUTHORIZATION, BEARER + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #149

## 📝 작업 요약

프로필 정보를 수정하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

로그인한 회원 객체를 `ArgumentResolver`에서 가져와 해당 회원 객체를 `Service`에서 수정하는 방식으로 로직이 진행되고 있습니다. 이게 가능한 이유는 `ArgumentResolver`에서 조회할 때 회원 객체가 영속성 컨텍스트에 들어가게 되고, `Service`에서는 영속성 컨텍스트에 있는 회원 객체를 수정하기 때문에 변경 감지가 가능한 것입니다.

`OSIV(open session in view)`와 관련있는데, 기본적으로 `true`로 설정되어 있기 때문에 영속성 컨텍스트의 생명 주기와 트랜잭션의 생명 주기가 다르게 동작합니다. OSIV를 사용하면 위와 같은 이점을 활용할 수 있지만, 영속성 컨텍스트가 계속 살아있기에 지속적으로 커넥션 연결이 되어있는 상태로 리소스를 낭비하게 된다는 단점도 존재합니다.

커넥션은 실시간 서비스에서 중요한 리소스이기에 한번 고민이 필요한 부분인 것 같아 이 부분에 대해서 얘기해보고 싶어요 🤓

## 🌟 리뷰 요구 사항

> 20분
> OSIV에 대해서 집중적으로 리뷰해주시면 감사합니다 :)