### PR TITLE
Feature/#195 멤버 프로필 추가, 수정 시 생성된 프로필 이미지 URL을 응답으로 전달한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
@@ -14,6 +14,7 @@ import org.dinosaur.foodbowl.domain.member.domain.MemberThumbnail;
 import org.dinosaur.foodbowl.domain.member.domain.vo.Introduction;
 import org.dinosaur.foodbowl.domain.member.domain.vo.Nickname;
 import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
+import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileImageResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponses;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
@@ -99,7 +100,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateProfileImage(MultipartFile image, Member loginMember) {
+    public MemberProfileImageResponse updateProfileImage(MultipartFile image, Member loginMember) {
         memberThumbnailRepository.findByMember(loginMember)
                 .ifPresent(this::deleteMemberThumbnail);
         Thumbnail thumbnail = thumbnailService.save(image);
@@ -108,6 +109,7 @@ public class MemberService {
                 .thumbnail(thumbnail)
                 .build();
         memberThumbnailRepository.save(memberThumbnail);
+        return new MemberProfileImageResponse(thumbnail.getPath());
     }
 
     private void deleteMemberThumbnail(MemberThumbnail memberThumbnail) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/dto/response/MemberProfileImageResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/dto/response/MemberProfileImageResponse.java
@@ -1,0 +1,10 @@
+package org.dinosaur.foodbowl.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 프로필 이미지 응답")
+public record MemberProfileImageResponse(
+        @Schema(description = "프로필 이미지 URL", example = "https://justdoeat.shop/static/images/thumbnail/profile/image.png")
+        String profileImageUrl
+) {
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
+import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileImageResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponses;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
@@ -79,12 +80,12 @@ public class MemberController implements MemberControllerDocs {
     }
 
     @PatchMapping(value = "/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> updateProfileImage(
+    public ResponseEntity<MemberProfileImageResponse> updateProfileImage(
             @RequestPart(name = "image") MultipartFile image,
             @Auth Member loginMember
     ) {
-        memberService.updateProfileImage(image, loginMember);
-        return ResponseEntity.noContent().build();
+        MemberProfileImageResponse response = memberService.updateProfileImage(image, loginMember);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping(value = "/profile/image")

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
+import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileImageResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponses;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
@@ -163,7 +164,7 @@ public interface MemberControllerDocs {
     )
     @ApiResponses({
             @ApiResponse(
-                    responseCode = "204",
+                    responseCode = "200",
                     description = "프로필 이미지 수정 성공"
             ),
             @ApiResponse(
@@ -178,7 +179,7 @@ public interface MemberControllerDocs {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    ResponseEntity<Void> updateProfileImage(
+    ResponseEntity<MemberProfileImageResponse> updateProfileImage(
             @Parameter(description = "수정할 프로필 이미지")
             MultipartFile thumbnail,
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.domain.MemberThumbnail;
 import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
+import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileImageResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponses;
@@ -261,12 +262,13 @@ class MemberServiceTest extends IntegrationTest {
             Member member = memberTestPersister.builder().save();
             MultipartFile multipartFile = FileTestUtils.generateMultiPartFile("image");
 
-            memberService.updateProfileImage(multipartFile, member);
+            MemberProfileImageResponse response = memberService.updateProfileImage(multipartFile, member);
 
             Optional<MemberThumbnail> memberThumbnail = memberThumbnailRepository.findByMember(member);
             assertSoftly(softly -> {
                 softly.assertThat(memberThumbnail).isPresent();
-                softly.assertThat(new File(memberThumbnail.get().getThumbnail().getPath())).exists();
+                softly.assertThat(memberThumbnail.get().getThumbnail().getPath()).isEqualTo(response.profileImageUrl());
+                softly.assertThat(new File(response.profileImageUrl())).exists();
             });
             FileTestUtils.cleanUp();
         }
@@ -279,12 +281,13 @@ class MemberServiceTest extends IntegrationTest {
             memberThumbnailTestPersister.builder().member(member).thumbnail(thumbnail).save();
 
             MultipartFile newFile = FileTestUtils.generateMultiPartFile("image");
-            memberService.updateProfileImage(newFile, member);
+            MemberProfileImageResponse response = memberService.updateProfileImage(newFile, member);
 
             Optional<MemberThumbnail> memberThumbnail = memberThumbnailRepository.findByMember(member);
             assertSoftly(softly -> {
                 softly.assertThat(memberThumbnail).isPresent();
-                softly.assertThat(new File(memberThumbnail.get().getThumbnail().getPath())).exists();
+                softly.assertThat(memberThumbnail.get().getThumbnail().getPath()).isEqualTo(response.profileImageUrl());
+                softly.assertThat(new File(response.profileImageUrl())).exists();
                 softly.assertThat(new File(thumbnail.getPath())).doesNotExist();
             });
             FileTestUtils.cleanUp();

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
@@ -24,6 +24,7 @@ import org.dinosaur.foodbowl.domain.member.application.MemberService;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
 import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
+import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileImageResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponses;
@@ -319,16 +320,22 @@ class MemberControllerTest extends PresentationTest {
         private final String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
 
         @Test
-        void 프로필_이미지_수정에_성공하면_204_응답을_반환한다() throws Exception {
+        void 프로필_이미지_수정에_성공하면_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             MockMultipartFile file = (MockMultipartFile) FileTestUtils.generateMultiPartFile("image");
-            willDoNothing().given(memberService).updateProfileImage(any(MultipartFile.class), any(Member.class));
+            MemberProfileImageResponse expected = new MemberProfileImageResponse("http://justdoeat.shop/image.png");
+            given(memberService.updateProfileImage(any(MultipartFile.class), any(Member.class))).willReturn(expected);
 
-            mockMvc.perform(multipart(HttpMethod.PATCH, "/v1/members/profile/image")
+            MvcResult mvcResult = mockMvc.perform(multipart(HttpMethod.PATCH, "/v1/members/profile/image")
                             .file(file)
                             .header(AUTHORIZATION, BEARER + accessToken))
                     .andDo(print())
-                    .andExpect(status().isNoContent());
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String jsonResponse = mvcResult.getResponse().getContentAsString();
+            MemberProfileImageResponse result = objectMapper.readValue(jsonResponse, MemberProfileImageResponse.class);
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
         }
 
         @Test


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #195

## 📝 작업 요약

멤버 프로필 수정 시 생성된 프로필 이미지 URL을 응답으로 전달하도록 수정하였습니다.

## 🔎 작업 상세 설명

생성된 URL을 응답으로 전달하도록 수정하였습니다.

## 🌟 리뷰 요구 사항

> 5분