### PR TITLE
Feature/#176 북마크 가게 리뷰 목록 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
@@ -15,6 +15,21 @@ public class ReviewCustomService {
     private final ReviewCustomRepository reviewCustomRepository;
 
     @Transactional(readOnly = true)
+    public List<Review> getReviewsByBookmarkInMapBounds(
+            Long bookmakerId,
+            Long lastReviewId,
+            MapCoordinateBoundDto mapCoordinateBoundDto,
+            int pageSize
+    ) {
+        return reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                bookmakerId,
+                lastReviewId,
+                mapCoordinateBoundDto,
+                pageSize
+        );
+    }
+
+    @Transactional(readOnly = true)
     public List<Review> getReviewsByFollowingInMapBounds(
             Long followerId,
             Long lastReviewId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
@@ -16,13 +16,13 @@ public class ReviewCustomService {
 
     @Transactional(readOnly = true)
     public List<Review> getReviewsByBookmarkInMapBounds(
-            Long bookmakerId,
+            Long memberId,
             Long lastReviewId,
             MapCoordinateBoundDto mapCoordinateBoundDto,
             int pageSize
     ) {
         return reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
-                bookmakerId,
+                memberId,
                 lastReviewId,
                 mapCoordinateBoundDto,
                 pageSize

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -45,6 +45,29 @@ public class ReviewService {
     private final BookmarkQueryService bookmarkQueryService;
 
     @Transactional(readOnly = true)
+    public ReviewPageResponse getReviewsByBookmarkInMapBounds(
+            Long lastReviewId,
+            MapCoordinateRequest mapCoordinateRequest,
+            DeviceCoordinateRequest deviceCoordinateRequest,
+            int pageSize,
+            Member loginMember
+    ) {
+        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                mapCoordinateRequest.x(),
+                mapCoordinateRequest.y(),
+                mapCoordinateRequest.deltaX(),
+                mapCoordinateRequest.deltaY()
+        );
+        List<Review> reviews = reviewCustomService.getReviewsByBookmarkInMapBounds(
+                loginMember.getId(),
+                lastReviewId,
+                mapCoordinateBoundDto,
+                pageSize
+        );
+        return convertToReviewPageResponse(loginMember, reviews, deviceCoordinateRequest);
+    }
+
+    @Transactional(readOnly = true)
     public ReviewPageResponse getReviewsByFollowingInMapBounds(
             Long lastReviewId,
             MapCoordinateRequest mapCoordinateRequest,
@@ -58,13 +81,20 @@ public class ReviewService {
                 mapCoordinateRequest.deltaX(),
                 mapCoordinateRequest.deltaY()
         );
-
         List<Review> reviews = reviewCustomService.getReviewsByFollowingInMapBounds(
                 loginMember.getId(),
                 lastReviewId,
                 mapCoordinateBoundDto,
                 pageSize
         );
+        return convertToReviewPageResponse(loginMember, reviews, deviceCoordinateRequest);
+    }
+
+    private ReviewPageResponse convertToReviewPageResponse(
+            Member loginMember,
+            List<Review> reviews,
+            DeviceCoordinateRequest deviceCoordinateRequest
+    ) {
         MemberToFollowerCountDto memberToFollowerCountDto =
                 followCustomService.getFollowerCountByMembers(getWriters(reviews));
         ReviewToPhotoPathDto reviewToPhotoPathDto = reviewPhotoCustomService.getPhotoPathByReviews(reviews);

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewPageResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewPageResponse.java
@@ -9,7 +9,7 @@ import org.dinosaur.foodbowl.domain.review.application.dto.ReviewToPhotoPathDto;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 
-@Schema(description = "내 팔로잉의 리뷰 조회 응답")
+@Schema(description = "리뷰 조회 페이지 응답")
 public record ReviewPageResponse(
         @Schema(description = "리뷰 응답 목록")
         List<ReviewResponse> reviews,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -25,7 +25,7 @@ public class ReviewCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     public List<Review> findPaginationReviewsByBookmarkInMapBounds(
-            Long bookmakerId,
+            Long memberId,
             Long lastReviewId,
             MapCoordinateBoundDto mapCoordinateBoundDto,
             int pageSize
@@ -37,7 +37,7 @@ public class ReviewCustomRepository {
                 .innerJoin(store.category, category).fetchJoin()
                 .innerJoin(bookmark).on(
                         bookmark.store.eq(review.store),
-                        bookmark.member.id.eq(bookmakerId)
+                        bookmark.member.id.eq(memberId)
                 )
                 .where(
                         ltLastReviewId(lastReviewId),

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -36,6 +36,30 @@ public class ReviewController implements ReviewControllerDocs {
 
     private final ReviewService reviewService;
 
+    @GetMapping("/bookmarks")
+    public ResponseEntity<ReviewPageResponse> getReviewsByBookmarkInMapBounds(
+            @RequestParam(name = "lastReviewId", required = false) @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long lastReviewId,
+            @RequestParam(name = "x") BigDecimal x,
+            @RequestParam(name = "y") BigDecimal y,
+            @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
+            @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
+            @RequestParam(name = "deviceX") BigDecimal deviceX,
+            @RequestParam(name = "deviceY") BigDecimal deviceY,
+            @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
+            @Auth Member loginMember
+    ) {
+        MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
+        DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
+        ReviewPageResponse response = reviewService.getReviewsByBookmarkInMapBounds(
+                lastReviewId,
+                mapCoordinateRequest,
+                deviceCoordinateRequest,
+                pageSize,
+                loginMember
+        );
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping("/following")
     public ResponseEntity<ReviewPageResponse> getReviewsByFollowingInMapBounds(
             @RequestParam(name = "lastReviewId", required = false) @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long lastReviewId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -24,6 +24,88 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ReviewControllerDocs {
 
     @Operation(
+            summary = "북마크한 가게의 리뷰 목록 범위 기반 페이징 조회",
+            description = """
+                    지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
+                                        
+                    해당 범위에 속한 북마크 한 가게에 작성된 리뷰 목록을 조회하는 기능입니다.
+                                        
+                    디바이스 경도(deviceX), 디바이스 위도(deviceY)를 통해 디바이스와 가게 사이의 거리를 계산합니다.
+                                        
+                    조회 성능을 높이기 위해 NO OFFSET 페이징으로 구현하였기에 페이지 번호 대신 마지막 리뷰 ID를 요청값으로 받습니다.
+                                        
+                    첫 페이지 조회 시에는 마지막 리뷰 ID를 파라미터에 담지 않고 요청을 보내면 됩니다.
+                                        
+                    두번째 페이지 조회 부터는 이전 조회 응답에 담겨 있는 마지막 리뷰 ID를 파라미터로 넘겨주면
+                                        
+                    해당 리뷰 ID보다 작은, 다시 말해서 요청으로 보낸 리뷰 이전에 작성된 리뷰부터 조회하게 됩니다.
+                                        
+                    페이지 크기(응답할 리뷰 개수)는 파라미터로 보내지 않으면 기본적으로 10개로 동작하게 되어있습니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "북마크한 가게의 리뷰 목록 범위 기반 페이징 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.리뷰 ID가 양수가 아닌 경우
+                                                        
+                            2.지도 중심 경도가 존재하지 않은 경우
+                                                        
+                            3.지도 중심 위도가 존재하지 않은 경우
+                                                        
+                            4.지도 경도 증가값이 존재하지 않은 경우
+                                                        
+                            5.지도 위도 증가값이 존재하지 않은 경우
+                                                        
+                            6.지도 경도 증가값이 0이상 양수가 아닌 경우
+                                                        
+                            7.지도 위도 증가값이 0이상 양수가 아닌 경우
+                                                        
+                            8.디바이스 경도가 존재하지 않은 경우
+                                                        
+                            9.디바이스 위도가 존재하지 않은 경우
+                                                        
+                            10.페이지 크기가 양수가 아닌 경우
+                            """
+            )
+    })
+    ResponseEntity<ReviewPageResponse> getReviewsByBookmarkInMapBounds(
+            @Parameter(description = "이전 조회의 마지막 리뷰 ID(첫 조회 시에는 파라미터 요청 X)", example = "1")
+            @Positive(message = "리뷰 ID는 양수만 가능합니다.")
+            Long lastReviewId,
+
+            @Parameter(description = "지도 중심 경도", example = "123.3636")
+            BigDecimal x,
+
+            @Parameter(description = "지도 중심 위도", example = "32.3636")
+            BigDecimal y,
+
+            @Parameter(description = "지도 경도 증가값", example = "3.1212")
+            @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaX,
+
+            @Parameter(description = "지도 위도 증가값", example = "3.1212")
+            @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaY,
+
+            @Parameter(description = "사용자 경도", example = "123.3636")
+            BigDecimal deviceX,
+
+            @Parameter(description = "사용자 위도", example = "32.3636")
+            BigDecimal deviceY,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @Positive(message = "페이지 크기는 양수만 가능합니다.")
+            int pageSize,
+
+            Member loginMember
+    );
+
+    @Operation(
             summary = "팔로잉 멤버의 리뷰 목록 범위 기반 페이징 조회",
             description = """
                     지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -70,7 +70,8 @@ public interface ReviewControllerDocs {
                             9.디바이스 위도가 존재하지 않은 경우
                                                         
                             10.페이지 크기가 양수가 아닌 경우
-                            """
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
     ResponseEntity<ReviewPageResponse> getReviewsByBookmarkInMapBounds(
@@ -152,7 +153,8 @@ public interface ReviewControllerDocs {
                             9.디바이스 위도가 존재하지 않은 경우
                                                         
                             10.페이지 크기가 양수가 아닌 경우
-                            """
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
     ResponseEntity<ReviewPageResponse> getReviewsByFollowingInMapBounds(

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
@@ -25,11 +25,11 @@ public interface StoreControllerDocs {
             summary = "가게 검색 결과 조회",
             description = """
                     키워드로 가게를 검색합니다.
-                    
+                                        
                     필수 파라미터: name(검색 키워드), x(경도), y(위도)
-                    
+                                        
                     선택 파라미터: size(응답으로 받을 최대 검색 결과 수, Default: 10, Max: 30)
-                    
+                                        
                     요청 예시: /v1/stores/search?name=김밥&x=123.5156&y=36.1425&size=15
                     """
     )
@@ -42,17 +42,17 @@ public interface StoreControllerDocs {
                     responseCode = "400",
                     description = """
                             1.검색어가 빈 값이나 공백인 경우
-                            
+                                                        
                             2.사용자 위치의 경도 값이 숫자가 아닌 경우
-                            
+                                                        
                             3.사용자 위치의 위도 값이 숫자가 아닌 경우
-                            
+                                                        
                             4.검색 결과 수가 최대 결과 수(30)보다 큰 경우
-                            
+                                                        
                             5.검색 결과 수가 0이하인 경우
-                            
+                                                        
                             6.사용자 위치의 경도 값이 없는 경우
-                            
+                                                        
                             7.사용자 위치의 위도 값이 없는 경우
                             """,
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
@@ -1,8 +1,9 @@
 package org.dinosaur.foodbowl.domain.review.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.math.BigDecimal;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
@@ -16,6 +17,29 @@ class ReviewCustomServiceTest extends IntegrationTest {
 
     @Autowired
     private ReviewCustomService reviewCustomService;
+
+    @Test
+    void 북마크한_가게_리뷰_목록을_범위를_통해_조회한다() {
+        Member member = memberTestPersister.builder().save();
+        Store store = storeTestPersister.builder().save();
+        Review review = reviewTestPersister.builder().store(store).save();
+        bookmarkTestPersister.builder().member(member).store(store).save();
+        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                BigDecimal.valueOf(3),
+                BigDecimal.valueOf(3)
+        );
+
+        List<Review> result = reviewCustomService.getReviewsByBookmarkInMapBounds(
+                member.getId(),
+                null,
+                mapCoordinateBoundDto,
+                10
+        );
+
+        assertThat(result).containsExactly(review);
+    }
 
     @Test
     void 팔로잉_하는_멤버의_리뷰_목록을_범위를_통해_조회한다() {
@@ -38,6 +62,6 @@ class ReviewCustomServiceTest extends IntegrationTest {
                 10
         );
 
-        Assertions.assertThat(result).containsExactly(review);
+        assertThat(result).containsExactly(review);
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -114,52 +114,6 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
         }
 
         @Test
-        void 폴리곤_영역에_경도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
-            Member member = memberTestPersister.builder().save();
-            Store store = storeTestPersister.builder().save();
-            reviewTestPersister.builder().store(store).save();
-            bookmarkTestPersister.builder().member(member).store(store).save();
-            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
-                    BigDecimal.valueOf(1),
-                    BigDecimal.valueOf(1)
-            );
-
-            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
-                    member.getId(),
-                    null,
-                    mapCoordinateBoundDto,
-                    10
-            );
-
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        void 폴리곤_영역에_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
-            Member member = memberTestPersister.builder().save();
-            Store store = storeTestPersister.builder().save();
-            reviewTestPersister.builder().store(store).save();
-            bookmarkTestPersister.builder().member(member).store(store).save();
-            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
-                    BigDecimal.valueOf(1),
-                    BigDecimal.valueOf(1)
-            );
-
-            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
-                    member.getId(),
-                    null,
-                    mapCoordinateBoundDto,
-                    10
-            );
-
-            assertThat(result).isEmpty();
-        }
-
-        @Test
         void 폴리곤_영역에_경도와_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
             Member member = memberTestPersister.builder().save();
             Store store = storeTestPersister.builder().save();
@@ -318,54 +272,6 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
                     BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
                     BigDecimal.valueOf(3),
                     BigDecimal.valueOf(3)
-            );
-
-            List<Review> result = reviewCustomRepository.findPaginationReviewsByFollowingInMapBounds(
-                    member.getId(),
-                    null,
-                    mapCoordinateBoundDto,
-                    10
-            );
-
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        void 폴리곤_영역에_경도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
-            Member member = memberTestPersister.builder().save();
-            Member writer = memberTestPersister.builder().save();
-            followTestPersister.builder().following(writer).follower(member).save();
-            Store store = storeTestPersister.builder().save();
-            reviewTestPersister.builder().store(store).member(writer).save();
-            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
-                    BigDecimal.valueOf(1),
-                    BigDecimal.valueOf(1)
-            );
-
-            List<Review> result = reviewCustomRepository.findPaginationReviewsByFollowingInMapBounds(
-                    member.getId(),
-                    null,
-                    mapCoordinateBoundDto,
-                    10
-            );
-
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        void 폴리곤_영역에_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
-            Member member = memberTestPersister.builder().save();
-            Member writer = memberTestPersister.builder().save();
-            followTestPersister.builder().following(writer).follower(member).save();
-            Store store = storeTestPersister.builder().save();
-            reviewTestPersister.builder().store(store).member(writer).save();
-            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
-                    BigDecimal.valueOf(1),
-                    BigDecimal.valueOf(1)
             );
 
             List<Review> result = reviewCustomRepository.findPaginationReviewsByFollowingInMapBounds(

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -20,6 +20,219 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
     private ReviewCustomRepository reviewCustomRepository;
 
     @Nested
+    class 북마크한_가게_리뷰_목록_페이징_조회_시 {
+
+        @Test
+        void 마지막_리뷰ID가_NULL이_아닐때_마지막_리뷰ID보다_작은_리뷰는_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().store(store).save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                    member.getId(),
+                    review.getId() + 1,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).containsExactly(review);
+        }
+
+        @Test
+        void 마지막_리뷰ID가_NULL이_아닐때_마지막_리뷰ID보다_큰_리뷰는_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().store(store).save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                    member.getId(),
+                    review.getId() - 1,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 북마크한_가게_리뷰를_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().store(store).save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).containsExactly(review);
+        }
+
+        @Test
+        void 북마크_하지_않은_가게_리뷰는_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 폴리곤_영역에_경도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().store(store).save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 폴리곤_영역에_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().store(store).save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 폴리곤_영역에_경도와_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().store(store).save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 리뷰ID를_내림차순으로_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().store(store).save();
+            Review reviewB = reviewTestPersister.builder().store(store).save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).containsExactly(reviewB, reviewA);
+        }
+
+        @Test
+        void 페이지_크기만큼_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().store(store).save();
+            Review reviewB = reviewTestPersister.builder().store(store).save();
+            Review reviewC = reviewTestPersister.builder().store(store).save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByBookmarkInMapBounds(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    2
+            );
+
+            assertThat(result).containsExactly(reviewC, reviewB);
+        }
+    }
+
+    @Nested
     class 팔로잉_유저의_리뷰_목록_페이징_조회_시 {
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -75,7 +75,7 @@ class ReviewControllerTest extends PresentationTest {
         private final String accessToken = jwtTokenProvider.createAccessToken(1L, ROLE_회원);
 
         @Test
-        void 정상적인_요청이라면_200_응답을_바노한한다() throws Exception {
+        void 정상적인_요청이라면_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             ReviewPageResponse response = new ReviewPageResponse(
                     List.of(

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -144,6 +144,66 @@ class ReviewControllerTest extends PresentationTest {
                     .andExpect(jsonPath("$.message").value(containsString("리뷰 ID는 양수만 가능합니다.")));
         }
 
+        @Test
+        void 경도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/bookmarks")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 위도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/bookmarks")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 경도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/bookmarks")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 위도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/bookmarks")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
         @ParameterizedTest
         @ValueSource(strings = {"-1", "0"})
         void 경도_증가값이_0이상의_양수가_아니라면_400_응답을_반환한다(String deltaX) throws Exception {
@@ -180,6 +240,36 @@ class ReviewControllerTest extends PresentationTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("errorCode").value("CLIENT-101"))
                     .andExpect(jsonPath("$.message").value(containsString("위도 증가값은 0이상의 양수만 가능합니다.")));
+        }
+
+        @Test
+        void 디바이스_경도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/bookmarks")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 디바이스_위도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/bookmarks")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -104,8 +104,8 @@ class StoreServiceTest extends IntegrationTest {
                     .locationId("12346585")
                     .storeName("김밥천국 선릉점")
                     .address(Address.of(
-                                    "서울시 강남구 선릉로 4244번길 2323-124",
-                                    PointUtils.generate(BigDecimal.valueOf(125.142), BigDecimal.valueOf(36.241)))
+                            "서울시 강남구 선릉로 4244번길 2323-124",
+                            PointUtils.generate(BigDecimal.valueOf(125.142), BigDecimal.valueOf(36.241)))
                     )
                     .save();
             Store nearestStoreB = storeTestPersister.builder()


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #176

## 📝 작업 요약

북마크한 가게의 리뷰 목록을 범위 기반 페이징 조회하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

팔로잉 중인 회원의 리뷰 목록 페이징 조회 기능과 거의 동일합니다.

### 논의 사항

### ON절에서 필터링

```java
return jpaQueryFactory.selectDistinct(review)
            .from(review)
            .innerJoin(review.store, store).fetchJoin()
            .innerJoin(review.member, member).fetchJoin()
            .innerJoin(store.category, category).fetchJoin()
            .innerJoin(bookmark).on(
                    bookmark.store.eq(review.store),
                    bookmark.member.id.eq(bookmakerId)
            )
            .where(
                    ltLastReviewId(lastReviewId),
                    containsPolygon(mapCoordinateBoundDto)
            )
            .orderBy(review.id.desc())
            .limit(pageSize)
            .fetch();
```

### WHERE절에서 필터링

```java
return jpaQueryFactory.selectDistinct(review)
            .from(review)
            .innerJoin(review.store, store).fetchJoin()
            .innerJoin(review.member, member).fetchJoin()
            .innerJoin(store.category, category).fetchJoin()
            .innerJoin(bookmark).on(bookmark.store.eq(review.store))
            .where(
                    ltLastReviewId(lastReviewId),
                    bookmark.member.id.eq(bookmakerId)
                    containsPolygon(mapCoordinateBoundDto)
            )
            .orderBy(review.id.desc())
            .limit(pageSize)
            .fetch();
```

`bookmark.member.id.eq(bookmakerId)`를 조인 시에서 위의 코드처럼 `ON`절에서 미리 필터링할 수 있고, 아래의 코드처럼 `WHERE`절에서 필터링도 가능합니다.

2개의 방식이 어떤 차이가 있고 어떤 것이 더 나은 방법인지 같이 얘기해보고 알아보면 좋을 것 같아요 !

## 🌟 리뷰 요구 사항

> 15분
> `ReviewCustomRepository`의 쿼리 부분 집중적으로 봐주시면 감사합니다 :)