### PR TITLE
Feature/#135 유저 프로필 리뷰 목록 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
@@ -15,6 +15,21 @@ public class ReviewCustomService {
     private final ReviewCustomRepository reviewCustomRepository;
 
     @Transactional(readOnly = true)
+    public List<Review> getReviewsByMemberInMapBounds(
+            Long memberId,
+            Long lastReviewId,
+            MapCoordinateBoundDto mapCoordinateBoundDto,
+            int pageSize
+    ) {
+        return reviewCustomRepository.findPaginationReviewsByMemberInMapBound(
+                memberId,
+                lastReviewId,
+                mapCoordinateBoundDto,
+                pageSize
+        );
+    }
+
+    @Transactional(readOnly = true)
     public List<Review> getReviewsByBookmarkInMapBounds(
             Long memberId,
             Long lastReviewId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -50,6 +50,25 @@ public class ReviewService {
     private final BookmarkQueryService bookmarkQueryService;
 
     @Transactional(readOnly = true)
+    public ReviewPageResponse getReviewsByMemberInMapBounds(
+            Long memberId,
+            Long lastReviewId,
+            MapCoordinateRequest mapCoordinateRequest,
+            DeviceCoordinateRequest deviceCoordinateRequest,
+            int pageSize,
+            Member loginMember
+    ) {
+        MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
+        List<Review> reviews = reviewCustomService.getReviewsByMemberInMapBounds(
+                memberId,
+                lastReviewId,
+                mapCoordinateBoundDto,
+                pageSize
+        );
+        return convertToReviewPageResponse(loginMember, reviews, deviceCoordinateRequest);
+    }
+
+    @Transactional(readOnly = true)
     public ReviewPageResponse getReviewsByBookmarkInMapBounds(
             Long lastReviewId,
             MapCoordinateRequest mapCoordinateRequest,
@@ -57,12 +76,7 @@ public class ReviewService {
             int pageSize,
             Member loginMember
     ) {
-        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
-                mapCoordinateRequest.x(),
-                mapCoordinateRequest.y(),
-                mapCoordinateRequest.deltaX(),
-                mapCoordinateRequest.deltaY()
-        );
+        MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
         List<Review> reviews = reviewCustomService.getReviewsByBookmarkInMapBounds(
                 loginMember.getId(),
                 lastReviewId,
@@ -80,12 +94,7 @@ public class ReviewService {
             int pageSize,
             Member loginMember
     ) {
-        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
-                mapCoordinateRequest.x(),
-                mapCoordinateRequest.y(),
-                mapCoordinateRequest.deltaX(),
-                mapCoordinateRequest.deltaY()
-        );
+        MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
         List<Review> reviews = reviewCustomService.getReviewsByFollowingInMapBounds(
                 loginMember.getId(),
                 lastReviewId,
@@ -106,12 +115,7 @@ public class ReviewService {
     ) {
         School school = schoolRepository.findById(schoolId)
                 .orElseThrow(() -> new NotFoundException(SchoolExceptionType.NOT_FOUND));
-        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
-                mapCoordinateRequest.x(),
-                mapCoordinateRequest.y(),
-                mapCoordinateRequest.deltaX(),
-                mapCoordinateRequest.deltaY()
-        );
+        MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
         List<Review> reviews = reviewCustomService.getReviewsBySchoolInMapBounds(
                 school.getId(),
                 lastReviewId,
@@ -119,6 +123,15 @@ public class ReviewService {
                 pageSize
         );
         return convertToReviewPageResponse(loginMember, reviews, deviceCoordinateRequest);
+    }
+
+    private MapCoordinateBoundDto convertToMapCoordinateBound(MapCoordinateRequest mapCoordinateRequest) {
+        return MapCoordinateBoundDto.of(
+                mapCoordinateRequest.x(),
+                mapCoordinateRequest.y(),
+                mapCoordinateRequest.deltaX(),
+                mapCoordinateRequest.deltaY()
+        );
     }
 
     private ReviewPageResponse convertToReviewPageResponse(

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -36,9 +36,9 @@ public class ReviewController implements ReviewControllerDocs {
 
     private final ReviewService reviewService;
 
-    @GetMapping("/{memberId}/profile")
+    @GetMapping("/members")
     public ResponseEntity<ReviewPageResponse> getReviewsByMemberInMapBounds(
-            @PathVariable(name = "memberId") @Positive(message = "멤버 ID는 양수만 가능합니다.") Long memberId,
+            @RequestParam(name = "memberId") @Positive(message = "멤버 ID는 양수만 가능합니다.") Long memberId,
             @RequestParam(name = "lastReviewId", required = false) @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long lastReviewId,
             @RequestParam(name = "x") BigDecimal x,
             @RequestParam(name = "y") BigDecimal y,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -36,6 +36,32 @@ public class ReviewController implements ReviewControllerDocs {
 
     private final ReviewService reviewService;
 
+    @GetMapping("/{memberId}/profile")
+    public ResponseEntity<ReviewPageResponse> getReviewsByMemberInMapBounds(
+            @PathVariable(name = "memberId") @Positive(message = "멤버 ID는 양수만 가능합니다.") Long memberId,
+            @RequestParam(name = "lastReviewId", required = false) @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long lastReviewId,
+            @RequestParam(name = "x") BigDecimal x,
+            @RequestParam(name = "y") BigDecimal y,
+            @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
+            @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
+            @RequestParam(name = "deviceX") BigDecimal deviceX,
+            @RequestParam(name = "deviceY") BigDecimal deviceY,
+            @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
+            @Auth Member loginMember
+    ) {
+        MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
+        DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
+        ReviewPageResponse response = reviewService.getReviewsByMemberInMapBounds(
+                memberId,
+                lastReviewId,
+                mapCoordinateRequest,
+                deviceCoordinateRequest,
+                pageSize,
+                loginMember
+        );
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping("/bookmarks")
     public ResponseEntity<ReviewPageResponse> getReviewsByBookmarkInMapBounds(
             @RequestParam(name = "lastReviewId", required = false) @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long lastReviewId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -24,6 +24,97 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ReviewControllerDocs {
 
     @Operation(
+            summary = "멤버의 리뷰 목록 범위 기반 페이징 조회",
+            description = """
+                    지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
+                                        
+                    해당 범위에 속한 멤버의 리뷰 목록을 조회하는 기능입니다.
+                                        
+                    디바이스 경도(deviceX), 디바이스 위도(deviceY)를 통해 디바이스와 가게 사이의 거리를 계산합니다.
+                                        
+                    조회 성능을 높이기 위해 NO OFFSET 페이징으로 구현하였기에 페이지 번호 대신 마지막 리뷰 ID를 요청값으로 받습니다.
+                                        
+                    첫 페이지 조회 시에는 마지막 리뷰 ID를 파라미터에 담지 않고 요청을 보내면 됩니다.
+                                        
+                    두번째 페이지 조회 부터는 이전 조회 응답에 담겨 있는 마지막 리뷰 ID를 파라미터로 넘겨주면
+                                        
+                    해당 리뷰 ID보다 작은, 다시 말해서 요청으로 보낸 리뷰 이전에 작성된 리뷰부터 조회하게 됩니다.
+                                        
+                    페이지 크기(응답할 리뷰 개수)는 파라미터로 보내지 않으면 기본적으로 10개로 동작하게 되어있습니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "멤버의 리뷰 목록 범위 기반 페이징 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.멤버 ID가 존재하지 않은 경우
+                                                        
+                            2.멤버 ID가 양수가 아닌 경우
+                                                        
+                            3.리뷰 ID가 양수가 아닌 경우
+                                                        
+                            4.지도 중심 경도가 존재하지 않은 경우
+                                                        
+                            5.지도 중심 위도가 존재하지 않은 경우
+                                                        
+                            6.지도 경도 증가값이 존재하지 않은 경우
+                                                        
+                            7.지도 위도 증가값이 존재하지 않은 경우
+                                                        
+                            8.지도 경도 증가값이 0이상 양수가 아닌 경우
+                                                        
+                            9.지도 위도 증가값이 0이상 양수가 아닌 경우
+                                                        
+                            10.디바이스 경도가 존재하지 않은 경우
+                                                        
+                            11.디바이스 위도가 존재하지 않은 경우
+                                                        
+                            12.페이지 크기가 양수가 아닌 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<ReviewPageResponse> getReviewsByMemberInMapBounds(
+            @Parameter(description = "리뷰 조회 멤버 ID", example = "1")
+            @Positive(message = "멤버 ID는 양수만 가능합니다.")
+            Long memberId,
+
+            @Parameter(description = "이전 조회의 마지막 리뷰 ID(첫 조회 시에는 파라미터 요청 X)", example = "1")
+            @Positive(message = "리뷰 ID는 양수만 가능합니다.")
+            Long lastReviewId,
+
+            @Parameter(description = "지도 중심 경도", example = "123.3636")
+            BigDecimal x,
+
+            @Parameter(description = "지도 중심 위도", example = "32.3636")
+            BigDecimal y,
+
+            @Parameter(description = "지도 경도 증가값", example = "3.1212")
+            @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaX,
+
+            @Parameter(description = "지도 위도 증가값", example = "3.1212")
+            @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaY,
+
+            @Parameter(description = "사용자 경도", example = "123.3636")
+            BigDecimal deviceX,
+
+            @Parameter(description = "사용자 위도", example = "32.3636")
+            BigDecimal deviceY,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @Positive(message = "페이지 크기는 양수만 가능합니다.")
+            int pageSize,
+
+            Member loginMember
+    );
+
+    @Operation(
             summary = "북마크한 가게의 리뷰 목록 범위 기반 페이징 조회",
             description = """
                     지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
@@ -217,27 +308,29 @@ public interface ReviewControllerDocs {
             @ApiResponse(
                     responseCode = "400",
                     description = """
-                            1.학교 ID가 양수가 아닌 경우
+                            1.학교 ID가 존재하지 않은 경우
                                                         
-                            2.리뷰 ID가 양수가 아닌 경우
+                            2.학교 ID가 양수가 아닌 경우
                                                         
-                            3.지도 중심 경도가 존재하지 않은 경우
+                            3.리뷰 ID가 양수가 아닌 경우
                                                         
-                            4.지도 중심 위도가 존재하지 않은 경우
+                            4.지도 중심 경도가 존재하지 않은 경우
                                                         
-                            5.지도 경도 증가값이 존재하지 않은 경우
+                            5.지도 중심 위도가 존재하지 않은 경우
                                                         
-                            6.지도 위도 증가값이 존재하지 않은 경우
+                            6.지도 경도 증가값이 존재하지 않은 경우
                                                         
-                            7.지도 경도 증가값이 0이상 양수가 아닌 경우
+                            7.지도 위도 증가값이 존재하지 않은 경우
                                                         
-                            8.지도 위도 증가값이 0이상 양수가 아닌 경우
+                            8.지도 경도 증가값이 0이상 양수가 아닌 경우
                                                         
-                            9.디바이스 경도가 존재하지 않은 경우
+                            9.지도 위도 증가값이 0이상 양수가 아닌 경우
                                                         
-                            10.디바이스 위도가 존재하지 않은 경우
+                            10.디바이스 경도가 존재하지 않은 경우
                                                         
-                            11.페이지 크기가 양수가 아닌 경우
+                            11.디바이스 위도가 존재하지 않은 경우
+                                                        
+                            12.페이지 크기가 양수가 아닌 경우
                             """,
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             ),

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
@@ -20,6 +20,28 @@ class ReviewCustomServiceTest extends IntegrationTest {
     private ReviewCustomService reviewCustomService;
 
     @Test
+    void 멤버_리뷰_목록을_범위를_통해_조회한다() {
+        Member writer = memberTestPersister.builder().save();
+        Store store = storeTestPersister.builder().save();
+        Review review = reviewTestPersister.builder().member(writer).store(store).save();
+        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                BigDecimal.valueOf(3),
+                BigDecimal.valueOf(3)
+        );
+
+        List<Review> result = reviewCustomService.getReviewsByMemberInMapBounds(
+                writer.getId(),
+                null,
+                mapCoordinateBoundDto,
+                10
+        );
+
+        assertThat(result).containsExactly(review);
+    }
+
+    @Test
     void 북마크한_가게_리뷰_목록을_범위를_통해_조회한다() {
         Member member = memberTestPersister.builder().save();
         Store store = storeTestPersister.builder().save();

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -44,6 +44,184 @@ class ReviewServiceTest extends IntegrationTest {
     private ReviewRepository reviewRepository;
 
     @Nested
+    class 멤버_리뷰_목록_페이징_조회_시 {
+
+        @Test
+        void 리뷰_작성자의_팔로워_수도_함께_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            followTestPersister.builder().following(writer).save();
+            followTestPersister.builder().following(writer).save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            ReviewPageResponse response = reviewService.getReviewsByMemberInMapBounds(
+                    writer.getId(),
+                    null,
+                    mapCoordinateRequest,
+                    deviceCoordinateRequest,
+                    10,
+                    member
+            );
+
+            List<ReviewResponse> result = response.reviews();
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(0).writer().id()).isEqualTo(writer.getId());
+                softly.assertThat(result.get(0).writer().nickname()).isEqualTo(writer.getNickname());
+                softly.assertThat(result.get(0).writer().followerCount()).isEqualTo(2);
+            });
+        }
+
+        @Test
+        void 리뷰의_사진_목록도_함께_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).save();
+            ReviewPhoto reviewPhotoA = reviewPhotoTestPersister.builder().review(review).save();
+            ReviewPhoto reviewPhotoB = reviewPhotoTestPersister.builder().review(review).save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            ReviewPageResponse response = reviewService.getReviewsByMemberInMapBounds(
+                    writer.getId(),
+                    null,
+                    mapCoordinateRequest,
+                    deviceCoordinateRequest,
+                    10,
+                    member
+            );
+
+            List<ReviewResponse> result = response.reviews();
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(0).review().id()).isEqualTo(review.getId());
+                softly.assertThat(result.get(0).review().content()).isEqualTo(review.getContent());
+                softly.assertThat(result.get(0).review().imagePaths())
+                        .containsExactly(reviewPhotoA.getPhoto().getPath(), reviewPhotoB.getPhoto().getPath());
+                softly.assertThat(result.get(0).review().createdAt()).isEqualTo(review.getCreatedAt());
+                softly.assertThat(result.get(0).review().updatedAt()).isEqualTo(review.getUpdatedAt());
+            });
+        }
+
+        @Test
+        void 북마크한_가게는_북마크_여부가_TRUE_이다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder()
+                    .address(
+                            Address.of(
+                                    "부산광역시 금정구 부산대학로63번길 2",
+                                    PointUtils.generate(
+                                            BigDecimal.valueOf(129.084180374589),
+                                            BigDecimal.valueOf(35.23159315706788)
+                                    )
+                            )
+                    )
+                    .save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(129.0842730512684),
+                    BigDecimal.valueOf(35.23038627521815)
+            );
+
+            ReviewPageResponse response = reviewService.getReviewsByMemberInMapBounds(
+                    writer.getId(),
+                    null,
+                    mapCoordinateRequest,
+                    deviceCoordinateRequest,
+                    10,
+                    member
+            );
+
+            List<ReviewResponse> result = response.reviews();
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(0).store().id()).isEqualTo(store.getId());
+                softly.assertThat(result.get(0).store().categoryName()).isEqualTo(store.getCategory().getName());
+                softly.assertThat(result.get(0).store().name()).isEqualTo(store.getStoreName());
+                softly.assertThat(result.get(0).store().addressName()).isEqualTo(store.getAddress().getAddressName());
+                softly.assertThat(Math.round(result.get(0).store().distance() / 10) * 10).isEqualTo(130);
+                softly.assertThat(result.get(0).store().isBookmarked()).isTrue();
+            });
+        }
+
+        @Test
+        void 북마크하지_않은_가게는_북마크_여부가_FALSE_이다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder()
+                    .address(
+                            Address.of(
+                                    "부산광역시 금정구 부산대학로63번길 2",
+                                    PointUtils.generate(
+                                            BigDecimal.valueOf(129.084180374589),
+                                            BigDecimal.valueOf(35.23159315706788)
+                                    )
+                            )
+                    )
+                    .save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(129.0842730512684),
+                    BigDecimal.valueOf(35.23038627521815)
+            );
+
+            ReviewPageResponse response = reviewService.getReviewsByMemberInMapBounds(
+                    writer.getId(),
+                    null,
+                    mapCoordinateRequest,
+                    deviceCoordinateRequest,
+                    10,
+                    member
+            );
+
+            List<ReviewResponse> result = response.reviews();
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(0).store().id()).isEqualTo(store.getId());
+                softly.assertThat(result.get(0).store().categoryName()).isEqualTo(store.getCategory().getName());
+                softly.assertThat(result.get(0).store().name()).isEqualTo(store.getStoreName());
+                softly.assertThat(result.get(0).store().addressName()).isEqualTo(store.getAddress().getAddressName());
+                softly.assertThat(Math.round(result.get(0).store().distance() / 10) * 10).isEqualTo(130);
+                softly.assertThat(result.get(0).store().isBookmarked()).isFalse();
+            });
+        }
+    }
+
+    @Nested
     class 북마크한_가게_리뷰_목록_페이징_조회_시 {
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -21,6 +21,168 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
     private ReviewCustomRepository reviewCustomRepository;
 
     @Nested
+    class 멤버의_리뷰_목록_페이징_조회_시 {
+
+        @Test
+        void 마지막_리뷰ID가_NULL이_아닐때_마지막_리뷰ID보다_작은_리뷰는_조회한다() {
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByMemberInMapBound(
+                    writer.getId(),
+                    review.getId() + 1,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).containsExactly(review);
+        }
+
+        @Test
+        void 마지막_리뷰ID가_NULL이_아닐때_마지막_리뷰ID보다_큰_리뷰는_조회하지_않는다() {
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByMemberInMapBound(
+                    writer.getId(),
+                    review.getId() - 1,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 멤버의_리뷰라면_조회한다() {
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByMemberInMapBound(
+                    writer.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).containsExactly(review);
+        }
+
+        @Test
+        void 멤버의_리뷰가_아니라면_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByMemberInMapBound(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 폴리곤_영역에_경도와_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByMemberInMapBound(
+                    writer.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 리뷰ID를_내림차순으로_조회한다() {
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().member(writer).store(store).save();
+            Review reviewB = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByMemberInMapBound(
+                    writer.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).containsExactly(reviewB, reviewA);
+        }
+
+        @Test
+        void 페이지_크기만큼_조회한다() {
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().member(writer).store(store).save();
+            Review reviewB = reviewTestPersister.builder().member(writer).store(store).save();
+            Review reviewC = reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByMemberInMapBound(
+                    writer.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    2
+            );
+
+            assertThat(result).containsExactly(reviewC, reviewB);
+        }
+    }
+
+    @Nested
     class 북마크한_가게_리뷰_목록_페이징_조회_시 {
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -70,6 +70,251 @@ class ReviewControllerTest extends PresentationTest {
     private ReviewService reviewService;
 
     @Nested
+    class 멤버_리뷰_페이징_조회_시 {
+
+        private final String accessToken = jwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        @Test
+        void 정상적인_요청이라면_200_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+            ReviewPageResponse response = new ReviewPageResponse(
+                    List.of(
+                            new ReviewResponse(
+                                    new ReviewWriterResponse(1L, "hello", "image.png", 0L),
+                                    new ReviewContentResponse(
+                                            1L,
+                                            "content",
+                                            List.of("image.png"),
+                                            LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS),
+                                            LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
+                                    ),
+                                    new ReviewStoreResponse(
+                                            1L,
+                                            "카페",
+                                            "가게",
+                                            "가게주소",
+                                            100.13,
+                                            false
+                                    )
+                            )
+                    ),
+                    new ReviewPageInfo(10L, 1L, 10)
+            );
+            given(reviewService.getReviewsByMemberInMapBounds(
+                    anyLong(),
+                    any(),
+                    any(MapCoordinateRequest.class),
+                    any(DeviceCoordinateRequest.class),
+                    anyInt(),
+                    any(Member.class)
+            )).willReturn(response);
+
+            MvcResult mvcResult = mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String jsonResponse = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+            ReviewPageResponse result = objectMapper.readValue(jsonResponse, ReviewPageResponse.class);
+            assertThat(result).usingRecursiveComparison().isEqualTo(response);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 멤버_ID가_양수가_아니라면_400_응답을_반환한다(String memberId) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", memberId)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("멤버 ID는 양수만 가능합니다.")));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 마지막_리뷰ID가_양수가_아니라면_400_응답을_반환한다(String lastReviewId) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("lastReviewId", lastReviewId)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("리뷰 ID는 양수만 가능합니다.")));
+        }
+
+        @Test
+        void 경도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 위도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 경도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 위도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 경도_증가값이_0이상의_양수가_아니라면_400_응답을_반환한다(String deltaX) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", deltaX)
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("경도 증가값은 0이상의 양수만 가능합니다.")));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 위도_증가값이_0이상의_양수가_아니라면_400_응답을_반환한다(String deltaY) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", deltaY)
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("위도 증가값은 0이상의 양수만 가능합니다.")));
+        }
+
+        @Test
+        void 디바이스_경도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceY", "32.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 디바이스_위도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 페이지_크기가_양수가_아니라면_400_응답을_반환한다(String pageSize) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636")
+                            .param("pageSize", pageSize))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("페이지 크기는 양수만 가능합니다.")));
+        }
+    }
+
+    @Nested
     class 북마크한_가게_리뷰_페이징_조회_시 {
 
         private final String accessToken = jwtTokenProvider.createAccessToken(1L, ROLE_회원);

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -109,8 +109,9 @@ class ReviewControllerTest extends PresentationTest {
                     any(Member.class)
             )).willReturn(response);
 
