### PR TITLE
Feature/#174 팔로우한 유저의 가게를 조회하는 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/member/dto/response/MemberSearchResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/dto/response/MemberSearchResponse.java
@@ -29,7 +29,7 @@ public record MemberSearchResponse(
             Member loginMember,
             long followerCount,
             boolean isFollowing
-            ) {
+    ) {
         return new MemberSearchResponse(
                 member.getId(),
                 member.getNickname(),

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
@@ -65,13 +65,13 @@ public interface MemberControllerDocs {
             summary = "회원 검색",
             description = """
                     닉네임으로 회원을 검색합니다.
-                    
+                                        
                     필수 파라미터: name(검색 키워드)
-                    
+                                        
                     선택 파라미터: size(응답으로 받을 최대 검색 결과 수, Default: 10, Max: 30)
-                    
+                                        
                     요청 예시: /v1/memberse/search?name=coby1234&size=15
-                    
+                                        
                     검색하는 사용자가 검색 결과에 포함되는 경우 isMe 필드가 true로 반환됩니다.
                     """
     )

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
@@ -3,8 +3,11 @@ package org.dinosaur.foodbowl.domain.review.application;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
+import org.dinosaur.foodbowl.domain.review.application.dto.StoreToReviewCountDto;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.domain.review.persistence.ReviewCustomRepository;
+import org.dinosaur.foodbowl.domain.review.persistence.dto.StoreReviewCountDto;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewCustomService {
 
     private final ReviewCustomRepository reviewCustomRepository;
+
+    @Transactional(readOnly = true)
+    public StoreToReviewCountDto getReviewCountByStores(List<Store> stores) {
+        List<StoreReviewCountDto> storeReviewCounts = reviewCustomRepository.findReviewCountByStores(stores);
+        return StoreToReviewCountDto.from(storeReviewCounts);
+    }
 
     @Transactional(readOnly = true)
     public List<Review> getReviewsByBookmarkInMapBounds(

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/dto/StoreToReviewCountDto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/dto/StoreToReviewCountDto.java
@@ -1,0 +1,30 @@
+package org.dinosaur.foodbowl.domain.review.application.dto;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.dinosaur.foodbowl.domain.review.persistence.dto.StoreReviewCountDto;
+
+public record StoreToReviewCountDto(
+        Map<Long, Long> storeToReviewCount
+) {
+
+    public static StoreToReviewCountDto from(List<StoreReviewCountDto> storeReviewCounts) {
+        Map<Long, Long> storeToReviewCount = storeReviewCounts.stream()
+                .collect(
+                        toMap(
+                                StoreReviewCountDto::storeId,
+                                StoreReviewCountDto::reviewCount,
+                                (exist, replace) -> replace,
+                                HashMap::new
+                        )
+                );
+        return new StoreToReviewCountDto(storeToReviewCount);
+    }
+
+    public long getReviewCount(Long storeId) {
+        return storeToReviewCount.getOrDefault(storeId, 0L);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -16,6 +16,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
+import org.dinosaur.foodbowl.domain.review.persistence.dto.QStoreReviewCountDto;
+import org.dinosaur.foodbowl.domain.review.persistence.dto.StoreReviewCountDto;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.springframework.stereotype.Repository;
 
@@ -24,6 +27,20 @@ import org.springframework.stereotype.Repository;
 public class ReviewCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+
+    public List<StoreReviewCountDto> findReviewCountByStores(List<Store> stores) {
+        return jpaQueryFactory.select(
+                        new QStoreReviewCountDto(
+                                store.id,
+                                review.count()
+                        )
+                )
+                .from(review)
+                .innerJoin(review.store, store)
+                .where(store.in(stores))
+                .groupBy(store.id)
+                .fetch();
+    }
 
     public List<Review> findPaginationReviewsByBookmarkInMapBounds(
             Long memberId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/dto/StoreReviewCountDto.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/dto/StoreReviewCountDto.java
@@ -1,0 +1,13 @@
+package org.dinosaur.foodbowl.domain.review.persistence.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record StoreReviewCountDto(
+        Long storeId,
+        long reviewCount
+) {
+
+    @QueryProjection
+    public StoreReviewCountDto {
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomService.java
@@ -1,0 +1,21 @@
+package org.dinosaur.foodbowl.domain.store.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
+import org.dinosaur.foodbowl.domain.store.persistence.StoreCustomRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class StoreCustomService {
+
+    private final StoreCustomRepository storeCustomRepository;
+
+    @Transactional(readOnly = true)
+    public List<Store> getStoresByFollowingInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return storeCustomRepository.findStoresByFollowingInMapBounds(memberId, mapCoordinateBoundDto);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
@@ -46,28 +46,6 @@ public class StoreService {
     private final BookmarkQueryService bookmarkQueryService;
 
     @Transactional(readOnly = true)
-    public StoreMapBoundResponses getStoresByFollowingInMapBounds(
-            MapCoordinateRequest mapCoordinateRequest,
-            Member loginMember
-    ) {
-        MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
-        List<Store> stores =
-                storeCustomService.getStoresByFollowingInMapBounds(loginMember.getId(), mapCoordinateBoundDto);
-        StoreToReviewCountDto storeToReviewCountDto = reviewCustomService.getReviewCountByStores(stores);
-        Set<Store> bookmarkStores = bookmarkQueryService.getBookmarkStoresByMember(loginMember);
-        return StoreMapBoundResponses.of(stores, storeToReviewCountDto, bookmarkStores);
-    }
-
-    private MapCoordinateBoundDto convertToMapCoordinateBound(MapCoordinateRequest mapCoordinateRequest) {
-        return MapCoordinateBoundDto.of(
-                mapCoordinateRequest.x(),
-                mapCoordinateRequest.y(),
-                mapCoordinateRequest.deltaX(),
-                mapCoordinateRequest.deltaY()
-        );
-    }
-
-    @Transactional(readOnly = true)
     public Store findById(Long id) {
         return storeRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(StoreExceptionType.NOT_FOUND));
@@ -76,6 +54,12 @@ public class StoreService {
     @Transactional(readOnly = true)
     public Optional<Store> findByLocationId(String locationId) {
         return storeRepository.findByLocationId(locationId);
+    }
+
+    @Transactional(readOnly = true)
+    public CategoriesResponse getCategories() {
+        List<Category> categories = categoryRepository.findAllByOrderById();
+        return CategoriesResponse.from(categories);
     }
 
     @Transactional(readOnly = true)
@@ -95,9 +79,25 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
-    public CategoriesResponse getCategories() {
-        List<Category> categories = categoryRepository.findAllByOrderById();
-        return CategoriesResponse.from(categories);
+    public StoreMapBoundResponses getStoresByFollowingInMapBounds(
+            MapCoordinateRequest mapCoordinateRequest,
+            Member loginMember
+    ) {
+        MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
+        List<Store> stores =
+                storeCustomService.getStoresByFollowingInMapBounds(loginMember.getId(), mapCoordinateBoundDto);
+        StoreToReviewCountDto storeToReviewCountDto = reviewCustomService.getReviewCountByStores(stores);
+        Set<Store> bookmarkStores = bookmarkQueryService.getBookmarkStoresByMember(loginMember);
+        return StoreMapBoundResponses.of(stores, storeToReviewCountDto, bookmarkStores);
+    }
+
+    private MapCoordinateBoundDto convertToMapCoordinateBound(MapCoordinateRequest mapCoordinateRequest) {
+        return MapCoordinateBoundDto.of(
+                mapCoordinateRequest.x(),
+                mapCoordinateRequest.y(),
+                mapCoordinateRequest.deltaX(),
+                mapCoordinateRequest.deltaY()
+        );
     }
 
     @Transactional

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/dto/response/StoreMapBoundResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/dto/response/StoreMapBoundResponse.java
@@ -1,0 +1,49 @@
+package org.dinosaur.foodbowl.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
+
+@Schema(description = "지도 경계 가게 응답")
+public record StoreMapBoundResponse(
+        @Schema(description = "가게 ID", example = "1")
+        Long id,
+
+        @Schema(description = "가게 이름", example = "홍대입구역 편의점")
+        String name,
+
+        @Schema(description = "가게 카테고리", example = "일식")
+        String categoryName,
+
+        @Schema(description = "가게 주소", example = "강원도 한섬로73 동해아파트 101동 101호")
+        String addressName,
+
+        @Schema(description = "가게 상세 정보 URL", example = "http://store.info.com")
+        String url,
+
+        @Schema(description = "가게 경도", example = "123.3636")
+        double x,
+
+        @Schema(description = "가게 위도", example = "32.3636")
+        double y,
+
+        @Schema(description = "가게 후기 개수", example = "123")
+        long reviewCount,
+
+        @Schema(description = "가게 북마크 여부", example = "false")
+        boolean isBookmarked
+) {
+
+    public static StoreMapBoundResponse of(Store store, long reviewCount, boolean isBookmarked) {
+        return new StoreMapBoundResponse(
+                store.getId(),
+                store.getStoreName(),
+                store.getCategory().getName(),
+                store.getAddress().getAddressName(),
+                store.getStoreUrl(),
+                store.getAddress().getCoordinate().getX(),
+                store.getAddress().getCoordinate().getY(),
+                reviewCount,
+                isBookmarked
+        );
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/dto/response/StoreMapBoundResponses.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/dto/response/StoreMapBoundResponses.java
@@ -1,0 +1,40 @@
+package org.dinosaur.foodbowl.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Set;
+import org.dinosaur.foodbowl.domain.review.application.dto.StoreToReviewCountDto;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
+
+@Schema(description = "지도 경계 가게 조회 응답")
+public record StoreMapBoundResponses(
+        @Schema(description = "지도 경계 가게 응답 목록")
+        List<StoreMapBoundResponse> stores
+) {
+
+    public static StoreMapBoundResponses of(
+            List<Store> stores,
+            StoreToReviewCountDto storeToReviewCountDto,
+            Set<Store> bookmarkStores
+    ) {
+        List<StoreMapBoundResponse> storeMapBounds =
+                convertToStoreMapBoundResponses(stores, storeToReviewCountDto, bookmarkStores);
+        return new StoreMapBoundResponses(storeMapBounds);
+    }
+
+    private static List<StoreMapBoundResponse> convertToStoreMapBoundResponses(
+            List<Store> stores,
+            StoreToReviewCountDto storeToReviewCountDto,
+            Set<Store> bookmarkStores
+    ) {
+        return stores.stream()
+                .map(
+                        store -> StoreMapBoundResponse.of(
+                                store,
+                                storeToReviewCountDto.getReviewCount(store.getId()),
+                                bookmarkStores.contains(store)
+                        )
+                )
+                .toList();
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
@@ -4,6 +4,7 @@ import static com.querydsl.core.types.Projections.constructor;
 import static org.dinosaur.foodbowl.domain.follow.domain.QFollow.follow;
 import static org.dinosaur.foodbowl.domain.member.domain.QMember.member;
 import static org.dinosaur.foodbowl.domain.review.domain.QReview.review;
+import static org.dinosaur.foodbowl.domain.store.domain.QCategory.category;
 import static org.dinosaur.foodbowl.domain.store.domain.QStore.store;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -29,6 +30,7 @@ public class StoreCustomRepository {
     public List<Store> findStoresByFollowingInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
         return jpaQueryFactory.selectDistinct(store)
                 .from(store)
+                .innerJoin(store.category, category).fetchJoin()
                 .innerJoin(review).on(review.store.eq(store))
                 .innerJoin(member).on(review.member.eq(member))
                 .innerJoin(follow).on(

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
@@ -1,15 +1,21 @@
 package org.dinosaur.foodbowl.domain.store.persistence;
 
 import static com.querydsl.core.types.Projections.constructor;
+import static org.dinosaur.foodbowl.domain.follow.domain.QFollow.follow;
+import static org.dinosaur.foodbowl.domain.member.domain.QMember.member;
 import static org.dinosaur.foodbowl.domain.review.domain.QReview.review;
 import static org.dinosaur.foodbowl.domain.store.domain.QStore.store;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponse;
 import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.springframework.stereotype.Repository;
@@ -19,6 +25,52 @@ import org.springframework.stereotype.Repository;
 public class StoreCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Store> findStoresByFollowingInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return jpaQueryFactory.selectDistinct(store)
+                .from(store)
+                .innerJoin(review).on(review.store.eq(store))
+                .innerJoin(member).on(review.member.eq(member))
+                .innerJoin(follow).on(
+                        review.member.id.eq(follow.following.id),
+                        follow.follower.id.eq(memberId)
+                )
+                .where(containsPolygon(mapCoordinateBoundDto))
+                .fetch();
+    }
+
+    private BooleanExpression containsPolygon(MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return Expressions.booleanTemplate(
+                "ST_Contains({0}, {1})",
+                convertTextToPolygon(mapCoordinateBoundDto),
+                store.address.coordinate
+        );
+    }
+
+    private StringExpression convertTextToPolygon(MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return Expressions.stringTemplate(
+                "ST_GeomFromText({0}, {1})",
+                getPolygon(mapCoordinateBoundDto),
+                PointUtils.getSrId()
+        );
+    }
+
+    private String getPolygon(MapCoordinateBoundDto mapCoordinateBoundDto) {
+        String polygonTemplate = "POLYGON((%s %s, %s %s, %s %s, %s %s, %s %s))";
+        return String.format(
+                polygonTemplate,
+                mapCoordinateBoundDto.downLeftPoint().getY(),
+                mapCoordinateBoundDto.downLeftPoint().getX(),
+                mapCoordinateBoundDto.downRightPoint().getY(),
+                mapCoordinateBoundDto.downRightPoint().getX(),
+                mapCoordinateBoundDto.topRightPoint().getY(),
+                mapCoordinateBoundDto.topRightPoint().getX(),
+                mapCoordinateBoundDto.topLeftPoint().getY(),
+                mapCoordinateBoundDto.topLeftPoint().getX(),
+                mapCoordinateBoundDto.downLeftPoint().getY(),
+                mapCoordinateBoundDto.downLeftPoint().getX()
+        );
+    }
 
     public List<StoreSearchResponse> search(String name, double x, double y, int size) {
         return jpaQueryFactory.select(

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
@@ -6,11 +6,15 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
 import org.dinosaur.foodbowl.domain.store.application.SchoolService;
 import org.dinosaur.foodbowl.domain.store.application.StoreService;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoriesResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
+import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponses;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponses;
+import org.dinosaur.foodbowl.global.presentation.Auth;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +30,20 @@ public class StoreController implements StoreControllerDocs {
 
     private final StoreService storeService;
     private final SchoolService schoolService;
+
+    @GetMapping("/followings")
+    public ResponseEntity<StoreMapBoundResponses> getStoresByFollowingInMapBounds(
+            @RequestParam(name = "x") BigDecimal x,
+            @RequestParam(name = "y") BigDecimal y,
+            @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
+            @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
+            @Auth Member loginMember
+    ) {
+        MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
+        StoreMapBoundResponses response =
+                storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, loginMember);
+        return ResponseEntity.ok(response);
+    }
 
     @GetMapping("/search")
     public ResponseEntity<StoreSearchResponses> search(

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
@@ -12,14 +12,65 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoriesResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
+import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponses;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponses;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "가게", description = "가게 API")
 public interface StoreControllerDocs {
+
+    @Operation(
+            summary = "팔로잉 하는 유저의 리뷰가 존재하는 가게 목록 범위 기반 조회",
+            description = """
+                    지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
+                                        
+                    해당 범위에 속한 팔로잉 하는 유저의 리뷰가 존재하는 가게 목록을 조회하는 기능입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "팔로잉 하는 유저의 리뷰가 존재하는 가게 목록 범위 기반 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.지도 중심 경도가 존재하지 않은 경우
+                                                        
+                            2.지도 중심 위도가 존재하지 않은 경우
+                                                        
+                            3.지도 경도 증가값이 존재하지 않은 경우
+                                                        
+                            4.지도 경도 증가값이 양수가 아닌 경우
+                                                        
+                            5.지도 위도 증가값이 존재하지 않은 경우
+                                                        
+                            6.지도 위도 증가값이 양수가 아닌 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<StoreMapBoundResponses> getStoresByFollowingInMapBounds(
+            @Parameter(description = "지도 중심 경도", example = "123.3636")
+            BigDecimal x,
+
+            @Parameter(description = "지도 중심 위도", example = "32.3636")
+            BigDecimal y,
+
+            @Parameter(description = "지도 경도 증가값", example = "3.1212")
+            @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaX,
+
+            @Parameter(description = "지도 위도 증가값", example = "3.1212")
+            @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaY,
+
+            Member loginMember
+    );
 
     @Operation(
             summary = "가게 검색 결과 조회",

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/dto/MemberToFollowingsDtoTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/dto/MemberToFollowingsDtoTest.java
@@ -15,20 +15,20 @@ class MemberToFollowingsDtoTest {
 
     @Test
     void 팔로잉_하는_상황이면_true를_반환한다() {
-        List<FollowerAndFollowingDto> followerAndFollowingDtos = List.of(
-                new FollowerAndFollowingDto(1L, 2L)
-        );
-        MemberToFollowingsDto memberToFollowingsDto = new MemberToFollowingsDto(new HashSet<>(followerAndFollowingDtos));
+        List<FollowerAndFollowingDto> followerAndFollowingDtos =
+                List.of(new FollowerAndFollowingDto(1L, 2L));
+        MemberToFollowingsDto memberToFollowingsDto =
+                new MemberToFollowingsDto(new HashSet<>(followerAndFollowingDtos));
 
         assertThat(memberToFollowingsDto.isFollowing(1L, 2L)).isTrue();
     }
 
     @Test
     void 팔로잉_하지_않는_상황이면_false를_반환한다() {
-        List<FollowerAndFollowingDto> followerAndFollowingDtos = List.of(
-                new FollowerAndFollowingDto(1L, 2L)
-        );
-        MemberToFollowingsDto memberToFollowingsDto = new MemberToFollowingsDto(new HashSet<>(followerAndFollowingDtos));
+        List<FollowerAndFollowingDto> followerAndFollowingDtos =
+                List.of(new FollowerAndFollowingDto(1L, 2L));
+        MemberToFollowingsDto memberToFollowingsDto =
+                new MemberToFollowingsDto(new HashSet<>(followerAndFollowingDtos));
 
         assertThat(memberToFollowingsDto.isFollowing(1L, 3L)).isFalse();
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
@@ -137,13 +137,15 @@ class MemberServiceTest extends IntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(memberSearchResponses.get(0).memberId()).isEqualTo(memberB.getId());
                 softly.assertThat(memberSearchResponses.get(0).nickname()).isEqualTo(memberB.getNickname());
-                softly.assertThat(memberSearchResponses.get(0).profileImageUrl()).isEqualTo(memberB.getProfileImageUrl());
+                softly.assertThat(memberSearchResponses.get(0).profileImageUrl())
+                        .isEqualTo(memberB.getProfileImageUrl());
                 softly.assertThat(memberSearchResponses.get(0).followerCount()).isOne();
                 softly.assertThat(memberSearchResponses.get(0).isFollowing()).isTrue();
                 softly.assertThat(memberSearchResponses.get(0).isMe()).isFalse();
                 softly.assertThat(memberSearchResponses.get(1).memberId()).isEqualTo(memberA.getId());
                 softly.assertThat(memberSearchResponses.get(1).nickname()).isEqualTo(memberA.getNickname());
-                softly.assertThat(memberSearchResponses.get(1).profileImageUrl()).isEqualTo(memberA.getProfileImageUrl());
+                softly.assertThat(memberSearchResponses.get(1).profileImageUrl())
+                        .isEqualTo(memberA.getProfileImageUrl());
                 softly.assertThat(memberSearchResponses.get(1).followerCount()).isZero();
                 softly.assertThat(memberSearchResponses.get(1).isFollowing()).isFalse();
                 softly.assertThat(memberSearchResponses.get(1).isMe()).isFalse();
@@ -161,7 +163,8 @@ class MemberServiceTest extends IntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(memberSearchResponses.get(0).memberId()).isEqualTo(member.getId());
                 softly.assertThat(memberSearchResponses.get(0).nickname()).isEqualTo(member.getNickname());
-                softly.assertThat(memberSearchResponses.get(0).profileImageUrl()).isEqualTo(member.getProfileImageUrl());
+                softly.assertThat(memberSearchResponses.get(0).profileImageUrl())
+                        .isEqualTo(member.getProfileImageUrl());
                 softly.assertThat(memberSearchResponses.get(0).followerCount()).isZero();
                 softly.assertThat(memberSearchResponses.get(0).isFollowing()).isFalse();
                 softly.assertThat(memberSearchResponses.get(0).isMe()).isTrue();

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
@@ -1,11 +1,13 @@
 package org.dinosaur.foodbowl.domain.review.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
+import org.dinosaur.foodbowl.domain.review.application.dto.StoreToReviewCountDto;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.domain.store.domain.School;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
@@ -18,6 +20,25 @@ class ReviewCustomServiceTest extends IntegrationTest {
 
     @Autowired
     private ReviewCustomService reviewCustomService;
+
+    @Test
+    void 가게_목록에_속한_가게의_리뷰_개수를_조회한다() {
+        Member writer = memberTestPersister.builder().save();
+        Store storeA = storeTestPersister.builder().save();
+        Store storeB = storeTestPersister.builder().save();
+        Store storeC = storeTestPersister.builder().save();
+        reviewTestPersister.builder().member(writer).store(storeA).save();
+        reviewTestPersister.builder().member(writer).store(storeA).save();
+        reviewTestPersister.builder().member(writer).store(storeB).save();
+
+        StoreToReviewCountDto result = reviewCustomService.getReviewCountByStores(List.of(storeA, storeC));
+
+        assertSoftly(softly -> {
+            softly.assertThat(result.getReviewCount(storeA.getId())).isEqualTo(2);
+            softly.assertThat(result.getReviewCount(storeB.getId())).isEqualTo(0);
+            softly.assertThat(result.getReviewCount(storeC.getId())).isEqualTo(0);
+        });
+    }
 
     @Test
     void 북마크한_가게_리뷰_목록을_범위를_통해_조회한다() {

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -32,12 +32,15 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
         reviewTestPersister.builder().member(writer).store(storeA).save();
         reviewTestPersister.builder().member(writer).store(storeB).save();
 
-        List<StoreReviewCountDto> result = reviewCustomRepository.findReviewCountByStores(List.of(storeA, storeC));
+        List<StoreReviewCountDto> result =
+                reviewCustomRepository.findReviewCountByStores(List.of(storeA, storeB, storeC));
 
         assertSoftly(softly -> {
-            softly.assertThat(result).hasSize(1);
+            softly.assertThat(result).hasSize(2);
             softly.assertThat(result.get(0).storeId()).isEqualTo(storeA.getId());
             softly.assertThat(result.get(0).reviewCount()).isEqualTo(2);
+            softly.assertThat(result.get(1).storeId()).isEqualTo(storeB.getId());
+            softly.assertThat(result.get(1).reviewCount()).isEqualTo(1);
         });
     }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -1,12 +1,14 @@
 package org.dinosaur.foodbowl.domain.review.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
+import org.dinosaur.foodbowl.domain.review.persistence.dto.StoreReviewCountDto;
 import org.dinosaur.foodbowl.domain.store.domain.School;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.test.PersistenceTest;
@@ -19,6 +21,25 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
 
     @Autowired
     private ReviewCustomRepository reviewCustomRepository;
+
+    @Test
+    void 가게_목록에_존재하는_가게의_리뷰_개수를_조회한다() {
+        Member writer = memberTestPersister.builder().save();
+        Store storeA = storeTestPersister.builder().save();
+        Store storeB = storeTestPersister.builder().save();
+        Store storeC = storeTestPersister.builder().save();
+        reviewTestPersister.builder().member(writer).store(storeA).save();
+        reviewTestPersister.builder().member(writer).store(storeA).save();
+        reviewTestPersister.builder().member(writer).store(storeB).save();
+
+        List<StoreReviewCountDto> result = reviewCustomRepository.findReviewCountByStores(List.of(storeA, storeC));
+
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(1);
+            softly.assertThat(result.get(0).storeId()).isEqualTo(storeA.getId());
+            softly.assertThat(result.get(0).reviewCount()).isEqualTo(2);
+        });
+    }
 
     @Nested
     class 북마크한_가게_리뷰_목록_페이징_조회_시 {

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomServiceTest.java
@@ -1,0 +1,38 @@
+package org.dinosaur.foodbowl.domain.store.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
+import org.dinosaur.foodbowl.test.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+class StoreCustomServiceTest extends IntegrationTest {
+
+    @Autowired
+    private StoreCustomService storeCustomService;
+
+    @Test
+    void 팔로잉_하는_유저의_리뷰가_작성된_가게_목록을_범위를_통해_조회한다() {
+        Member member = memberTestPersister.builder().save();
+        Member writer = memberTestPersister.builder().save();
+        followTestPersister.builder().following(writer).follower(member).save();
+        Store store = storeTestPersister.builder().save();
+        reviewTestPersister.builder().member(writer).store(store).save();
+        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                BigDecimal.valueOf(1),
+                BigDecimal.valueOf(1)
+        );
+
+        List<Store> result = storeCustomService.getStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+        assertThat(result).containsExactly(store);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -206,6 +206,22 @@ class StoreServiceTest extends IntegrationTest {
                 softly.assertThat(result.get(0).isBookmarked()).isTrue();
             });
         }
+
+        @Test
+        void 일치하는_가게가_없으면_빈_리스트를_반환한다() {
+            Member member = memberTestPersister.builder().save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(123.3636),
+                    BigDecimal.valueOf(32.3131),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            StoreMapBoundResponses response =
+                    storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, member);
+
+            assertThat(response.stores()).isEmpty();
+        }
     }
 
     @Nested

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
@@ -5,11 +5,14 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.math.BigDecimal;
 import java.util.List;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.domain.store.domain.vo.Address;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponse;
 import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.dinosaur.foodbowl.test.PersistenceTest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -18,6 +21,91 @@ class StoreCustomRepositoryTest extends PersistenceTest {
 
     @Autowired
     private StoreCustomRepository storeCustomRepository;
+
+    @Nested
+    class 팔로잉_하는_유저의_리뷰가_작성된_가게_목록_범위_조회_시 {
+
+        @Test
+        void 팔로잉_하는_유저의_리뷰가_작성된_가게는_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            followTestPersister.builder().following(writer).follower(member).save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).containsExactly(store);
+        }
+
+        @Test
+        void 팔로잉_하는_유저의_리뷰가_작성되지_않은_가게는_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 팔로잉_하는_유저가_작성한_리뷰가_동일한_가게인_경우_중복_조회_하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Member writerA = memberTestPersister.builder().save();
+            Member writerB = memberTestPersister.builder().save();
+            followTestPersister.builder().following(writerA).follower(member).save();
+            followTestPersister.builder().following(writerB).follower(member).save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().member(writerA).store(store).save();
+            reviewTestPersister.builder().member(writerB).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).containsExactly(store);
+        }
+
+        @Test
+        void 폴리곤_영역에_경도와_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            followTestPersister.builder().following(writer).follower(member).save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().member(writer).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).isEmpty();
+        }
+    }
 
     @Test
     void 이름이_포함된_가게를_가까운_순으로_조회한다() {

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
@@ -17,12 +17,16 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
 import org.dinosaur.foodbowl.domain.store.application.SchoolService;
 import org.dinosaur.foodbowl.domain.store.application.StoreService;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoriesResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoryResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.SchoolResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
+import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponse;
+import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponses;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponses;
 import org.dinosaur.foodbowl.test.PresentationTest;
@@ -54,6 +58,134 @@ class StoreControllerTest extends PresentationTest {
 
     @MockBean
     private SchoolService schoolService;
+
+    @Nested
+    class 팔로잉_하는_유저의_리뷰가_존재하는_가게_목록_조회_시 {
+
+        private final String accessToken = jwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        @Test
+        void 정상적인_요청이라면_200_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+            StoreMapBoundResponses response = new StoreMapBoundResponses(
+                    List.of(
+                            new StoreMapBoundResponse(
+                                    1L,
+                                    "가게 이름",
+                                    "가게 카테고리명",
+                                    "가게 주소",
+                                    "가게 URL",
+                                    123.3636,
+                                    32.3636,
+                                    5,
+                                    false
+                            )
+                    )
+            );
+            given(storeService.getStoresByFollowingInMapBounds(any(MapCoordinateRequest.class), any(Member.class)))
+                    .willReturn(response);
+
+            MvcResult mvcResult = mockMvc.perform(get("/v1/stores/followings")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.1212")
+                            .param("deltaY", "3.1212"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String jsonResponse = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+            StoreMapBoundResponses result = objectMapper.readValue(jsonResponse, StoreMapBoundResponses.class);
+            assertThat(result).usingRecursiveComparison().isEqualTo(response);
+        }
+
+        @Test
+        void 경도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/followings")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 위도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/followings")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 경도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/followings")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaY", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 위도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/followings")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 경도_증가값이_0이상의_양수가_아니라면_400_응답을_반환한다(String deltaX) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/followings")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", deltaX)
+                            .param("deltaY", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("경도 증가값은 0이상의 양수만 가능합니다.")));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 위도_증가값이_0이상의_양수가_아니라면_400_응답을_반환한다(String deltaY) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/followings")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", deltaY))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("위도 증가값은 0이상의 양수만 가능합니다.")));
+        }
+    }
 
     @Nested
     class 가게_검색_시 {


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #174

## 📝 작업 요약

팔로우한 유저가 작성한 리뷰가 존재하는 가게 목록을 조회하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 가게 카테고리 조회를 위해 `fetch join`을 사용하였습니다.
- 가게마다 리뷰 개수 조회가 필요하기에 가게 목록에 존재하는 가게의 리뷰 개수를 조회하는 기능을 구현하였습니다.
- 북마크 여부 확인은 기존에 사용하던 북마크 가게 목록 조회 기능을 사용하였습니다.

## 🌟 리뷰 요구 사항

> 30분
> Repository 코드 위주로 리뷰해주시면 감사합니다 :)