### PR TITLE
Feature/#175 177 유저 프로필 가게, 학교 주변 가게 목록 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -9,6 +9,8 @@ import org.dinosaur.foodbowl.domain.bookmark.application.BookmarkQueryService;
 import org.dinosaur.foodbowl.domain.follow.application.FollowCustomService;
 import org.dinosaur.foodbowl.domain.follow.application.dto.MemberToFollowerCountDto;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.exception.MemberExceptionType;
+import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
 import org.dinosaur.foodbowl.domain.photo.application.PhotoService;
 import org.dinosaur.foodbowl.domain.photo.domain.Photo;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
@@ -39,6 +41,7 @@ public class ReviewService {
 
     private static final int REVIEW_PHOTO_MAX_SIZE = 4;
 
+    private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
     private final SchoolRepository schoolRepository;
     private final StoreService storeService;
@@ -58,9 +61,11 @@ public class ReviewService {
             int pageSize,
             Member loginMember
     ) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
         MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
         List<Review> reviews = reviewCustomService.getReviewsByMemberInMapBounds(
-                memberId,
+                member.getId(),
                 lastReviewId,
                 mapCoordinateBoundDto,
                 pageSize

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomService.java
@@ -15,6 +15,11 @@ public class StoreCustomService {
     private final StoreCustomRepository storeCustomRepository;
 
     @Transactional(readOnly = true)
+    public List<Store> getStoresByMemberInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return storeCustomRepository.findStoresByMemberInMapBounds(memberId, mapCoordinateBoundDto);
+    }
+
+    @Transactional(readOnly = true)
     public List<Store> getStoresByBookmarkInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
         return storeCustomRepository.findStoresByBookmarkInMapBounds(memberId, mapCoordinateBoundDto);
     }
@@ -22,5 +27,10 @@ public class StoreCustomService {
     @Transactional(readOnly = true)
     public List<Store> getStoresByFollowingInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
         return storeCustomRepository.findStoresByFollowingInMapBounds(memberId, mapCoordinateBoundDto);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Store> getStoresBySchoolInMapBounds(Long schoolId, MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return storeCustomRepository.findStoresBySchoolInMapBounds(schoolId, mapCoordinateBoundDto);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
@@ -6,6 +6,7 @@ import static org.dinosaur.foodbowl.domain.member.domain.QMember.member;
 import static org.dinosaur.foodbowl.domain.review.domain.QReview.review;
 import static org.dinosaur.foodbowl.domain.store.domain.QCategory.category;
 import static org.dinosaur.foodbowl.domain.store.domain.QStore.store;
+import static org.dinosaur.foodbowl.domain.store.domain.QStoreSchool.storeSchool;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -59,6 +60,18 @@ public class StoreCustomRepository {
         );
     }
 
+    public List<Store> findStoresByMemberInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return jpaQueryFactory.selectDistinct(store)
+                .from(store)
+                .innerJoin(store.category, category).fetchJoin()
+                .innerJoin(review).on(
+                        review.store.eq(store),
+                        review.member.id.eq(memberId)
+                )
+                .where(containsPolygon(mapCoordinateBoundDto))
+                .fetch();
+    }
+
     public List<Store> findStoresByBookmarkInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
         return jpaQueryFactory.selectDistinct(store)
                 .from(store)
@@ -80,6 +93,18 @@ public class StoreCustomRepository {
                 .innerJoin(follow).on(
                         review.member.id.eq(follow.following.id),
                         follow.follower.id.eq(memberId)
+                )
+                .where(containsPolygon(mapCoordinateBoundDto))
+                .fetch();
+    }
+
+    public List<Store> findStoresBySchoolInMapBounds(Long schoolId, MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return jpaQueryFactory.selectDistinct(store)
+                .from(store)
+                .innerJoin(store.category, category).fetchJoin()
+                .innerJoin(storeSchool).on(
+                        storeSchool.store.eq(store),
+                        storeSchool.school.id.eq(schoolId)
                 )
                 .where(containsPolygon(mapCoordinateBoundDto))
                 .fetch();

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/SchoolController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/SchoolController.java
@@ -1,0 +1,23 @@
+package org.dinosaur.foodbowl.domain.store.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.dinosaur.foodbowl.domain.store.application.SchoolService;
+import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/schools")
+@RestController
+public class SchoolController implements SchoolControllerDocs {
+
+    private final SchoolService schoolService;
+
+    @GetMapping
+    public ResponseEntity<SchoolsResponse> getSchools() {
+        SchoolsResponse response = schoolService.getSchools();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/SchoolControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/SchoolControllerDocs.java
@@ -1,0 +1,21 @@
+package org.dinosaur.foodbowl.domain.store.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "학교", description = "학교 API")
+public interface SchoolControllerDocs {
+
+    @Operation(
+            summary = "학교 목록 조회",
+            description = "DB에 존재하는 학교 목록을 조회한다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "학교 목록 조회 성공"
+    )
+    ResponseEntity<SchoolsResponse> getSchools();
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
@@ -8,10 +8,8 @@ import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
-import org.dinosaur.foodbowl.domain.store.application.SchoolService;
 import org.dinosaur.foodbowl.domain.store.application.StoreService;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoriesResponse;
-import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponses;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponses;
 import org.dinosaur.foodbowl.global.presentation.Auth;
@@ -29,17 +27,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class StoreController implements StoreControllerDocs {
 
     private final StoreService storeService;
-    private final SchoolService schoolService;
 
     @GetMapping("/categories")
     public ResponseEntity<CategoriesResponse> getCategories() {
         CategoriesResponse response = storeService.getCategories();
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/schools")
-    public ResponseEntity<SchoolsResponse> getSchools() {
-        SchoolsResponse response = schoolService.getSchools();
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
@@ -46,6 +46,21 @@ public class StoreController implements StoreControllerDocs {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/members")
+    public ResponseEntity<StoreMapBoundResponses> getStoresByMemberInMapBounds(
+            @RequestParam(name = "memberId") @Positive(message = "멤버 ID는 양수만 가능합니다.") Long memberId,
+            @RequestParam(name = "x") BigDecimal x,
+            @RequestParam(name = "y") BigDecimal y,
+            @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
+            @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
+            @Auth Member loginMember
+    ) {
+        MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
+        StoreMapBoundResponses response =
+                storeService.getStoresByMemberInMapBounds(memberId, mapCoordinateRequest, loginMember);
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping("/bookmarks")
     public ResponseEntity<StoreMapBoundResponses> getStoresByBookmarkInMapBounds(
             @RequestParam(name = "x") BigDecimal x,
@@ -71,6 +86,21 @@ public class StoreController implements StoreControllerDocs {
         MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
         StoreMapBoundResponses response =
                 storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, loginMember);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/schools")
+    public ResponseEntity<StoreMapBoundResponses> getStoresBySchoolInMapBounds(
+            @RequestParam(name = "schoolId") @Positive(message = "학교 ID는 양수만 가능합니다.") Long schoolId,
+            @RequestParam(name = "x") BigDecimal x,
+            @RequestParam(name = "y") BigDecimal y,
+            @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
+            @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
+            @Auth Member loginMember
+    ) {
+        MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
+        StoreMapBoundResponses response =
+                storeService.getStoresBySchoolInMapBounds(schoolId, mapCoordinateRequest, loginMember);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
@@ -86,6 +86,68 @@ public interface StoreControllerDocs {
     );
 
     @Operation(
+            summary = "멤버 리뷰가 존재하는 가게 목록 범위 기반 조회",
+            description = """
+                    지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
+                                        
+                    해당 범위에 속한 멤버 리뷰가 존재하는 가게 목록을 조회하는 기능입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "멤버 리뷰가 존재하는 가게 목록 범위 기반 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.멤버 ID가 존재하지 않은 경우
+                                                        
+                            2.멤버 ID가 양수가 아닌 경우
+                                                        
+                            3.지도 중심 경도가 존재하지 않은 경우
+                                                        
+                            4.지도 중심 위도가 존재하지 않은 경우
+                                                        
+                            5.지도 경도 증가값이 존재하지 않은 경우
+                                                        
+                            6.지도 경도 증가값이 양수가 아닌 경우
+                                                        
+                            7.지도 위도 증가값이 존재하지 않은 경우
+                                                        
+                            8.지도 위도 증가값이 양수가 아닌 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "멤버가 존재하지 않은 경우",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<StoreMapBoundResponses> getStoresByMemberInMapBounds(
+            @Parameter(description = "멤버 ID", example = "1")
+            @Positive(message = "멤버 ID는 양수만 가능합니다.")
+            Long memberId,
+
+            @Parameter(description = "지도 중심 경도", example = "123.3636")
+            BigDecimal x,
+
+            @Parameter(description = "지도 중심 위도", example = "32.3636")
+            BigDecimal y,
+
+            @Parameter(description = "지도 경도 증가값", example = "3.1212")
+            @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaX,
+
+            @Parameter(description = "지도 위도 증가값", example = "3.1212")
+            @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaY,
+
+            Member loginMember
+    );
+
+    @Operation(
             summary = "북마크한 가게 목록 범위 기반 조회",
             description = """
                     지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
@@ -166,6 +228,68 @@ public interface StoreControllerDocs {
             )
     })
     ResponseEntity<StoreMapBoundResponses> getStoresByFollowingInMapBounds(
+            @Parameter(description = "지도 중심 경도", example = "123.3636")
+            BigDecimal x,
+
+            @Parameter(description = "지도 중심 위도", example = "32.3636")
+            BigDecimal y,
+
+            @Parameter(description = "지도 경도 증가값", example = "3.1212")
+            @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaX,
+
+            @Parameter(description = "지도 위도 증가값", example = "3.1212")
+            @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaY,
+
+            Member loginMember
+    );
+
+    @Operation(
+            summary = "학교 근처 가게 목록 범위 기반 조회",
+            description = """
+                    지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
+                                        
+                    해당 범위에 속한 학교 근처 가게 목록을 조회하는 기능입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "학교 근처 가게 목록 범위 기반 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.학교 ID가 존재하지 않은 경우
+                                                        
+                            2.학교 ID가 양수가 아닌 경우
+                                                        
+                            3.지도 중심 경도가 존재하지 않은 경우
+                                                        
+                            4.지도 중심 위도가 존재하지 않은 경우
+                                                        
+                            5.지도 경도 증가값이 존재하지 않은 경우
+                                                        
+                            6.지도 경도 증가값이 양수가 아닌 경우
+                                                        
+                            7.지도 위도 증가값이 존재하지 않은 경우
+                                                        
+                            8.지도 위도 증가값이 양수가 아닌 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "학교가 존재하지 않은 경우",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<StoreMapBoundResponses> getStoresBySchoolInMapBounds(
+            @Parameter(description = "학교 ID", example = "1")
+            @Positive(message = "학교 ID는 양수만 가능합니다.")
+            Long schoolId,
+
             @Parameter(description = "지도 중심 경도", example = "123.3636")
             BigDecimal x,
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
@@ -14,7 +14,6 @@ import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoriesResponse;
-import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponses;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponses;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
@@ -32,16 +31,6 @@ public interface StoreControllerDocs {
             description = "카테고리 목록 조회 성공"
     )
     ResponseEntity<CategoriesResponse> getCategories();
-
-    @Operation(
-            summary = "학교 목록 조회",
-            description = "DB에 존재하는 학교 목록을 조회한다."
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "학교 목록 조회 성공"
-    )
-    ResponseEntity<SchoolsResponse> getSchools();
 
     @Operation(
             summary = "가게 검색 결과 조회",

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -47,6 +47,33 @@ class ReviewServiceTest extends IntegrationTest {
     class 멤버_리뷰_목록_페이징_조회_시 {
 
         @Test
+        void 존재하지_않은_멤버라면_예외를_던진다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            assertThatThrownBy(() -> reviewService.getReviewsByMemberInMapBounds(
+                    -1L,
+                    null,
+                    mapCoordinateRequest,
+                    deviceCoordinateRequest,
+                    10,
+                    member
+            ))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
         void 리뷰_작성자의_팔로워_수도_함께_조회한다() {
             Member member = memberTestPersister.builder().save();
             Member writer = memberTestPersister.builder().save();

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomServiceTest.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
+import org.dinosaur.foodbowl.domain.store.domain.School;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,23 @@ class StoreCustomServiceTest extends IntegrationTest {
 
     @Autowired
     private StoreCustomService storeCustomService;
+
+    @Test
+    void 멤버가_작성한_리뷰가_존재하는_가게_목록을_범위를_통해_조회한다() {
+        Member member = memberTestPersister.builder().save();
+        Store store = storeTestPersister.builder().save();
+        reviewTestPersister.builder().member(member).store(store).save();
+        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                BigDecimal.valueOf(1),
+                BigDecimal.valueOf(1)
+        );
+
+        List<Store> result = storeCustomService.getStoresByMemberInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+        assertThat(result).contains(store);
+    }
 
     @Test
     void 북마크한_가게_목록을_범위를_통해_조회한다() {
@@ -51,5 +69,22 @@ class StoreCustomServiceTest extends IntegrationTest {
         List<Store> result = storeCustomService.getStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
 
         assertThat(result).containsExactly(store);
+    }
+
+    @Test
+    void 학교_근거의_가게_목록을_범위를_통해_조회한다() {
+        Store store = storeTestPersister.builder().save();
+        School school = schoolTestPersister.builder().save();
+        storeSchoolTestPersister.builder().store(store).school(school).save();
+        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                BigDecimal.valueOf(1),
+                BigDecimal.valueOf(1)
+        );
+
+        List<Store> result = storeCustomService.getStoresBySchoolInMapBounds(school.getId(), mapCoordinateBoundDto);
+
+        assertThat(result).contains(store);
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -414,14 +414,16 @@ class StoreServiceTest extends IntegrationTest {
         void 가게_리뷰_수도_함께_조회한다() {
             Member member = memberTestPersister.builder().save();
             Member writer = memberTestPersister.builder().save();
-            Store store = storeTestPersister.builder().save();
+            Store storeA = storeTestPersister.builder().save();
+            Store storeB = storeTestPersister.builder().save();
             School school = schoolTestPersister.builder().save();
-            storeSchoolTestPersister.builder().store(store).school(school).save();
-            reviewTestPersister.builder().member(writer).store(store).save();
-            reviewTestPersister.builder().member(member).store(store).save();
+            storeSchoolTestPersister.builder().store(storeA).school(school).save();
+            storeSchoolTestPersister.builder().store(storeB).school(school).save();
+            reviewTestPersister.builder().member(writer).store(storeA).save();
+            reviewTestPersister.builder().member(member).store(storeA).save();
             MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
-                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(storeA.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(storeA.getAddress().getCoordinate().getY()),
                     BigDecimal.valueOf(1),
                     BigDecimal.valueOf(1)
             );
@@ -431,16 +433,25 @@ class StoreServiceTest extends IntegrationTest {
 
             List<StoreMapBoundResponse> result = response.stores();
             assertSoftly(softly -> {
-                softly.assertThat(result).hasSize(1);
-                softly.assertThat(result.get(0).id()).isEqualTo(store.getId());
-                softly.assertThat(result.get(0).name()).isEqualTo(store.getStoreName());
-                softly.assertThat(result.get(0).categoryName()).isEqualTo(store.getCategory().getName());
-                softly.assertThat(result.get(0).addressName()).isEqualTo(store.getAddress().getAddressName());
-                softly.assertThat(result.get(0).url()).isEqualTo(store.getStoreUrl());
-                softly.assertThat(result.get(0).x()).isEqualTo(store.getAddress().getCoordinate().getX());
-                softly.assertThat(result.get(0).y()).isEqualTo(store.getAddress().getCoordinate().getY());
+                softly.assertThat(result).hasSize(2);
+                softly.assertThat(result.get(0).id()).isEqualTo(storeA.getId());
+                softly.assertThat(result.get(0).name()).isEqualTo(storeA.getStoreName());
+                softly.assertThat(result.get(0).categoryName()).isEqualTo(storeA.getCategory().getName());
+                softly.assertThat(result.get(0).addressName()).isEqualTo(storeA.getAddress().getAddressName());
+                softly.assertThat(result.get(0).url()).isEqualTo(storeA.getStoreUrl());
+                softly.assertThat(result.get(0).x()).isEqualTo(storeA.getAddress().getCoordinate().getX());
+                softly.assertThat(result.get(0).y()).isEqualTo(storeA.getAddress().getCoordinate().getY());
                 softly.assertThat(result.get(0).reviewCount()).isEqualTo(2);
                 softly.assertThat(result.get(0).isBookmarked()).isFalse();
+                softly.assertThat(result.get(1).id()).isEqualTo(storeB.getId());
+                softly.assertThat(result.get(1).name()).isEqualTo(storeB.getStoreName());
+                softly.assertThat(result.get(1).categoryName()).isEqualTo(storeB.getCategory().getName());
+                softly.assertThat(result.get(1).addressName()).isEqualTo(storeB.getAddress().getAddressName());
+                softly.assertThat(result.get(1).url()).isEqualTo(storeB.getStoreUrl());
+                softly.assertThat(result.get(1).x()).isEqualTo(storeB.getAddress().getCoordinate().getX());
+                softly.assertThat(result.get(1).y()).isEqualTo(storeB.getAddress().getCoordinate().getY());
+                softly.assertThat(result.get(1).reviewCount()).isEqualTo(0);
+                softly.assertThat(result.get(1).isBookmarked()).isFalse();
             });
         }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
+import org.dinosaur.foodbowl.domain.store.domain.School;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.domain.store.domain.vo.Address;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponse;
@@ -60,6 +61,63 @@ class StoreCustomRepositoryTest extends PersistenceTest {
                 "서울시 서초구 방배동 1234",
                 PointUtils.generate(new BigDecimal(x), new BigDecimal(y))
         );
+    }
+
+    @Nested
+    class 멤버의_리뷰가_작성된_가게_목록_범위_조회_시 {
+
+        @Test
+        void 멤버의_리뷰가_작성된_가게는_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByMemberInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).contains(store);
+        }
+
+        @Test
+        void 멤버의_리뷰가_작성되지_않은_가게는_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByMemberInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 폴리곤_영역에_경도와_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByMemberInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).isEmpty();
+        }
     }
 
     @Nested
@@ -199,6 +257,63 @@ class StoreCustomRepositoryTest extends PersistenceTest {
 
             List<Store> result =
                     storeCustomRepository.findStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    class 학교_근처_가게_목록_범위_조회_시 {
+
+        @Test
+        void 학교_근처_가게는_조회한다() {
+            Store store = storeTestPersister.builder().save();
+            School school = schoolTestPersister.builder().save();
+            storeSchoolTestPersister.builder().store(store).school(school).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresBySchoolInMapBounds(school.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).contains(store);
+        }
+
+        @Test
+        void 학교_근처가_아닌_가게는_조회하지_않는다() {
+            Store store = storeTestPersister.builder().save();
+            School school = schoolTestPersister.builder().save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresBySchoolInMapBounds(school.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 폴리곤_영역에_경도와_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
+            Store store = storeTestPersister.builder().save();
+            School school = schoolTestPersister.builder().save();
+            storeSchoolTestPersister.builder().store(store).school(school).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresBySchoolInMapBounds(school.getId(), mapCoordinateBoundDto);
 
             assertThat(result).isEmpty();
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/SchoolControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/SchoolControllerTest.java
@@ -1,0 +1,74 @@
+package org.dinosaur.foodbowl.domain.store.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dinosaur.foodbowl.domain.member.domain.vo.RoleType.ROLE_회원;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
+import org.dinosaur.foodbowl.domain.store.application.SchoolService;
+import org.dinosaur.foodbowl.domain.store.dto.response.SchoolResponse;
+import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
+import org.dinosaur.foodbowl.test.PresentationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SuppressWarnings("NonAsciiCharacters")
+@WebMvcTest(SchoolController.class)
+class SchoolControllerTest extends PresentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private SchoolService schoolService;
+
+    @Test
+    void 학교_목록_조회시_학교_목록과_200_응답을_반환한다() throws Exception {
+        SchoolsResponse schoolsResponse = new SchoolsResponse(
+                List.of(
+                        new SchoolResponse(
+                                1L,
+                                "강남대학교",
+                                "경기도 용인시 기흥구 강남로 40",
+                                BigDecimal.valueOf(127.125),
+                                BigDecimal.valueOf(35.12)
+                        ),
+                        new SchoolResponse(
+                                2L,
+                                "부산대학교",
+                                "부산광역시 금정구 부산대학로63번길 2",
+                                BigDecimal.valueOf(127.350),
+                                BigDecimal.valueOf(35.78)
+                        )
+                )
+        );
+        given(schoolService.getSchools()).willReturn(schoolsResponse);
+
+        MvcResult mvcResult = mockMvc.perform(get("/v1/schools")
+                        .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+        String jsonResponse = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        SchoolsResponse result = objectMapper.readValue(jsonResponse, SchoolsResponse.class);
+
+        assertThat(result).usingRecursiveComparison().isEqualTo(schoolsResponse);
+    }
+}

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
@@ -19,12 +19,9 @@ import java.util.List;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
-import org.dinosaur.foodbowl.domain.store.application.SchoolService;
 import org.dinosaur.foodbowl.domain.store.application.StoreService;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoriesResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoryResponse;
-import org.dinosaur.foodbowl.domain.store.dto.response.SchoolResponse;
-import org.dinosaur.foodbowl.domain.store.dto.response.SchoolsResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponses;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponse;
@@ -56,9 +53,6 @@ class StoreControllerTest extends PresentationTest {
     @MockBean
     private StoreService storeService;
 
-    @MockBean
-    private SchoolService schoolService;
-
     @Test
     void 가게_카테고리_목록_조회시_카테고리_목록과_200_응답을_반환한다() throws Exception {
         CategoriesResponse categoriesResponse = new CategoriesResponse(
@@ -77,39 +71,6 @@ class StoreControllerTest extends PresentationTest {
         CategoriesResponse result = objectMapper.readValue(jsonResponse, CategoriesResponse.class);
 
         assertThat(result).usingRecursiveComparison().isEqualTo(categoriesResponse);
-    }
-
-    @Test
-    void 학교_목록_조회시_학교_목록과_200_응답을_반환한다() throws Exception {
-        SchoolsResponse schoolsResponse = new SchoolsResponse(
-                List.of(
-                        new SchoolResponse(
-                                1L,
-                                "강남대학교",
-                                "경기도 용인시 기흥구 강남로 40",
-                                BigDecimal.valueOf(127.125),
-                                BigDecimal.valueOf(35.12)
-                        ),
-                        new SchoolResponse(
-                                2L,
-                                "부산대학교",
-                                "부산광역시 금정구 부산대학로63번길 2",
-                                BigDecimal.valueOf(127.350),
-                                BigDecimal.valueOf(35.78)
-                        )
-                )
-        );
-        given(schoolService.getSchools()).willReturn(schoolsResponse);
-
-        MvcResult mvcResult = mockMvc.perform(get("/v1/stores/schools")
-                        .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andReturn();
-        String jsonResponse = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
-        SchoolsResponse result = objectMapper.readValue(jsonResponse, SchoolsResponse.class);
-
-        assertThat(result).usingRecursiveComparison().isEqualTo(schoolsResponse);
     }
 
     @Nested

--- a/src/test/java/org/dinosaur/foodbowl/test/config/TestQuerydslConfig.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/config/TestQuerydslConfig.java
@@ -30,6 +30,11 @@ public class TestQuerydslConfig {
     }
 
     @Bean
+    public MemberCustomRepository memberCustomRepository() {
+        return new MemberCustomRepository(jpaQueryFactory());
+    }
+
+    @Bean
     public ReviewCustomRepository reviewCustomRepository() {
         return new ReviewCustomRepository(jpaQueryFactory());
     }
@@ -42,10 +47,5 @@ public class TestQuerydslConfig {
     @Bean
     public StoreCustomRepository storeCustomRepository() {
         return new StoreCustomRepository(jpaQueryFactory());
-    }
-
-    @Bean
-    public MemberCustomRepository memberCustomRepository() {
-        return new MemberCustomRepository(jpaQueryFactory());
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #175
* close: #177

## 📝 작업 요약

유저 프로필 가게, 학교 주변 가게 목록 조회 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 유저 프로필 가게 목록 조회 시 존재하지 않은 유저인 경우 예외를 던집니다.
- 학교 주변 가게 목록 조회 시 존재하지 않은 학교인 경우 예외를 던집니다.
- 그 외에는 다른 가게 목록 조회의 플로우와 동일합니다.

## 🌟 리뷰 요구 사항

> 30분
> Querydsl을 통해 가게 목록을 조회하는 쿼리 위주로 리뷰해주시면 감사합니다 :)