### PR TITLE
Feature/#193 리뷰가 존재하지 않을 때 리뷰 페이지 정보에서 예외가 발생한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewPageInfo.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewPageInfo.java
@@ -19,8 +19,8 @@ public record ReviewPageInfo(
     public static ReviewPageInfo from(List<Review> reviews) {
         int size = reviews.size();
         return new ReviewPageInfo(
-                reviews.get(0).getId(),
-                reviews.get(size - 1).getId(),
+                size == 0 ? null : reviews.get(0).getId(),
+                size == 0 ? null : reviews.get(size - 1).getId(),
                 size
         );
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -77,8 +77,7 @@ public class ReviewCustomRepository {
                 .innerJoin(review.member, member).fetchJoin();
 
         setReviewFilterIfExists(jpaQuery, memberId, reviewFilter);
-        return
-                jpaQuery.where(
+        return jpaQuery.where(
                         review.store.id.eq(storeId),
                         ltLastReviewId(lastReviewId)
                 )

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -252,6 +252,39 @@ class ReviewServiceTest extends IntegrationTest {
                 softly.assertThat(result.get(0).store().isBookmarked()).isFalse();
             });
         }
+
+        @Test
+        void 일치하는_리뷰가_없으면_빈_리스트를_반환한다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            ReviewPageResponse response = reviewService.getReviewsByMemberInMapBounds(
+                    writer.getId(),
+                    null,
+                    mapCoordinateRequest,
+                    deviceCoordinateRequest,
+                    10,
+                    member
+            );
+
+            assertSoftly(softly -> {
+                softly.assertThat(response.reviews()).isEmpty();
+                softly.assertThat(response.page().firstId()).isNull();
+                softly.assertThat(response.page().lastId()).isNull();
+                softly.assertThat(response.page().size()).isZero();
+            });
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #193

## 📝 작업 요약

리뷰가 존재하지 않을 때 리뷰 페이지 정보에서 발생하는 예외를 수정하였습니다.

## 🔎 작업 상세 설명

조회된 리뷰 `size`가 `0`일 때 처리를 추가하고 테스트 코드를 작성하였습니다.

## 🌟 리뷰 요구 사항

> 1분