### PR TITLE
Feature/#169 학교 상세 주소 필드를 추가한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation platform("org.springframework.cloud:spring-cloud-dependencies:2022.0.2")
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.hibernate:hibernate-spatial:6.2.7.Final'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/Blame.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/domain/Blame.java
@@ -31,12 +31,9 @@ import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 @Table(
         name = "blame",
         uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "UQ_MEMBER_TARGET_ID_TYPE",
-                        columnNames = {"member_id", "target_id", "target_type"}
-                )
+                @UniqueConstraint(name = "uniq_blame", columnNames = {"member_id", "target_id", "target_type"})
         },
-        indexes = {@Index(name = "IDX_BLAME", columnList = "target_id, target_type")}
+        indexes = {@Index(name = "idx_blame", columnList = "target_id, target_type")}
 )
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/domain/Bookmark.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/domain/Bookmark.java
@@ -24,9 +24,7 @@ import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 @Entity
 @Table(
         name = "bookmark",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "UQ_MEMBER_STORE", columnNames = {"member_id", "store_id"})
-        }
+        uniqueConstraints = {@UniqueConstraint(name = "uniq_bookmark", columnNames = {"member_id", "store_id"})}
 )
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/domain/Follow.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/domain/Follow.java
@@ -23,9 +23,7 @@ import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 @Entity
 @Table(
         name = "follow",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "UQ_FOLLOWING_FOLLOWER", columnNames = {"following_id", "follower_id"})
-        }
+        uniqueConstraints = {@UniqueConstraint(name = "uniq_follow", columnNames = {"following_id", "follower_id"})}
 )
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
@@ -32,7 +32,7 @@ import org.hibernate.annotations.Formula;
 @Entity
 @Table(
         name = "member",
-        uniqueConstraints = {@UniqueConstraint(name = "UQ_MEMBER", columnNames = {"social_id", "social_type"})}
+        uniqueConstraints = {@UniqueConstraint(name = "uniq_social_info", columnNames = {"social_id", "social_type"})}
 )
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/Member.java
@@ -9,7 +9,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
@@ -33,10 +32,7 @@ import org.hibernate.annotations.Formula;
 @Entity
 @Table(
         name = "member",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "UQ_MEMBER", columnNames = {"social_id", "social_type"})
-        },
-        indexes = {@Index(name = "IDX_MEMBER", columnList = "social_id, social_type")}
+        uniqueConstraints = {@UniqueConstraint(name = "UQ_MEMBER", columnNames = {"social_id", "social_type"})}
 )
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/MemberRole.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/MemberRole.java
@@ -22,9 +22,7 @@ import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 @Entity
 @Table(
         name = "member_role",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "UQ_MEMBER_ROLE", columnNames = {"member_id", "role_id"})
-        }
+        uniqueConstraints = {@UniqueConstraint(name = "uniq_member_role", columnNames = {"member_id", "role_id"})}
 )
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/domain/MemberThumbnail.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/domain/MemberThumbnail.java
@@ -25,7 +25,7 @@ import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 @Table(
         name = "member_thumbnail",
         uniqueConstraints = {
-                @UniqueConstraint(name = "UQ_MEMBER_THUMBNAIL", columnNames = {"member_id", "thumbnail_id"})
+                @UniqueConstraint(name = "uniq_member_thumbnail", columnNames = {"member_id", "thumbnail_id"})
         }
 )
 @EqualsAndHashCode(of = {"id"}, callSuper = false)

