### PR TITLE
Feature/#166 신고하기 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/application/BlameService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/application/BlameService.java
@@ -28,8 +28,8 @@ public class BlameService {
     private final ReviewRepository reviewRepository;
 
     private final Map<BlameTarget, Predicate<Long>> reportCheck = new EnumMap<>(BlameTarget.class) {{
-        put(BlameTarget.MEMBER, BlameService.this::existMember);
-        put(BlameTarget.REVIEW, BlameService.this::existReview);
+        put(BlameTarget.MEMBER, BlameService.this::isExistMember);
+        put(BlameTarget.REVIEW, BlameService.this::isExistReview);
     }};
 
     private final Map<BlameTarget, BiPredicate<Long, Member>> reportMe = new EnumMap<>(BlameTarget.class) {{
@@ -37,11 +37,11 @@ public class BlameService {
         put(BlameTarget.REVIEW, BlameService.this::isReviewMe);
     }};
 
-    private boolean existMember(Long targetId) {
+    private boolean isExistMember(Long targetId) {
         return memberRepository.findById(targetId).isPresent();
     }
 
-    private boolean existReview(Long targetId) {
+    private boolean isExistReview(Long targetId) {
         return reviewRepository.findById(targetId).isPresent();
     }
 
@@ -74,14 +74,18 @@ public class BlameService {
     }
 
     private void validateExistTarget(BlameRequest blameRequest) {
-        boolean existTarget = reportCheck.get(blameRequest.blameTarget()).test(blameRequest.targetId());
-        if (!existTarget) {
+        boolean isExistTarget = reportCheck.get(blameRequest.blameTarget())
+                .test(blameRequest.targetId());
+
+        if (!isExistTarget) {
             throw new NotFoundException(BlameExceptionType.NOT_EXIST_TARGET);
         }
     }
 
     private void validateBlameMe(BlameRequest blameRequest, Member member) {
-        boolean blameMe = reportMe.get(blameRequest.blameTarget()).test(blameRequest.targetId(), member);
+        boolean blameMe = reportMe.get(blameRequest.blameTarget())
+                .test(blameRequest.targetId(), member);
+
         if (blameMe) {
             throw new BadRequestException(BlameExceptionType.BLAME_ME);
         }

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/application/BlameService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/application/BlameService.java
@@ -1,0 +1,101 @@
+package org.dinosaur.foodbowl.domain.blame.application;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.blame.domain.Blame;
+import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
+import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
+import org.dinosaur.foodbowl.domain.blame.exception.BlameExceptionType;
+import org.dinosaur.foodbowl.domain.blame.persistence.BlameRepository;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
+import org.dinosaur.foodbowl.domain.review.persistence.ReviewRepository;
+import org.dinosaur.foodbowl.global.exception.BadRequestException;
+import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class BlameService {
+
+    private final BlameRepository blameRepository;
+    private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
+
+    private final Map<BlameTarget, Predicate<Long>> reportCheck = new EnumMap<>(BlameTarget.class) {{
+        put(BlameTarget.MEMBER, BlameService.this::existMember);
+        put(BlameTarget.REVIEW, BlameService.this::existReview);
+    }};
+
+    private final Map<BlameTarget, BiPredicate<Long, Member>> reportMe = new EnumMap<>(BlameTarget.class) {{
+        put(BlameTarget.MEMBER, BlameService.this::isMemberMe);
+        put(BlameTarget.REVIEW, BlameService.this::isReviewMe);
+    }};
+
+    private boolean existMember(Long targetId) {
+        return memberRepository.findById(targetId).isPresent();
+    }
+
+    private boolean existReview(Long targetId) {
+        return reviewRepository.findById(targetId).isPresent();
+    }
+
+    private boolean isMemberMe(Long targetId, Member member) {
+        return Objects.equals(targetId, member.getId());
+    }
+
+    private boolean isReviewMe(Long targetId, Member member) {
+        return reviewRepository.findById(targetId)
+                .map(review -> !review.isNotOwnerOf(member))
+                .orElse(false);
+    }
+
+    @Transactional
+    public void blame(BlameRequest blameRequest, Member loginMember) {
+        validateBlame(blameRequest, loginMember);
+        Blame blame = Blame.builder()
+                .member(loginMember)
+                .targetId(blameRequest.targetId())
+                .blameTarget(blameRequest.blameTarget())
+                .description(blameRequest.description())
+                .build();
+        blameRepository.save(blame);
+    }
+
+    private void validateBlame(BlameRequest blameRequest, Member member) {
+        validateExistTarget(blameRequest);
+        validateBlameMe(blameRequest, member);
+        validateDuplicate(blameRequest, member);
+    }
+
+    private void validateExistTarget(BlameRequest blameRequest) {
+        boolean existTarget = reportCheck.get(blameRequest.blameTarget()).test(blameRequest.targetId());
+        if (!existTarget) {
+            throw new NotFoundException(BlameExceptionType.NOT_EXIST_TARGET);
+        }
+    }
+
+    private void validateBlameMe(BlameRequest blameRequest, Member member) {
+        boolean blameMe = reportMe.get(blameRequest.blameTarget()).test(blameRequest.targetId(), member);
+        if (blameMe) {
+            throw new BadRequestException(BlameExceptionType.BLAME_ME);
+        }
+    }
+
+    private void validateDuplicate(BlameRequest blameRequest, Member member) {
+        Optional<Blame> blame = blameRepository.findByMemberAndTargetIdAndBlameTarget(
+                member,
+                blameRequest.targetId(),
+                blameRequest.blameTarget()
+        );
+        if (blame.isPresent()) {
+            throw new BadRequestException(BlameExceptionType.DUPLICATE_BLAME);
+        }
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/application/BlameService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/application/BlameService.java
@@ -3,7 +3,6 @@ package org.dinosaur.foodbowl.domain.blame.application;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
@@ -89,13 +88,12 @@ public class BlameService {
     }
 
     private void validateDuplicate(BlameRequest blameRequest, Member member) {
-        Optional<Blame> blame = blameRepository.findByMemberAndTargetIdAndBlameTarget(
+        blameRepository.findByMemberAndTargetIdAndBlameTarget(
                 member,
                 blameRequest.targetId(),
                 blameRequest.blameTarget()
-        );
-        if (blame.isPresent()) {
+        ).ifPresent(exist -> {
             throw new BadRequestException(BlameExceptionType.DUPLICATE_BLAME);
-        }
+        });
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/Blame.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/Blame.java
@@ -1,6 +1,7 @@
 package org.dinosaur.foodbowl.domain.blame.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -13,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,6 +22,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
+import org.dinosaur.foodbowl.domain.blame.domain.vo.Description;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 
@@ -58,10 +61,15 @@ public class Blame extends AuditingEntity {
     @Column(name = "target_type", updatable = false)
     private BlameTarget blameTarget;
 
+    @Valid
+    @Embedded
+    private Description description;
+
     @Builder
-    private Blame(Member member, Long targetId, BlameTarget blameTarget) {
+    private Blame(Member member, Long targetId, BlameTarget blameTarget, String description) {
         this.member = member;
         this.targetId = targetId;
         this.blameTarget = blameTarget;
+        this.description = new Description(description);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/vo/BlameTarget.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/vo/BlameTarget.java
@@ -1,7 +1,18 @@
 package org.dinosaur.foodbowl.domain.blame.domain.vo;
 
+import org.dinosaur.foodbowl.domain.blame.exception.BlameExceptionType;
+import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
+
 public enum BlameTarget {
 
     MEMBER,
-    REVIEW
+    REVIEW;
+
+    public static BlameTarget from(String blameTarget) {
+        return switch (blameTarget) {
+            case "MEMBER" -> MEMBER;
+            case "REVIEW" -> REVIEW;
+            default -> throw new InvalidArgumentException(BlameExceptionType.NOT_EXIST_TYPE);
+        };
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/vo/Description.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/vo/Description.java
@@ -1,0 +1,37 @@
+package org.dinosaur.foodbowl.domain.blame.domain.vo;
+
+import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dinosaur.foodbowl.domain.blame.exception.BlameExceptionType;
+import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Description {
+
+    private static final int MAXIMUM_LENGTH = 255;
+
+    @NotNull
+    @Column(name = "description", updatable = false, length = MAXIMUM_LENGTH)
+    private String value;
+
+    public Description(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(String value) {
+        if (StringUtils.isBlank(value)) {
+            throw new InvalidArgumentException(BlameExceptionType.DESCRIPTION_EMPTY);
+        }
+        if (value.length() > MAXIMUM_LENGTH) {
+            throw new InvalidArgumentException(BlameExceptionType.INVALID_DESCRIPTION_LENGTH);
+        }
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/vo/Description.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/vo/Description.java
@@ -1,6 +1,5 @@
 package org.dinosaur.foodbowl.domain.blame.domain.vo;
 
-import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
@@ -27,7 +26,7 @@ public class Description {
     }
 
     private void validate(String value) {
-        if (StringUtils.isBlank(value)) {
+        if (value == null || value.isBlank()) {
             throw new InvalidArgumentException(BlameExceptionType.DESCRIPTION_EMPTY);
         }
         if (value.length() > MAXIMUM_LENGTH) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/dto/request/BlameRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/dto/request/BlameRequest.java
@@ -2,8 +2,8 @@ package org.dinosaur.foodbowl.domain.blame.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
 
 @Schema(description = "신고 요청")
 public record BlameRequest(
@@ -12,7 +12,8 @@ public record BlameRequest(
         Long targetId,
 
         @Schema(description = "신고 대상 타입", example = "MEMBER")
-        BlameTarget blameTarget,
+        @NotNull(message = "신고 대상 타입이 공백이거나 존재하지 않습니다.")
+        String blameTarget,
 
         @Schema(description = "신고 사유", example = "부적절한 리뷰입니다.")
         @NotBlank(message = "신고 사유가 공백이거나 존재하지 않습니다.")

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/dto/request/BlameRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/dto/request/BlameRequest.java
@@ -1,0 +1,21 @@
+package org.dinosaur.foodbowl.domain.blame.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
+
+@Schema(description = "신고 요청")
+public record BlameRequest(
+        @Schema(description = "신고 대상 ID", example = "1")
+        @Positive(message = "신고 대상 ID는 양의 정수만 가능합니다.")
+        Long targetId,
+
+        @Schema(description = "신고 대상 타입", example = "MEMBER")
+        BlameTarget blameTarget,
+
+        @Schema(description = "신고 사유", example = "부적절한 리뷰입니다.")
+        @NotBlank(message = "신고 사유가 공백이거나 존재하지 않습니다.")
+        String description
+) {
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/dto/request/BlameRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/dto/request/BlameRequest.java
@@ -2,7 +2,6 @@ package org.dinosaur.foodbowl.domain.blame.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 @Schema(description = "신고 요청")
@@ -12,7 +11,7 @@ public record BlameRequest(
         Long targetId,
 
         @Schema(description = "신고 대상 타입", example = "MEMBER")
-        @NotNull(message = "신고 대상 타입이 공백이거나 존재하지 않습니다.")
+        @NotBlank(message = "신고 대상 타입이 공백이거나 존재하지 않습니다.")
         String blameTarget,
 
         @Schema(description = "신고 사유", example = "부적절한 리뷰입니다.")

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/exception/BlameExceptionType.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/exception/BlameExceptionType.java
@@ -10,12 +10,13 @@ public enum BlameExceptionType implements ExceptionType {
     NOT_EXIST_TARGET("BLAME-101", "존재하지 않는 신고 대상입니다."),
     DUPLICATE_BLAME("BLAME-102", "신고 대상에 대한 신고 이력이 존재합니다."),
     DESCRIPTION_EMPTY("BLAME-103", "신고 내용이 공백이거나 존재하지 않습니다."),
-    INVALID_DESCRIPTION_LENGTH("BLAME-104", "신고 내용의 최대 길이를 초과하였습니다.");
+    INVALID_DESCRIPTION_LENGTH("BLAME-104", "신고 내용의 최대 길이를 초과하였습니다."),
+    NOT_EXIST_TYPE("BLAME-105", "존재하지 않는 신고 타입입니다.");
 
     private final String errorCode;
     private final String message;
 
-    BlameExceptionType(final String errorCode, final String message) {
+    BlameExceptionType(String errorCode, String message) {
         this.errorCode = errorCode;
         this.message = message;
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/exception/BlameExceptionType.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/exception/BlameExceptionType.java
@@ -1,0 +1,22 @@
+package org.dinosaur.foodbowl.domain.blame.exception;
+
+import lombok.Getter;
+import org.dinosaur.foodbowl.global.exception.type.ExceptionType;
+
+@Getter
+public enum BlameExceptionType implements ExceptionType {
+
+    BLAME_ME("BLAME-100", "스스로에 대해 신고할 수 없습니다."),
+    NOT_EXIST_TARGET("BLAME-101", "존재하지 않는 신고 대상입니다."),
+    DUPLICATE_BLAME("BLAME-102", "신고 대상에 대한 신고 이력이 존재합니다."),
+    DESCRIPTION_EMPTY("BLAME-103", "신고 내용이 공백이거나 존재하지 않습니다."),
+    INVALID_DESCRIPTION_LENGTH("BLAME-104", "신고 내용의 최대 길이를 초과하였습니다.");
+
+    private final String errorCode;
+    private final String message;
+
+    BlameExceptionType(final String errorCode, final String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/exception/BlameExceptionType.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/exception/BlameExceptionType.java
@@ -6,7 +6,7 @@ import org.dinosaur.foodbowl.global.exception.type.ExceptionType;
 @Getter
 public enum BlameExceptionType implements ExceptionType {
 
-    BLAME_ME("BLAME-100", "스스로에 대해 신고할 수 없습니다."),
+    BLAME_ME("BLAME-100", "본인을 신고할 수 없습니다."),
     NOT_EXIST_TARGET("BLAME-101", "존재하지 않는 신고 대상입니다."),
     DUPLICATE_BLAME("BLAME-102", "신고 대상에 대한 신고 이력이 존재합니다."),
     DESCRIPTION_EMPTY("BLAME-103", "신고 내용이 공백이거나 존재하지 않습니다."),

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/persistence/BlameRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/persistence/BlameRepository.java
@@ -1,7 +1,14 @@
 package org.dinosaur.foodbowl.domain.blame.persistence;
 
+import java.util.Optional;
 import org.dinosaur.foodbowl.domain.blame.domain.Blame;
+import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.springframework.data.repository.Repository;
 
 public interface BlameRepository extends Repository<Blame, Long> {
+
+    Optional<Blame> findByMemberAndTargetIdAndBlameTarget(Member member, Long targetId, BlameTarget blameTarget);
+
+    Blame save(Blame blame);
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameController.java
@@ -1,0 +1,27 @@
+package org.dinosaur.foodbowl.domain.blame.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.blame.application.BlameService;
+import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/blames")
+@RestController
+public class BlameController {
+
+    private final BlameService blameService;
+
+    @PostMapping
+    public ResponseEntity<Void> blame(@RequestBody @Valid BlameRequest blameRequest, @Auth Member loginMember) {
+        blameService.blame(blameRequest, loginMember);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/v1/blames")
 @RestController
-public class BlameController {
+public class BlameController implements BlameControllerDocs {
 
     private final BlameService blameService;
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerDocs.java
@@ -1,0 +1,58 @@
+package org.dinosaur.foodbowl.domain.blame.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "신고", description = "신고 API")
+public interface BlameControllerDocs {
+
+    @Operation(
+            summary = "신고 등록",
+            description = """
+                    신고하는 대상의 ID를 통해 신고를 등록합니다.
+                                        
+                    현재는 회원(MEMBER), 리뷰(REVIEW)의 신고만 가능합니다.
+                                        
+                    blameTarget에 회원을 신고하는 경우 MEMBER를, 리뷰를 신고하는 경우 REVIEW값을 등록합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "신고 등록 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.양의 정수가 아닌 신고 대상 ID
+                                                        
+                            2.정상적이지 않은 신고 대상 타입
+                                                        
+                            3.신고 사유가 존재하지 않을 경우
+                                                        
+                            4.스스로를 신고하는 경우
+                                                        
+                            5.이미 신고 대상에 대한 신고 내역이 존재하는 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            1.존재하지 않는 회원 신고
+                                                        
+                            2.존재하지 않는 리뷰 신고
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<Void> blame(BlameRequest blameRequest, Member loginMember);
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -81,7 +81,12 @@ public class ReviewService {
     }
 
     @Transactional
-    public void update(Long id, ReviewUpdateRequest reviewUpdateRequest, List<MultipartFile> imageFiles, Member member) {
+    public void update(
+            Long id,
+            ReviewUpdateRequest reviewUpdateRequest,
+            List<MultipartFile> imageFiles,
+            Member member
+    ) {
         Review review = reviewRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ReviewExceptionType.NOT_FOUND));
         validateReviewOwner(member, review);

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -57,14 +57,14 @@ public interface ReviewControllerDocs {
 
     @Operation(summary = "리뷰 수정",
             description = """
-                        가게에 해당하는 리뷰를 수정합니다.
-                        
-                        images 필드에는 새롭게 추가되는 사진을 보내면 됩니다.
-                        
-                        request의 deleteIds 필드에는 삭제하는 사진의 ID를 담아서 보내면 됩니다.
-                        
-                        삭제하는 사진이 없는 경우에도 deleteIds 빈 배열 '[]'을 반드시 보내야 합니다.
-                        """
+                    가게에 해당하는 리뷰를 수정합니다.
+                                            
+                    images 필드에는 새롭게 추가되는 사진을 보내면 됩니다.
+                                            
+                    request의 deleteIds 필드에는 삭제하는 사진의 ID를 담아서 보내면 됩니다.
+                                            
+                    삭제하는 사진이 없는 경우에도 deleteIds 빈 배열 '[]'을 반드시 보내야 합니다.
+                    """
     )
     @ApiResponses({
             @ApiResponse(
@@ -77,15 +77,15 @@ public interface ReviewControllerDocs {
                             1.사진이 4개보다 많은 경우
                                                         
                             2.삭제 사진 필드가 없는 경우
-                            
+                                                        
                             3.삭제 사진 ID에 음수가 포함된 경우
-                            
+                                                        
                             4.수정하는 리뷰 내용이 없는 경우
-                            
+                                                        
                             5.양수가 아닌 리뷰 ID
-                            
+                                                        
                             6.삭제 사진 ID가 4개보다 많은 경우
-                            
+                                                        
                             7.삭제하려는 사진이 해당 리뷰의 사진이 아닌 경우
                             """,
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))

--- a/src/main/java/org/dinosaur/foodbowl/global/presentation/PositiveList.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/presentation/PositiveList.java
@@ -13,6 +13,8 @@ import java.lang.annotation.Target;
 public @interface PositiveList {
 
     String message() default "List elements must be positive";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
@@ -1,0 +1,92 @@
+package org.dinosaur.foodbowl.domain.blame.application;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
+import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.review.domain.Review;
+import org.dinosaur.foodbowl.global.exception.BadRequestException;
+import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.test.IntegrationTest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BlameServiceTest extends IntegrationTest {
+
+    @Autowired
+    private BlameService blameService;
+
+    @Nested
+    class 신고_시 {
+
+        @Test
+        void 정상적인_요청이라면_신고가_등록된다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+            Member target = memberTestPersister.memberBuilder().save();
+            BlameRequest request = new BlameRequest(target.getId(), BlameTarget.MEMBER, "부적절한 닉네임");
+
+            assertThatNoException().isThrownBy(() -> blameService.blame(request, loginMember));
+        }
+
+        @Test
+        void 회원_신고_시_존재하지_않는_회원이면_예외를_던진다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+            Long invalidMemberId = loginMember.getId() + 1;
+            BlameRequest request = new BlameRequest(invalidMemberId, BlameTarget.MEMBER, "부적절한 닉네임");
+
+            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("존재하지 않는 신고 대상입니다.");
+        }
+
+        @Test
+        void 리뷰_신고_시_존재하지_않는_리뷰라면_예외를_던진다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+            BlameRequest request = new BlameRequest(1L, BlameTarget.REVIEW, "부적절한 리뷰 내용");
+
+            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("존재하지 않는 신고 대상입니다.");
+        }
+
+        @Test
+        void 회원_신고_시_나를_신고한다면_예외를_던진다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+            BlameRequest request = new BlameRequest(loginMember.getId(), BlameTarget.MEMBER, "부적절한 닉네임");
+
+            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("스스로에 대해 신고할 수 없습니다.");
+        }
+
+        @Test
+        void 리뷰_신고_시_나의_리뷰를_신고한다면_예외를_던진다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+            Review review = reviewTestPersister.builder().member(loginMember).save();
+            BlameRequest request = new BlameRequest(review.getId(), BlameTarget.REVIEW, "부적절한 닉네임");
+
+            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("스스로에 대해 신고할 수 없습니다.");
+        }
+
+        @Test
+        void 이미_신고한_대상이라면_예외를_던진다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+            Member target = memberTestPersister.memberBuilder().save();
+            BlameRequest request = new BlameRequest(target.getId(), BlameTarget.MEMBER, "부적절한 닉네임");
+            blameService.blame(request, loginMember);
+
+            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("신고 대상에 대한 신고 이력이 존재합니다.");
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
@@ -60,7 +60,7 @@ class BlameServiceTest extends IntegrationTest {
 
             assertThatThrownBy(() -> blameService.blame(request, loginMember))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage("스스로에 대해 신고할 수 없습니다.");
+                    .hasMessage("본인을 신고할 수 없습니다.");
         }
 
         @Test
@@ -71,7 +71,7 @@ class BlameServiceTest extends IntegrationTest {
 
             assertThatThrownBy(() -> blameService.blame(request, loginMember))
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessage("스스로에 대해 신고할 수 없습니다.");
+                    .hasMessage("본인을 신고할 수 없습니다.");
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
@@ -8,6 +8,7 @@ import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
+import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.junit.jupiter.api.Nested;
@@ -27,16 +28,27 @@ class BlameServiceTest extends IntegrationTest {
         void 정상적인_요청이라면_신고가_등록된다() {
             Member loginMember = memberTestPersister.memberBuilder().save();
             Member target = memberTestPersister.memberBuilder().save();
-            BlameRequest request = new BlameRequest(target.getId(), BlameTarget.MEMBER, "부적절한 닉네임");
+            BlameRequest request = new BlameRequest(target.getId(), BlameTarget.MEMBER.name(), "부적절한 닉네임");
 
             assertThatNoException().isThrownBy(() -> blameService.blame(request, loginMember));
+        }
+
+        @Test
+        void 정상적이지_않은_신고_타입이라면_예외를_던진다() {
+            Member loginMember = memberTestPersister.memberBuilder().save();
+            Member target = memberTestPersister.memberBuilder().save();
+            BlameRequest request = new BlameRequest(target.getId(), "HELLO", "부적절한 닉네임");
+
+            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+                    .isInstanceOf(InvalidArgumentException.class)
+                    .hasMessage("존재하지 않는 신고 타입입니다.");
         }
 
         @Test
         void 회원_신고_시_존재하지_않는_회원이면_예외를_던진다() {
             Member loginMember = memberTestPersister.memberBuilder().save();
             Long invalidMemberId = loginMember.getId() + 1;
-            BlameRequest request = new BlameRequest(invalidMemberId, BlameTarget.MEMBER, "부적절한 닉네임");
+            BlameRequest request = new BlameRequest(invalidMemberId, BlameTarget.MEMBER.name(), "부적절한 닉네임");
 
             assertThatThrownBy(() -> blameService.blame(request, loginMember))
                     .isInstanceOf(NotFoundException.class)
@@ -46,7 +58,7 @@ class BlameServiceTest extends IntegrationTest {
         @Test
         void 리뷰_신고_시_존재하지_않는_리뷰라면_예외를_던진다() {
             Member loginMember = memberTestPersister.memberBuilder().save();
-            BlameRequest request = new BlameRequest(1L, BlameTarget.REVIEW, "부적절한 리뷰 내용");
+            BlameRequest request = new BlameRequest(1L, BlameTarget.REVIEW.name(), "부적절한 리뷰 내용");
 
             assertThatThrownBy(() -> blameService.blame(request, loginMember))
                     .isInstanceOf(NotFoundException.class)
@@ -56,7 +68,7 @@ class BlameServiceTest extends IntegrationTest {
         @Test
         void 회원_신고_시_나를_신고한다면_예외를_던진다() {
             Member loginMember = memberTestPersister.memberBuilder().save();
-            BlameRequest request = new BlameRequest(loginMember.getId(), BlameTarget.MEMBER, "부적절한 닉네임");
+            BlameRequest request = new BlameRequest(loginMember.getId(), BlameTarget.MEMBER.name(), "부적절한 닉네임");
 
             assertThatThrownBy(() -> blameService.blame(request, loginMember))
                     .isInstanceOf(BadRequestException.class)
@@ -67,7 +79,7 @@ class BlameServiceTest extends IntegrationTest {
         void 리뷰_신고_시_나의_리뷰를_신고한다면_예외를_던진다() {
             Member loginMember = memberTestPersister.memberBuilder().save();
             Review review = reviewTestPersister.builder().member(loginMember).save();
-            BlameRequest request = new BlameRequest(review.getId(), BlameTarget.REVIEW, "부적절한 닉네임");
+            BlameRequest request = new BlameRequest(review.getId(), BlameTarget.REVIEW.name(), "부적절한 닉네임");
 
             assertThatThrownBy(() -> blameService.blame(request, loginMember))
                     .isInstanceOf(BadRequestException.class)
@@ -78,7 +90,7 @@ class BlameServiceTest extends IntegrationTest {
         void 이미_신고한_대상이라면_예외를_던진다() {
             Member loginMember = memberTestPersister.memberBuilder().save();
             Member target = memberTestPersister.memberBuilder().save();
-            BlameRequest request = new BlameRequest(target.getId(), BlameTarget.MEMBER, "부적절한 닉네임");
+            BlameRequest request = new BlameRequest(target.getId(), BlameTarget.MEMBER.name(), "부적절한 닉네임");
             blameService.blame(request, loginMember);
 
             assertThatThrownBy(() -> blameService.blame(request, loginMember))

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
@@ -10,14 +10,11 @@ import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
 import org.dinosaur.foodbowl.test.IntegrationTest;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("NonAsciiCharacters")
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class BlameServiceTest extends IntegrationTest {
 
     @Autowired

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/domain/BlameTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/domain/BlameTest.java
@@ -1,33 +1,81 @@
 package org.dinosaur.foodbowl.domain.blame.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
+import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class BlameTest {
 
-    @Test
-    void 신고를_생성한다() {
-        Member member = Member.builder()
+    @Nested
+    class 신고_생성_시 {
+
+        @Test
+        void 신고를_정상적으로_생성한다() {
+            Member member = mockingMember();
+            Blame blame = Blame.builder()
+                    .member(member)
+                    .targetId(1L)
+                    .blameTarget(BlameTarget.MEMBER)
+                    .description("invalid")
+                    .build();
+
+            assertThat(blame.getMember()).isEqualTo(member);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" "})
+        void 신고_내용이_공백이거나_존재하지_않으면_예외를_던진다(String description) {
+            Member member = mockingMember();
+
+            assertThatThrownBy(() -> Blame.builder()
+                    .member(member)
+                    .targetId(1L)
+                    .blameTarget(BlameTarget.MEMBER)
+                    .description(description)
+                    .build()
+            )
+                    .isInstanceOf(InvalidArgumentException.class)
+                    .hasMessage("신고 내용이 공백이거나 존재하지 않습니다.");
+        }
+
+        @Test
+        void 신고_내용이_최대_길이를_초과하면_얘외를_던진다() {
+            Member member = mockingMember();
+            String description = "a".repeat(256);
+
+            assertThatThrownBy(() -> Blame.builder()
+                    .member(member)
+                    .targetId(1L)
+                    .blameTarget(BlameTarget.MEMBER)
+                    .description(description)
+                    .build()
+            )
+                    .isInstanceOf(InvalidArgumentException.class)
+                    .hasMessage("신고 내용의 최대 길이를 초과하였습니다.");
+        }
+    }
+
+    private Member mockingMember() {
+        return Member.builder()
                 .socialType(SocialType.APPLE)
                 .socialId("1")
                 .email("email@email.com")
                 .nickname("hello")
                 .introduction("hello world")
                 .build();
-        Blame blame = Blame.builder()
-                .member(member)
-                .targetId(1L)
-                .blameTarget(BlameTarget.MEMBER)
-                .build();
-
-        assertThat(blame.getMember()).isEqualTo(member);
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/domain/vo/BlameTargetTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/domain/vo/BlameTargetTest.java
@@ -1,0 +1,36 @@
+package org.dinosaur.foodbowl.domain.blame.domain.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BlameTargetTest {
+
+    @Nested
+    class 신고_타입_생성 {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"MEMBER", "REVIEW"})
+        void 존재하는_신고_타입이면_신고_대상을_반환한다(String target) {
+            BlameTarget blameTarget = BlameTarget.from(target);
+
+            assertThat(blameTarget).isEqualTo(BlameTarget.valueOf(target));
+        }
+
+        @Test
+        void 존재하는_신고_타입이_아니라면_예외를_던진다() {
+            assertThatThrownBy(() -> BlameTarget.from("HELLO"))
+                    .isInstanceOf(InvalidArgumentException.class)
+                    .hasMessage("존재하지 않는 신고 타입입니다.");
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/persistence/BlameRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/persistence/BlameRepositoryTest.java
@@ -7,14 +7,11 @@ import org.dinosaur.foodbowl.domain.blame.domain.Blame;
 import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.test.PersistenceTest;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("NonAsciiCharacters")
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class BlameRepositoryTest extends PersistenceTest {
 
     @Autowired

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/persistence/BlameRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/persistence/BlameRepositoryTest.java
@@ -1,0 +1,75 @@
+package org.dinosaur.foodbowl.domain.blame.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.dinosaur.foodbowl.domain.blame.domain.Blame;
+import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.test.PersistenceTest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BlameRepositoryTest extends PersistenceTest {
+
+    @Autowired
+    private BlameRepository blameRepository;
+
+    @Nested
+    class 신고자와_타겟ID와_타겟대상으로_조회_시 {
+
+        @Test
+        void 존재한다면_신고를_반환한다() {
+            Member member = memberTestPersister.memberBuilder().save();
+            Member target = memberTestPersister.memberBuilder().save();
+            blameTestPersister.builder().member(member).targetId(target.getId()).blameTarget(BlameTarget.MEMBER).save();
+
+            Optional<Blame> blame =
+                    blameRepository.findByMemberAndTargetIdAndBlameTarget(member, target.getId(), BlameTarget.MEMBER);
+
+            assertThat(blame).isPresent();
+        }
+
+        @Test
+        void 신고자만_달라도_조회되지_않는다() {
+            Member member = memberTestPersister.memberBuilder().save();
+            Member target = memberTestPersister.memberBuilder().save();
+            blameTestPersister.builder().targetId(target.getId()).blameTarget(BlameTarget.MEMBER).save();
+
+            Optional<Blame> blame =
+                    blameRepository.findByMemberAndTargetIdAndBlameTarget(member, target.getId(), BlameTarget.MEMBER);
+
+            assertThat(blame).isNotPresent();
+        }
+
+        @Test
+        void 타겟ID만_달라도_조회되지_않는다() {
+            Member member = memberTestPersister.memberBuilder().save();
+            Member target = memberTestPersister.memberBuilder().save();
+            blameTestPersister.builder().targetId(target.getId()).blameTarget(BlameTarget.MEMBER).save();
+
+            Long otherTargetId = target.getId() + 1;
+            Optional<Blame> blame =
+                    blameRepository.findByMemberAndTargetIdAndBlameTarget(member, otherTargetId, BlameTarget.MEMBER);
+
+            assertThat(blame).isNotPresent();
+        }
+
+        @Test
+        void 타겟대상만_달라도_조회되지_않는다() {
+            Member member = memberTestPersister.memberBuilder().save();
+            Member target = memberTestPersister.memberBuilder().save();
+            blameTestPersister.builder().targetId(target.getId()).blameTarget(BlameTarget.MEMBER).save();
+
+            Optional<Blame> blame =
+                    blameRepository.findByMemberAndTargetIdAndBlameTarget(member, target.getId(), BlameTarget.REVIEW);
+
+            assertThat(blame).isNotPresent();
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerTest.java
@@ -1,0 +1,113 @@
+package org.dinosaur.foodbowl.domain.blame.presentation;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.domain.blame.application.BlameService;
+import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
+import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
+import org.dinosaur.foodbowl.test.PresentationTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SuppressWarnings("NonAsciiCharacters")
+@WebMvcTest(BlameController.class)
+class BlameControllerTest extends PresentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private BlameService blameService;
+
+    @Nested
+    class 신고_시 {
+
+        private final String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+        @Test
+        void 정상적인_요청이라면_200_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+            BlameRequest request = new BlameRequest(1L, BlameTarget.MEMBER, "부적절한 닉네임");
+            willDoNothing().given(blameService).blame(any(BlameRequest.class), any(Member.class));
+
+            mockMvc.perform(post("/v1/blames")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void 신고_대상_ID가_양의_정수가_아니라면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+            BlameRequest request = new BlameRequest(-1L, BlameTarget.MEMBER, "부적절한 닉네임");
+
+            mockMvc.perform(post("/v1/blames")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
+                    .andExpect(jsonPath("$.message", containsString("신고 대상 ID는 양의 정수만 가능합니다.")));
+            ;
+        }
+
+        @Test
+        void 신고_대상_타입이_올바르지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+            String content = """
+                    "targetId":-1,"blameTarget":"HELLO","description":"부적절한 닉네임"
+                    """;
+
+            mockMvc.perform(post("/v1/blames")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(content))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" "})
+        void 신고_사유가_공백이거나_존재하지_않으면_400_응답을_반환한다(String description) throws Exception {
+            mockingAuthMemberInResolver();
+            BlameRequest request = new BlameRequest(1L, BlameTarget.MEMBER, description);
+
+            mockMvc.perform(post("/v1/blames")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
+                    .andExpect(jsonPath("$.message", containsString("신고 사유가 공백이거나 존재하지 않습니다.")));
+        }
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerTest.java
@@ -51,7 +51,7 @@ class BlameControllerTest extends PresentationTest {
         @Test
         void 정상적인_요청이라면_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
-            BlameRequest request = new BlameRequest(1L, BlameTarget.MEMBER, "부적절한 닉네임");
+            BlameRequest request = new BlameRequest(1L, BlameTarget.MEMBER.name(), "부적절한 닉네임");
             willDoNothing().given(blameService).blame(any(BlameRequest.class), any(Member.class));
 
             mockMvc.perform(post("/v1/blames")
@@ -65,7 +65,7 @@ class BlameControllerTest extends PresentationTest {
         @Test
         void 신고_대상_ID가_양의_정수가_아니라면_400_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
-            BlameRequest request = new BlameRequest(-1L, BlameTarget.MEMBER, "부적절한 닉네임");
+            BlameRequest request = new BlameRequest(-1L, BlameTarget.MEMBER.name(), "부적절한 닉네임");
 
             mockMvc.perform(post("/v1/blames")
                             .header(AUTHORIZATION, BEARER + accessToken)
@@ -98,7 +98,7 @@ class BlameControllerTest extends PresentationTest {
         @ValueSource(strings = {" "})
         void 신고_사유가_공백이거나_존재하지_않으면_400_응답을_반환한다(String description) throws Exception {
             mockingAuthMemberInResolver();
-            BlameRequest request = new BlameRequest(1L, BlameTarget.MEMBER, description);
+            BlameRequest request = new BlameRequest(1L, BlameTarget.MEMBER.name(), description);
 
             mockMvc.perform(post("/v1/blames")
                             .header(AUTHORIZATION, BEARER + accessToken)

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerTest.java
@@ -78,19 +78,21 @@ class BlameControllerTest extends PresentationTest {
             ;
         }
 
-        @Test
-        void 신고_대상_타입이_올바르지_않으면_400_응답을_반환한다() throws Exception {
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" "})
+        void 신고_대상_타입이_공백이거나_존재하지_않으면_400_응답을_반환한다(String blameTarget) throws Exception {
             mockingAuthMemberInResolver();
-            String content = """
-                    "targetId":-1,"blameTarget":"HELLO","description":"부적절한 닉네임"
-                    """;
+            BlameRequest request = new BlameRequest(1L, blameTarget, "부적절한 닉네임");
 
             mockMvc.perform(post("/v1/blames")
                             .header(AUTHORIZATION, BEARER + accessToken)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(content))
+                            .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("CLIENT-100"))
+                    .andExpect(jsonPath("$.message", containsString("신고 대상 타입이 공백이거나 존재하지 않습니다.")));
         }
 
         @ParameterizedTest

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -160,7 +160,7 @@ class ReviewServiceTest extends IntegrationTest {
             reviewService.update(review.getId(), reviewUpdateRequest, updateImages, member);
 
             Review updateReview = reviewRepository.findById(review.getId()).get();
-            int updatePhotoSize = multipartFiles.size()  + updateImages.size() - deletePhotoIds.size();
+            int updatePhotoSize = multipartFiles.size() + updateImages.size() - deletePhotoIds.size();
             assertSoftly(softly -> {
                 softly.assertThat(updateReview.getContent()).isEqualTo(reviewUpdateRequest.reviewContent());
                 softly.assertThat(reviewPhotoService.findPhotos(updateReview)).hasSize(updatePhotoSize);

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewPhotoCustomRepositoryImplTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewPhotoCustomRepositoryImplTest.java
@@ -69,7 +69,8 @@ class ReviewPhotoCustomRepositoryImplTest extends PersistenceTest {
         assertSoftly(softly -> {
             softly.assertThat(deleteCount).isEqualTo(deleteTargetPhotos.size());
             softly.assertThat(reviewPhotoRepository.findAllByReview(review)).containsExactly(reviewPhoto);
-            softly.assertThat(reviewPhotoRepository.findAllByReview(review)).doesNotContain(deleteReviewPhotoA, deleteReviewPhotoB);
+            softly.assertThat(reviewPhotoRepository.findAllByReview(review))
+                    .doesNotContain(deleteReviewPhotoA, deleteReviewPhotoB);
         });
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/test/IntegrationTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/IntegrationTest.java
@@ -1,11 +1,13 @@
 package org.dinosaur.foodbowl.test;
 
+import org.dinosaur.foodbowl.test.persister.BlameTestPersister;
 import org.dinosaur.foodbowl.test.persister.FollowTestPersister;
 import org.dinosaur.foodbowl.test.persister.MemberTestPersister;
 import org.dinosaur.foodbowl.test.persister.PhotoTestPersister;
 import org.dinosaur.foodbowl.test.persister.ReviewTestPersister;
 import org.dinosaur.foodbowl.test.persister.SchoolTestPersister;
 import org.dinosaur.foodbowl.test.persister.StoreTestPersister;
+import org.dinosaur.foodbowl.test.persister.ThumbnailTestPersister;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class IntegrationTest {
 
     @Autowired
-    protected ReviewTestPersister reviewTestPersister;
+    protected BlameTestPersister blameTestPersister;
+
+    @Autowired
+    protected FollowTestPersister followTestPersister;
 
     @Autowired
     protected MemberTestPersister memberTestPersister;
@@ -27,11 +32,14 @@ public class IntegrationTest {
     protected PhotoTestPersister photoTestPersister;
 
     @Autowired
-    protected StoreTestPersister storeTestPersister;
+    protected ReviewTestPersister reviewTestPersister;
 
     @Autowired
     protected SchoolTestPersister schoolTestPersister;
 
     @Autowired
-    protected FollowTestPersister followTestPersister;
+    protected StoreTestPersister storeTestPersister;
+
+    @Autowired
+    protected ThumbnailTestPersister thumbnailTestPersister;
 }

--- a/src/test/java/org/dinosaur/foodbowl/test/PersistenceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/PersistenceTest.java
@@ -1,6 +1,7 @@
 package org.dinosaur.foodbowl.test;
 
 import org.dinosaur.foodbowl.global.config.JpaConfig;
+import org.dinosaur.foodbowl.test.persister.BlameTestPersister;
 import org.dinosaur.foodbowl.test.persister.FollowTestPersister;
 import org.dinosaur.foodbowl.test.persister.MemberTestPersister;
 import org.dinosaur.foodbowl.test.persister.Persister;
@@ -8,6 +9,7 @@ import org.dinosaur.foodbowl.test.persister.PhotoTestPersister;
 import org.dinosaur.foodbowl.test.persister.ReviewTestPersister;
 import org.dinosaur.foodbowl.test.persister.SchoolTestPersister;
 import org.dinosaur.foodbowl.test.persister.StoreTestPersister;
+import org.dinosaur.foodbowl.test.persister.ThumbnailTestPersister;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,20 +27,26 @@ import org.springframework.context.annotation.Import;
 public class PersistenceTest {
 
     @Autowired
-    protected StoreTestPersister storeTestPersister;
+    protected BlameTestPersister blameTestPersister;
 
     @Autowired
-    protected SchoolTestPersister schoolTestPersister;
+    protected FollowTestPersister followTestPersister;
 
     @Autowired
     protected MemberTestPersister memberTestPersister;
 
     @Autowired
-    protected ReviewTestPersister reviewTestPersister;
-
-    @Autowired
     protected PhotoTestPersister photoTestPersister;
 
     @Autowired
-    protected FollowTestPersister followTestPersister;
+    protected ReviewTestPersister reviewTestPersister;
+
+    @Autowired
+    protected SchoolTestPersister schoolTestPersister;
+
+    @Autowired
+    protected StoreTestPersister storeTestPersister;
+
+    @Autowired
+    protected ThumbnailTestPersister thumbnailTestPersister;
 }

--- a/src/test/java/org/dinosaur/foodbowl/test/persister/BlameTestPersister.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/persister/BlameTestPersister.java
@@ -1,0 +1,57 @@
+package org.dinosaur.foodbowl.test.persister;
+
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.blame.domain.Blame;
+import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
+import org.dinosaur.foodbowl.domain.blame.persistence.BlameRepository;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+
+@RequiredArgsConstructor
+@Persister
+public class BlameTestPersister {
+
+    private final BlameRepository blameRepository;
+    private final MemberTestPersister memberTestPersister;
+
+    public BlameBuilder builder() {
+        return new BlameBuilder();
+    }
+
+    public final class BlameBuilder {
+
+        private Member member;
+        private Long targetId;
+        private BlameTarget blameTarget;
+        private String description;
+
+        public BlameBuilder member(Member member) {
+            this.member = member;
+            return this;
+        }
+
+        public BlameBuilder targetId(Long targetId) {
+            this.targetId = targetId;
+            return this;
+        }
+
+        public BlameBuilder blameTarget(BlameTarget blameTarget) {
+            this.blameTarget = blameTarget;
+            return this;
+        }
+
+        public BlameBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Blame save() {
+            Blame blame = Blame.builder()
+                    .member(member == null ? memberTestPersister.memberBuilder().save() : member)
+                    .targetId(targetId == null ? 1L : targetId)
+                    .blameTarget(blameTarget == null ? BlameTarget.MEMBER : blameTarget)
+                    .description(description == null ? "invalid" : description)
+                    .build();
+            return blameRepository.save(blame);
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #166

## 📝 작업 요약

신고하기 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 멤버, 리뷰에 대한 신고가 가능합니다.
- 존재하지 않는 멤버, 리뷰에 대한 신고는 불가능합니다.
- 스스로 본인에 대한 신고는 불가능합니다.
- 이미 신고한 대상에 대한 신고는 불가능합니다.

`Q`
신고 후에 해당 신고 ID를 사용할 일이 없기에 아무 것도 반환하지 않도록 구현하였습니다. 그렇기에 신고 등록 후 검증할 수 있는 방법이 없어 예외를 던지지 않는 것을 확인하도록 검증하였는데 애매한 것 같아서 이 부분에 대해 좋은 의견이 있으시면 알려주세요 😙

## 🌟 리뷰 요구 사항

> 30분
> 신고가 안되는 상황에 대해 생각하며 리뷰해주시면 감사합니다 :)