-            MvcResult mvcResult = mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            MvcResult mvcResult = mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", "1")
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaX", "3.12")
@@ -131,8 +132,9 @@ class ReviewControllerTest extends PresentationTest {
         void 멤버_ID가_양수가_아니라면_400_응답을_반환한다(String memberId) throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", memberId)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", memberId)
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaX", "3.12")
@@ -150,9 +152,10 @@ class ReviewControllerTest extends PresentationTest {
         void 마지막_리뷰ID가_양수가_아니라면_400_응답을_반환한다(String lastReviewId) throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
                             .param("lastReviewId", lastReviewId)
+                            .param("memberId", "1")
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaX", "3.12")
@@ -169,8 +172,9 @@ class ReviewControllerTest extends PresentationTest {
         void 경도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", "1")
                             .param("y", "32.3636")
                             .param("deltaX", "3.12")
                             .param("deltaY", "3.12")
@@ -184,8 +188,9 @@ class ReviewControllerTest extends PresentationTest {
         void 위도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", "1")
                             .param("x", "123.3636")
                             .param("deltaX", "3.12")
                             .param("deltaY", "3.12")
@@ -199,8 +204,9 @@ class ReviewControllerTest extends PresentationTest {
         void 경도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", "1")
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaY", "3.12")
@@ -214,8 +220,9 @@ class ReviewControllerTest extends PresentationTest {
         void 위도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memerId", "1")
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaX", "3.12")
@@ -230,8 +237,9 @@ class ReviewControllerTest extends PresentationTest {
         void 경도_증가값이_0이상의_양수가_아니라면_400_응답을_반환한다(String deltaX) throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", "1")
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaX", deltaX)
@@ -249,8 +257,9 @@ class ReviewControllerTest extends PresentationTest {
         void 위도_증가값이_0이상의_양수가_아니라면_400_응답을_반환한다(String deltaY) throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", "1")
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaX", "3.12")
@@ -267,8 +276,9 @@ class ReviewControllerTest extends PresentationTest {
         void 디바이스_경도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", "1")
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaX", "3.12")
@@ -282,8 +292,9 @@ class ReviewControllerTest extends PresentationTest {
         void 디바이스_위도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", "1")
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaX", "3.12")
@@ -298,8 +309,9 @@ class ReviewControllerTest extends PresentationTest {
         void 페이지_크기가_양수가_아니라면_400_응답을_반환한다(String pageSize) throws Exception {
             mockingAuthMemberInResolver();
 
-            mockMvc.perform(get("/v1/reviews/{memberId}/profile", 1L)
+            mockMvc.perform(get("/v1/reviews/members")
                             .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("memberId", "1")
                             .param("x", "123.3636")
                             .param("y", "32.3636")
                             .param("deltaX", "3.12")


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #135

## 📝 작업 요약

유저 프로필 리뷰 목록을 조회하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

기존 리뷰 조회와 전체적인 플로우는 동일하기에, 쿼리 위주로 보면 될 것 같습니다.

### 논의할 점

API URI를 `/v1/reviews/{memberId}/profile`로 했는데 혹시 더 좋은 URI가 있을까요? 🤔

## 🌟 리뷰 요구 사항

> 10분
> 동일한 리뷰의 연속이네요 :0