--- a/src/main/java/org/dinosaur/foodbowl/domain/photo/domain/Thumbnail.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/photo/domain/Thumbnail.java
@@ -30,18 +30,8 @@ public class Thumbnail extends AuditingEntity {
     @Column(name = "path", length = 512)
     private String path;
 
-    @NotNull
-    @Column(name = "width")
-    private Integer width;
-
-    @NotNull
-    @Column(name = "height")
-    private Integer height;
-
     @Builder
-    private Thumbnail(String path, Integer width, Integer height) {
+    private Thumbnail(String path) {
         this.path = path;
-        this.width = width;
-        this.height = height;
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -75,6 +75,7 @@ public class ReviewService {
                 reviewCreateRequest.storeUrl(),
                 reviewCreateRequest.phone(),
                 reviewCreateRequest.schoolName(),
+                reviewCreateRequest.schoolAddress(),
                 reviewCreateRequest.schoolX(),
                 reviewCreateRequest.schoolY()
         );

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/dto/request/ReviewCreateRequest.java
@@ -47,6 +47,9 @@ public record ReviewCreateRequest(
         @Schema(description = "학교 이름", example = "부산대학교")
         String schoolName,
 
+        @Schema(description = "학교 주소", example = "부산광역시 금정구 부산대학로63번길 2")
+        String schoolAddress,
+
         @Schema(description = "학교 경도", example = "126.12557")
         BigDecimal schoolX,
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/domain/ReviewPhoto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/domain/ReviewPhoto.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,7 +22,10 @@ import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 
 @Getter
 @Entity
-@Table(name = "review_photo")
+@Table(
+        name = "review_photo",
+        uniqueConstraints = {@UniqueConstraint(name = "uniq_review_photo", columnNames = {"review_id", "photo_id"})}
+)
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReviewPhoto extends AuditingEntity {

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/SchoolService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/SchoolService.java
@@ -31,7 +31,7 @@ public class SchoolService {
     }
 
     @Transactional
-    public School save(String name, BigDecimal x, BigDecimal y) {
+    public School save(String name, String address, BigDecimal x, BigDecimal y) {
         schoolRepository.findByName(new SchoolName(name)).ifPresent(
                 existingSchool -> {
                     throw new BadRequestException(SchoolExceptionType.DUPLICATE_SCHOOL);
@@ -39,6 +39,7 @@ public class SchoolService {
 
         School school = School.builder()
                 .name(name)
+                .addressName(address)
                 .x(x)
                 .y(y)
                 .build();

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/SchoolService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/SchoolService.java
@@ -10,6 +10,7 @@ import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
 import org.dinosaur.foodbowl.domain.store.exception.SchoolExceptionType;
 import org.dinosaur.foodbowl.domain.store.persistence.SchoolRepository;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
+import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,8 +41,7 @@ public class SchoolService {
         School school = School.builder()
                 .name(name)
                 .addressName(address)
-                .x(x)
-                .y(y)
+                .coordinate(PointUtils.generate(x, y))
                 .build();
         return schoolRepository.save(school);
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
@@ -54,7 +54,13 @@ public class StoreService {
         );
         Store store = storeRepository.save(convertToStore(storeCreateDto));
         if (storeCreateDto.schoolName() != null) {
-            saveSchool(store, storeCreateDto.schoolName(), storeCreateDto.schoolX(), storeCreateDto.schoolY());
+            saveSchool(
+                    store,
+                    storeCreateDto.schoolName(),
+                    storeCreateDto.schoolAddress(),
+                    storeCreateDto.schoolX(),
+                    storeCreateDto.schoolY()
+            );
         }
         return store;
     }
@@ -74,9 +80,15 @@ public class StoreService {
                 .build();
     }
 
-    private void saveSchool(Store store, String schoolName, BigDecimal schoolX, BigDecimal schoolY) {
+    private void saveSchool(
+            Store store,
+            String schoolName,
+            String schoolAddress,
+            BigDecimal schoolX,
+            BigDecimal schoolY
+    ) {
         School school = schoolService.findByName(schoolName)
-                .orElseGet(() -> schoolService.save(schoolName, schoolX, schoolY));
+                .orElseGet(() -> schoolService.save(schoolName, schoolAddress, schoolX, schoolY));
 
         storeSchoolService.save(store, school);
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
@@ -16,6 +16,8 @@ import org.dinosaur.foodbowl.domain.store.persistence.CategoryRepository;
 import org.dinosaur.foodbowl.domain.store.persistence.StoreRepository;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.util.PointUtils;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,7 +70,8 @@ public class StoreService {
     private Store convertToStore(StoreCreateDto storeCreateDto) {
         CategoryType categoryType = CategoryType.of(storeCreateDto.category());
         Category category = categoryRepository.findById(categoryType.getId());
-        Address address = Address.of(storeCreateDto.address(), storeCreateDto.storeX(), storeCreateDto.storeY());
+        Point coordinate = PointUtils.generate(storeCreateDto.storeX(), storeCreateDto.storeY());
+        Address address = Address.of(storeCreateDto.address(), coordinate);
 
         return Store.builder()
                 .locationId(storeCreateDto.locationId())

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/dto/StoreCreateDto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/dto/StoreCreateDto.java
@@ -12,6 +12,7 @@ public record StoreCreateDto(
         String storeUrl,
         String phone,
         String schoolName,
+        String schoolAddress,
         BigDecimal schoolX,
         BigDecimal schoolY
 ) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/domain/School.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/domain/School.java
@@ -15,9 +15,9 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.dinosaur.foodbowl.domain.store.domain.vo.Coordinate;
 import org.dinosaur.foodbowl.domain.store.domain.vo.SchoolName;
 import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
+import org.locationtech.jts.geom.Point;
 
 @Getter
 @Entity
@@ -39,15 +39,15 @@ public class School extends AuditingEntity {
     @Column(name = "address_name", length = 512)
     private String addressName;
 
-    @Valid
-    @Embedded
-    private Coordinate coordinate;
+    @NotNull
+    @Column(name = "coordinate")
+    private Point coordinate;
 
     @Builder
-    private School(String name, String addressName, BigDecimal x, BigDecimal y) {
+    private School(String name, String addressName, Point coordinate) {
         this.name = new SchoolName(name);
         this.addressName = addressName;
-        this.coordinate = new Coordinate(x, y);
+        this.coordinate = coordinate;
     }
 
     public String getName() {
@@ -55,10 +55,10 @@ public class School extends AuditingEntity {
     }
 
     public BigDecimal getX() {
-        return this.coordinate.getX();
+        return BigDecimal.valueOf(this.coordinate.getX());
     }
 
     public BigDecimal getY() {
-        return this.coordinate.getY();
+        return BigDecimal.valueOf(this.coordinate.getY());
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/domain/School.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/domain/School.java
@@ -40,7 +40,7 @@ public class School extends AuditingEntity {
     private String addressName;
 
     @NotNull
-    @Column(name = "coordinate")
+    @Column(name = "coordinate", columnDefinition = "point")
     private Point coordinate;
 
     @Builder

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/domain/School.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/domain/School.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -34,13 +35,18 @@ public class School extends AuditingEntity {
     @Embedded
     private SchoolName name;
 
+    @NotNull
+    @Column(name = "address_name", length = 512)
+    private String addressName;
+
     @Valid
     @Embedded
     private Coordinate coordinate;
 
     @Builder
-    private School(String name, BigDecimal x, BigDecimal y) {
+    private School(String name, String addressName, BigDecimal x, BigDecimal y) {
         this.name = new SchoolName(name);
+        this.addressName = addressName;
         this.coordinate = new Coordinate(x, y);
     }
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/domain/Store.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/domain/Store.java
@@ -7,7 +7,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,10 +22,7 @@ import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 
 @Getter
 @Entity
-@Table(
-        name = "store",
-        indexes = {@Index(name = "IDX_STORE", columnList = "x, y")}
-)
+@Table(name = "store")
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store extends AuditingEntity {

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/domain/StoreSchool.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/domain/StoreSchool.java
@@ -23,9 +23,7 @@ import org.dinosaur.foodbowl.global.persistence.AuditingEntity;
 @Entity
 @Table(
         name = "store_school",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "UQ_STORE_SCHOOL", columnNames = {"store_id", "school_id"})
-        }
+        uniqueConstraints = {@UniqueConstraint(name = "uniq_store_school", columnNames = {"store_id", "school_id"})}
 )
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/domain/vo/Address.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/domain/vo/Address.java
@@ -2,10 +2,7 @@ package org.dinosaur.foodbowl.domain.store.domain.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.Embedded;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import lombok.AccessLevel;
@@ -14,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.store.exception.StoreExceptionType;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
+import org.locationtech.jts.geom.Point;
 
 @Getter
 @Embeddable
@@ -43,11 +41,11 @@ public class Address {
     @Column(name = "road_name", length = 100)
     private String roadName;
 
-    @Valid
-    @Embedded
-    private Coordinate coordinate;
+    @NotNull
+    @Column(name = "coordinate")
+    private Point coordinate;
 
-    public static Address of(String storeAddress, BigDecimal x, BigDecimal y) {
+    public static Address of(String storeAddress, Point coordinate) {
         if (storeAddress == null) {
             throw new InvalidArgumentException(StoreExceptionType.ADDRESS_NOT_FOUND);
         }
@@ -63,8 +61,7 @@ public class Address {
                 .region2depthName(addressElements.get(1))
                 .region3depthName(addressElements.get(2))
                 .roadName(roadName)
-                .x(x)
-                .y(y)
+                .coordinate(coordinate)
                 .build();
     }
 
@@ -75,14 +72,13 @@ public class Address {
             String region2depthName,
             String region3depthName,
             String roadName,
-            BigDecimal x,
-            BigDecimal y
+            Point coordinate
     ) {
         this.addressName = addressName;
         this.region1depthName = region1depthName;
         this.region2depthName = region2depthName;
         this.region3depthName = region3depthName;
         this.roadName = roadName;
-        this.coordinate = new Coordinate(x, y);
+        this.coordinate = coordinate;
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/domain/vo/Address.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/domain/vo/Address.java
@@ -42,7 +42,7 @@ public class Address {
     private String roadName;
 
     @NotNull
-    @Column(name = "coordinate")
+    @Column(name = "coordinate", columnDefinition = "point")
     private Point coordinate;
 
     public static Address of(String storeAddress, Point coordinate) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/dto/response/SchoolResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/dto/response/SchoolResponse.java
@@ -12,6 +12,9 @@ public record SchoolResponse(
         @Schema(description = "학교명", example = "부산대학교")
         String name,
 
+        @Schema(description = "학교 주소", example = "부산광역시 금정구 부산대학로63번길 2")
+        String address,
+
         @Schema(description = "경도", example = "127.521")
         BigDecimal x,
 
@@ -23,6 +26,7 @@ public record SchoolResponse(
         return new SchoolResponse(
                 school.getId(),
                 school.getName(),
+                school.getAddressName(),
                 school.getX(),
                 school.getY()
         );

--- a/src/main/java/org/dinosaur/foodbowl/global/util/PointUtils.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/util/PointUtils.java
@@ -1,0 +1,23 @@
+package org.dinosaur.foodbowl.global.util;
+
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PointUtils {
+
+    private static final int SR_ID = 4326;
+    private static final GeometryFactory geometryFactory = new GeometryFactory();
+
+    public static Point generate(BigDecimal x, BigDecimal y) {
+        VerifiedCoordinate verifiedCoordinate = new VerifiedCoordinate(x, y);
+        Coordinate coordinate = new Coordinate(verifiedCoordinate.getX(), verifiedCoordinate.getY());
+        Point point = geometryFactory.createPoint(coordinate);
+        point.setSRID(SR_ID);
+        return point;
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/util/VerifiedCoordinate.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/util/VerifiedCoordinate.java
@@ -1,34 +1,20 @@
-package org.dinosaur.foodbowl.domain.store.domain.vo;
+package org.dinosaur.foodbowl.global.util;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.dinosaur.foodbowl.domain.store.exception.CoordinateExceptionType;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 
-@Getter
-@Embeddable
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Coordinate {
+public class VerifiedCoordinate {
 
     private static final BigDecimal MIN_X_VALUE = BigDecimal.valueOf(-180);
     private static final BigDecimal MAX_X_VALUE = BigDecimal.valueOf(180);
     private static final BigDecimal MIN_Y_VALUE = BigDecimal.valueOf(-90);
     private static final BigDecimal MAX_Y_VALUE = BigDecimal.valueOf(90);
 
-    @NotNull
-    @Column(name = "x", updatable = false)
     private BigDecimal x;
-
-    @NotNull
-    @Column(name = "y", updatable = false)
     private BigDecimal y;
 
-    public Coordinate(BigDecimal x, BigDecimal y) {
+    public VerifiedCoordinate(BigDecimal x, BigDecimal y) {
         validateX(x);
         validateY(y);
         this.x = x;
@@ -47,4 +33,11 @@ public class Coordinate {
         }
     }
 
+    public double getX() {
+        return x.doubleValue();
+    }
+
+    public double getY() {
+        return y.doubleValue();
+    }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberThumbnailTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/domain/MemberThumbnailTest.java
@@ -23,8 +23,6 @@ class MemberThumbnailTest {
                 .build();
         Thumbnail thumbnail = Thumbnail.builder()
                 .path("http://foodbowl.com/static/images/image.png")
-                .width(100)
-                .height(100)
                 .build();
         MemberThumbnail memberThumbnail = MemberThumbnail.builder()
                 .member(member)

--- a/src/test/java/org/dinosaur/foodbowl/domain/photo/domain/ThumbnailTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/photo/domain/ThumbnailTest.java
@@ -14,8 +14,6 @@ class ThumbnailTest {
     void 썸네일을_생성한다() {
         Thumbnail thumbnail = Thumbnail.builder()
                 .path("http://foodbowl.com/static/images/image.png")
-                .width(100)
-                .height(100)
                 .build();
 
         assertThat(thumbnail.getPath()).isEqualTo("http://foodbowl.com/static/images/image.png");

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -271,6 +271,7 @@ class ReviewServiceTest extends IntegrationTest {
                 "한식",
                 "맛있습니다.",
                 "부산대학교",
+                "부산광역시 금정구 부산대학로63번길 2",
                 BigDecimal.valueOf(124.1234),
                 BigDecimal.valueOf(34.545)
         );

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -178,7 +178,9 @@ class ReviewControllerTest extends PresentationTest {
                     "가성비가 매우 좋아요",
                     null,
                     null,
-                    null);
+                    null,
+                    null
+            );
             MockMultipartFile request = new MockMultipartFile(
                     "request",
                     "",
@@ -212,7 +214,9 @@ class ReviewControllerTest extends PresentationTest {
                     "가성비가 매우 좋아요",
                     null,
                     null,
-                    null);
+                    null,
+                    null
+            );
             MockMultipartFile request = new MockMultipartFile(
                     "request",
                     "",
@@ -246,7 +250,9 @@ class ReviewControllerTest extends PresentationTest {
                     "가성비가 매우 좋아요",
                     null,
                     null,
-                    null);
+                    null,
+                    null
+            );
             MockMultipartFile request = new MockMultipartFile(
                     "request",
                     "",
@@ -278,7 +284,9 @@ class ReviewControllerTest extends PresentationTest {
                     "가성비가 매우 좋아요",
                     null,
                     null,
-                    null);
+                    null,
+                    null
+            );
             MockMultipartFile request = new MockMultipartFile(
                     "request",
                     "",
@@ -310,7 +318,9 @@ class ReviewControllerTest extends PresentationTest {
                     "가성비가 매우 좋아요",
                     null,
                     null,
-                    null);
+                    null,
+                    null
+            );
             MockMultipartFile request = new MockMultipartFile(
                     "request",
                     "",
@@ -344,7 +354,9 @@ class ReviewControllerTest extends PresentationTest {
                     "가성비가 매우 좋아요",
                     null,
                     null,
-                    null);
+                    null,
+                    null
+            );
             MockMultipartFile request = new MockMultipartFile(
                     "request",
                     "",
@@ -378,7 +390,9 @@ class ReviewControllerTest extends PresentationTest {
                     "가성비가 매우 좋아요",
                     null,
                     null,
-                    null);
+                    null,
+                    null
+            );
             MockMultipartFile request = new MockMultipartFile(
                     "request",
                     "",
@@ -412,7 +426,9 @@ class ReviewControllerTest extends PresentationTest {
                     content,
                     null,
                     null,
-                    null);
+                    null,
+                    null
+            );
             MockMultipartFile request = new MockMultipartFile(
                     "request",
                     "",
@@ -674,6 +690,7 @@ class ReviewControllerTest extends PresentationTest {
                 "02-1234-2424",
                 "한식",
                 "가성비가 매우 좋아요",
+                null,
                 null,
                 null,
                 null

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/SchoolServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/SchoolServiceTest.java
@@ -25,9 +25,10 @@ class SchoolServiceTest extends IntegrationTest {
         @Test
         void 등록된_학교라면_학교를_조회한다() {
             String name = "부산대학교";
+            String addressName = "부산광역시 금정구 부산대학로63번길 2";
             BigDecimal x = BigDecimal.valueOf(123.1234);
             BigDecimal y = BigDecimal.valueOf(37.12421);
-            schoolService.save(name, x, y);
+            schoolService.save(name, addressName, x, y);
 
             assertThat(schoolService.findByName(name)).isPresent();
         }
@@ -55,6 +56,7 @@ class SchoolServiceTest extends IntegrationTest {
         void 정상적인_요청이라면_학교를_저장한다() {
             School school = schoolService.save(
                     "부산대학교",
+                    "부산광역시 금정구 부산대학로63번길 2",
                     BigDecimal.valueOf(123.1234),
                     BigDecimal.valueOf(37.12421)
             );
@@ -65,11 +67,12 @@ class SchoolServiceTest extends IntegrationTest {
         @Test
         void 이미_등록된_학교라면_예외를_던진다() {
             String name = "부산대학교";
+            String addressName = "부산광역시 금정구 부산대학로63번길 2";
             BigDecimal x = BigDecimal.valueOf(123.1234);
             BigDecimal y = BigDecimal.valueOf(37.12421);
-            schoolService.save(name, x, y);
+            schoolService.save(name, addressName, x, y);
 
-            assertThatThrownBy(() -> schoolService.save(name, x, y))
+            assertThatThrownBy(() -> schoolService.save(name, addressName, x, y))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("이미 존재하는 학교입니다.");
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -47,6 +47,7 @@ class StoreServiceTest extends IntegrationTest {
             StoreCreateDto storeCreateDtoWithoutSchool = generateStoreCreateDto(
                     null,
                     null,
+                    null,
                     null
             );
             Store store = storeService.create(storeCreateDtoWithoutSchool);
@@ -68,6 +69,7 @@ class StoreServiceTest extends IntegrationTest {
         @Test
         void 등록된_가게라면_가게를_조회한다() {
             StoreCreateDto storeCreateDtoWithoutSchool = generateStoreCreateDto(
+                    null,
                     null,
                     null,
                     null
@@ -95,6 +97,7 @@ class StoreServiceTest extends IntegrationTest {
             StoreCreateDto storeCreateDtoWithoutSchool = generateStoreCreateDto(
                     null,
                     null,
+                    null,
                     null
             );
 
@@ -113,6 +116,7 @@ class StoreServiceTest extends IntegrationTest {
         void 학교와_함께_생성한다() {
             StoreCreateDto storeCreateDtoWithSchool = generateStoreCreateDto(
                     "부산대학교",
+                    "부산광역시 금정구 부산대학로63번길 2",
                     BigDecimal.valueOf(123.12),
                     BigDecimal.valueOf(37.1234)
             );
@@ -136,6 +140,7 @@ class StoreServiceTest extends IntegrationTest {
         void 이미_존재하는_학교인_경우도_학교와_함께_생성한다() {
             StoreCreateDto storeCreateDtoWithSchool = generateStoreCreateDto(
                     "부산대학교",
+                    "부산광역시 금정구 부산대학로63번길 2",
                     BigDecimal.valueOf(123.12),
                     BigDecimal.valueOf(37.1234)
             );
@@ -150,6 +155,7 @@ class StoreServiceTest extends IntegrationTest {
                     "http://images2.foodbowl",
                     "02-2141-4567",
                     "부산대학교",
+                    "부산광역시 금정구 부산대학로63번길 2",
                     BigDecimal.valueOf(123.12),
                     BigDecimal.valueOf(37.1234));
 
@@ -168,6 +174,7 @@ class StoreServiceTest extends IntegrationTest {
         @Test
         void 이미_등록된_가게라면_예외를_던진다() {
             StoreCreateDto storeCreateDtoWithoutSchool = generateStoreCreateDto(
+                    null,
                     null,
                     null,
                     null
@@ -193,6 +200,7 @@ class StoreServiceTest extends IntegrationTest {
                     "02-123-4567",
                     schoolName,
                     null,
+                    null,
                     null
             );
 
@@ -216,6 +224,7 @@ class StoreServiceTest extends IntegrationTest {
                     "02-123-4567",
                     null,
                     null,
+                    null,
                     null
             );
 
@@ -225,7 +234,12 @@ class StoreServiceTest extends IntegrationTest {
         }
     }
 
-    private StoreCreateDto generateStoreCreateDto(String schoolName, BigDecimal schoolX, BigDecimal schoolY) {
+    private StoreCreateDto generateStoreCreateDto(
+            String schoolName,
+            String schoolAddress,
+            BigDecimal schoolX,
+            BigDecimal schoolY
+    ) {
         return new StoreCreateDto(
                 "12314535",
                 "농민백암순대",
@@ -236,6 +250,7 @@ class StoreServiceTest extends IntegrationTest {
                 "http://images.foodbowl",
                 "02-123-4567",
                 schoolName,
+                schoolAddress,
                 schoolX,
                 schoolY
         );

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/SchoolTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/SchoolTest.java
@@ -15,6 +15,7 @@ class SchoolTest {
     void 학교를_생성한다() {
         School school = School.builder()
                 .name("부산대학교")
+                .addressName("부산광역시 금정구 부산대학로63번길 2")
                 .x(BigDecimal.valueOf(124.1234))
                 .y(BigDecimal.valueOf(34.545))
                 .build();

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/SchoolTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/SchoolTest.java
@@ -3,6 +3,7 @@ package org.dinosaur.foodbowl.domain.store.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -16,8 +17,7 @@ class SchoolTest {
         School school = School.builder()
                 .name("부산대학교")
                 .addressName("부산광역시 금정구 부산대학로63번길 2")
-                .x(BigDecimal.valueOf(124.1234))
-                .y(BigDecimal.valueOf(34.545))
+                .coordinate(PointUtils.generate(BigDecimal.valueOf(124.1234), BigDecimal.valueOf(34.545)))
                 .build();
 
         assertThat(school.getName()).isEqualTo("부산대학교");

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/StoreSchoolTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/StoreSchoolTest.java
@@ -3,6 +3,7 @@ package org.dinosaur.foodbowl.domain.store.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -20,8 +21,8 @@ class StoreSchoolTest {
                 .build();
         School school = School.builder()
                 .name("부산대학교")
-                .x(BigDecimal.valueOf(124.1234))
-                .y(BigDecimal.valueOf(34.545))
+                .addressName("부산광역시 금정구 부산대학로63번길 2")
+                .coordinate(PointUtils.generate(BigDecimal.valueOf(124.1234), BigDecimal.valueOf(34.545)))
                 .build();
         StoreSchool storeSchool = StoreSchool.builder()
                 .store(store)

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/StoreTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/StoreTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import org.dinosaur.foodbowl.domain.store.domain.vo.Address;
 import org.dinosaur.foodbowl.domain.store.domain.vo.CategoryType;
+import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -25,8 +26,7 @@ class StoreTest {
                 .region2depthName("강남구")
                 .region3depthName("선릉로")
                 .roadName("14번길 245")
-                .x(BigDecimal.valueOf(123.124))
-                .y(BigDecimal.valueOf(37.4545))
+                .coordinate(PointUtils.generate(BigDecimal.valueOf(123.124), BigDecimal.valueOf(37.4545)))
                 .build();
         Store store = Store.builder()
                 .category(category)

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/domain/vo/AddressTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/domain/vo/AddressTest.java
@@ -5,12 +5,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
+import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.locationtech.jts.geom.Point;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -24,8 +26,9 @@ class AddressTest {
             String storeAddress = "서울시 강남구 테헤란로 17 강남빌딩 1201호";
             BigDecimal x = BigDecimal.valueOf(123.1234);
             BigDecimal y = BigDecimal.valueOf(36.12431);
+            Point coordinate = PointUtils.generate(x, y);
 
-            Address address = Address.of(storeAddress, x, y);
+            Address address = Address.of(storeAddress, coordinate);
 
             assertThat(address.getAddressName()).isEqualTo(storeAddress);
         }
@@ -35,8 +38,9 @@ class AddressTest {
         void 정상적이지_않는_주소라면_예외를_던진다(String storeAddress) {
             BigDecimal x = BigDecimal.valueOf(123.1234);
             BigDecimal y = BigDecimal.valueOf(36.12431);
+            Point coordinate = PointUtils.generate(x, y);
 
-            assertThatThrownBy(() -> Address.of(storeAddress, x, y))
+            assertThatThrownBy(() -> Address.of(storeAddress, coordinate))
                     .isInstanceOf(InvalidArgumentException.class)
                     .hasMessage("가게 주소 형식이 잘못되었습니다.");
         }
@@ -45,8 +49,9 @@ class AddressTest {
         void 주소가_없으면_예외를_던진다() {
             BigDecimal x = BigDecimal.valueOf(123.1234);
             BigDecimal y = BigDecimal.valueOf(36.12431);
+            Point coordinate = PointUtils.generate(x, y);
 
-            assertThatThrownBy(() -> Address.of(null, x, y))
+            assertThatThrownBy(() -> Address.of(null, coordinate))
                     .isInstanceOf(InvalidArgumentException.class)
                     .hasMessage("가게 주소가 존재하지 않습니다.");
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/SchoolRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/SchoolRepositoryTest.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.store.domain.School;
 import org.dinosaur.foodbowl.domain.store.domain.vo.SchoolName;
+import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.dinosaur.foodbowl.test.PersistenceTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,8 +41,8 @@ class SchoolRepositoryTest extends PersistenceTest {
     void 학교를_저장한다() {
         School school = School.builder()
                 .name("부산대학교")
-                .x(BigDecimal.valueOf(123.12451))
-                .y(BigDecimal.valueOf(37.124125))
+                .addressName("부산광역시 금정구 부산대학로63번길 2")
+                .coordinate(PointUtils.generate(BigDecimal.valueOf(123.12451), BigDecimal.valueOf(37.124125)))
                 .build();
 
         School saveSchool = schoolRepository.save(school);

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.domain.store.domain.vo.Address;
+import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.dinosaur.foodbowl.test.PersistenceTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,8 +41,7 @@ class StoreRepositoryTest extends PersistenceTest {
                 .category(categoryRepository.findById(1L))
                 .address(Address.of(
                         "서울시 영등포구 여의도동 451",
-                        BigDecimal.valueOf(123.23),
-                        BigDecimal.valueOf(35.52))
+                        PointUtils.generate(BigDecimal.valueOf(123.23), BigDecimal.valueOf(35.52)))
                 )
                 .storeUrl("http://image.bbq.foodbowl")
                 .phone("02-123-4567")

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
@@ -69,8 +69,20 @@ class StoreControllerTest extends PresentationTest {
     void 학교_목록_조회시_학교_목록과_200_응답을_반환한다() throws Exception {
         SchoolsResponse schoolsResponse = new SchoolsResponse(
                 List.of(
-                        new SchoolResponse(1L, "강남대학교", BigDecimal.valueOf(127.125), BigDecimal.valueOf(35.12)),
-                        new SchoolResponse(1L, "부산대학교", BigDecimal.valueOf(127.350), BigDecimal.valueOf(35.78))
+                        new SchoolResponse(
+                                1L,
+                                "강남대학교",
+                                "경기도 용인시 기흥구 강남로 40",
+                                BigDecimal.valueOf(127.125),
+                                BigDecimal.valueOf(35.12)
+                        ),
+                        new SchoolResponse(
+                                2L,
+                                "부산대학교",
+                                "부산광역시 금정구 부산대학로63번길 2",
+                                BigDecimal.valueOf(127.350),
+                                BigDecimal.valueOf(35.78)
+                        )
                 )
         );
         given(schoolService.getSchools()).willReturn(schoolsResponse);

--- a/src/test/java/org/dinosaur/foodbowl/global/util/PointUtilsTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/global/util/PointUtilsTest.java
@@ -1,0 +1,28 @@
+package org.dinosaur.foodbowl.global.util;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Point;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PointUtilsTest {
+
+    @Test
+    void 좌표를_생성한다() {
+        BigDecimal x = new BigDecimal(123.3636);
+        BigDecimal y = new BigDecimal(32.3838);
+
+        Point coordinate = PointUtils.generate(x, y);
+
+        assertSoftly(softly -> {
+            softly.assertThat(coordinate.getX()).isEqualTo(x.doubleValue());
+            softly.assertThat(coordinate.getY()).isEqualTo(y.doubleValue());
+            softly.assertThat(coordinate.getSRID()).isEqualTo(4326);
+        });
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/global/util/VerifiedCoordinateTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/global/util/VerifiedCoordinateTest.java
@@ -1,4 +1,4 @@
-package org.dinosaur.foodbowl.domain.store.domain.vo;
+package org.dinosaur.foodbowl.global.util;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -13,18 +13,18 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class CoordinateTest {
+class VerifiedCoordinateTest {
 
     @Test
     void X_좌표_Y_좌표로_좌표_객체를_만든다() {
         BigDecimal x = BigDecimal.valueOf(123.1234);
         BigDecimal y = BigDecimal.valueOf(37.1234);
 
-        Coordinate coordinate = new Coordinate(x, y);
+        VerifiedCoordinate verifiedCoordinate = new VerifiedCoordinate(x, y);
 
         assertSoftly(softly -> {
-            softly.assertThat(coordinate.getX()).isEqualTo(x);
-            softly.assertThat(coordinate.getY()).isEqualTo(y);
+            softly.assertThat(verifiedCoordinate.getX()).isEqualTo(x.doubleValue());
+            softly.assertThat(verifiedCoordinate.getY()).isEqualTo(y.doubleValue());
         });
     }
 
@@ -33,7 +33,7 @@ class CoordinateTest {
     void 경도_범위를_벗어나면_예외를_던진다(String x) {
         BigDecimal y = BigDecimal.valueOf(37.1234);
 
-        assertThatThrownBy(() -> new Coordinate(new BigDecimal(x), y))
+        assertThatThrownBy(() -> new VerifiedCoordinate(new BigDecimal(x), y))
                 .isInstanceOf(InvalidArgumentException.class)
                 .hasMessage("경도 값의 크기가 잘못되었습니다.");
 
@@ -44,7 +44,7 @@ class CoordinateTest {
     void 위도_범위를_벗어나면_예외를_던진다(String y) {
         BigDecimal x = BigDecimal.valueOf(123.1234);
 
-        assertThatThrownBy(() -> new Coordinate(x, new BigDecimal(y)))
+        assertThatThrownBy(() -> new VerifiedCoordinate(x, new BigDecimal(y)))
                 .isInstanceOf(InvalidArgumentException.class)
                 .hasMessage("위도 값의 크기가 잘못되었습니다.");
     }

--- a/src/test/java/org/dinosaur/foodbowl/test/persister/SchoolTestPersister.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/persister/SchoolTestPersister.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.dinosaur.foodbowl.domain.store.domain.School;
 import org.dinosaur.foodbowl.domain.store.persistence.SchoolRepository;
+import org.dinosaur.foodbowl.global.util.PointUtils;
+import org.locationtech.jts.geom.Point;
 
 @RequiredArgsConstructor
 @Persister
@@ -20,8 +22,7 @@ public class SchoolTestPersister {
 
         private String name;
         private String addressName;
-        private BigDecimal x;
-        private BigDecimal y;
+        private Point coordinate;
 
         public SchoolBuilder name(String name) {
             this.name = name;
@@ -33,13 +34,8 @@ public class SchoolTestPersister {
             return this;
         }
 
-        public SchoolBuilder x(BigDecimal x) {
-            this.x = x;
-            return this;
-        }
-
-        public SchoolBuilder y(BigDecimal y) {
-            this.y = y;
+        public SchoolBuilder coordinate(Point coordinate) {
+            this.coordinate = coordinate;
             return this;
         }
 
@@ -47,8 +43,9 @@ public class SchoolTestPersister {
             School school = School.builder()
                     .name(name == null ? RandomStringUtils.random(2, true, false) + "대학교" : name)
                     .addressName(addressName == null ? "서울시 영등포구 여의도동 451" : addressName)
-                    .x(x == null ? BigDecimal.valueOf(123.1245) : x)
-                    .y(y == null ? BigDecimal.valueOf(37.445) : y)
+                    .coordinate(coordinate == null ?
+                            PointUtils.generate(BigDecimal.valueOf(123.1245), BigDecimal.valueOf(37.445)) : coordinate
+                    )
                     .build();
             return schoolRepository.save(school);
         }

--- a/src/test/java/org/dinosaur/foodbowl/test/persister/SchoolTestPersister.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/persister/SchoolTestPersister.java
@@ -19,11 +19,17 @@ public class SchoolTestPersister {
     public class SchoolBuilder {
 
         private String name;
+        private String addressName;
         private BigDecimal x;
         private BigDecimal y;
 
         public SchoolBuilder name(String name) {
             this.name = name;
+            return this;
+        }
+
+        public SchoolBuilder addressName(String addressName) {
+            this.addressName = addressName;
             return this;
         }
 
@@ -40,6 +46,7 @@ public class SchoolTestPersister {
         public School save() {
             School school = School.builder()
                     .name(name == null ? RandomStringUtils.random(2, true, false) + "대학교" : name)
+                    .addressName(addressName == null ? "서울시 영등포구 여의도동 451" : addressName)
                     .x(x == null ? BigDecimal.valueOf(123.1245) : x)
                     .y(y == null ? BigDecimal.valueOf(37.445) : y)
                     .build();

--- a/src/test/java/org/dinosaur/foodbowl/test/persister/StoreTestPersister.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/persister/StoreTestPersister.java
@@ -8,6 +8,7 @@ import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.domain.store.domain.vo.Address;
 import org.dinosaur.foodbowl.domain.store.persistence.CategoryRepository;
 import org.dinosaur.foodbowl.domain.store.persistence.StoreRepository;
+import org.dinosaur.foodbowl.global.util.PointUtils;
 
 @RequiredArgsConstructor
 @Persister
@@ -67,8 +68,7 @@ public class StoreTestPersister {
                     .address(address == null ?
                             Address.of(
                                     "서울시 영등포구 여의도동 451",
-                                    BigDecimal.valueOf(123.23),
-                                    BigDecimal.valueOf(35.52)
+                                    PointUtils.generate(BigDecimal.valueOf(123.23), BigDecimal.valueOf(35.52))
                             ) : address
                     )
                     .storeUrl(storeUrl == null ? "http://image.bbq.foodbowl" : storeUrl)

--- a/src/test/java/org/dinosaur/foodbowl/test/persister/ThumbnailTestPersister.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/persister/ThumbnailTestPersister.java
@@ -17,29 +17,15 @@ public class ThumbnailTestPersister {
     public final class ThumbnailBuilder {
 
         private String path;
-        private Integer width;
-        private Integer height;
 
         public ThumbnailBuilder path(String path) {
             this.path = path;
             return this;
         }
 
-        public ThumbnailBuilder width(Integer width) {
-            this.width = width;
-            return this;
-        }
-
-        public ThumbnailBuilder height(Integer height) {
-            this.height = height;
-            return this;
-        }
-
         public Thumbnail save() {
             Thumbnail thumbnail = Thumbnail.builder()
                     .path(path == null ? "http://justdoeat.shop/static/images/thumbnail.png" : path)
-                    .width(width == null ? 100 : width)
-                    .height(height == null ? 100 : height)
                     .build();
             return thumbnailRepository.save(thumbnail);
         }


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #169

## 📝 작업 요약

학교 상세 주소 필드를 추가하였습니다.

## 🔎 작업 상세 설명

- 썸네일 높이, 너비 필드를 삭제하였습니다.
- 학교 주소 필드를 추가하였습니다.
- 가게와 학교의 위도, 경도 필드를 공간 데이터로 수정하였습니다.
- 학교 주소 필드 추가에 따라 리뷰 생성 API와 학교 목록 조회 API를 수정하였습니다.
- 공간 데이터를 사용함에 따라 유틸 클래스를 생성하고 기존의 로직을 전반적으로 리팩토링 하였습니다.

## 🌟 리뷰 요구 사항

> 30분
> 필드 삭제, 추가, 수정에 따라 빠진 부분이 있는지 한번 더 확인해주시면 감사합니다 :)