### PR TITLE
Feature/#51 모니터링 환경을 구성한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation platform("org.springframework.cloud:spring-cloud-dependencies:2022.0.2")
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'

--- a/src/main/java/org/dinosaur/foodbowl/FoodbowlApplication.java
+++ b/src/main/java/org/dinosaur/foodbowl/FoodbowlApplication.java
@@ -2,7 +2,9 @@ package org.dinosaur.foodbowl;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class FoodbowlApplication {
 

--- a/src/main/java/org/dinosaur/foodbowl/global/config/SecurityConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                 .requestMatchers(SWAGGER_URL).permitAll()
                 .requestMatchers("/v1/health-check").permitAll()
                 .requestMatchers("/v1/auth/login/oauth/apple", "/v1/auth/token/renew").permitAll()
+                .requestMatchers("/actuator/**").permitAll()
                 .anyRequest().hasRole("회원")
                 .and()
                 .httpBasic().disable()

--- a/src/main/java/org/dinosaur/foodbowl/global/config/SecurityConfig.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/config/SecurityConfig.java
@@ -1,23 +1,28 @@
 package org.dinosaur.foodbowl.global.config;
 
-import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.global.presentation.jwt.JwtAuthenticationFilter;
+import org.dinosaur.foodbowl.global.presentation.security.ActuatorProperties;
 import org.dinosaur.foodbowl.global.presentation.security.CustomAccessDeniedHandler;
 import org.dinosaur.foodbowl.global.presentation.security.CustomAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-@RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
@@ -36,18 +41,41 @@ public class SecurityConfig {
             "/swagger-ui/**"
     };
 
+    private final ActuatorProperties actuatorProperties;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    public SecurityConfig(
+            ActuatorProperties actuatorProperties,
+            CustomAccessDeniedHandler customAccessDeniedHandler,
+            CustomAuthenticationEntryPoint customAuthenticationEntryPoint,
+            JwtAuthenticationFilter jwtAuthenticationFilter
+    ) {
+        this.actuatorProperties = actuatorProperties;
+        this.customAccessDeniedHandler = customAccessDeniedHandler;
+        this.customAuthenticationEntryPoint = customAuthenticationEntryPoint;
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Order(0)
+    public SecurityFilterChain actuatorFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher(actuatorProperties.pattern())
+                .httpBasic(Customizer.withDefaults());
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests()
                 .requestMatchers(SWAGGER_URL).permitAll()
                 .requestMatchers("/v1/health-check").permitAll()
                 .requestMatchers("/v1/auth/login/oauth/apple", "/v1/auth/token/renew").permitAll()
-                .requestMatchers("/actuator/**").permitAll()
                 .anyRequest().hasRole("회원")
                 .and()
                 .httpBasic().disable()
@@ -64,6 +92,15 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.withUsername(actuatorProperties.user())
+                .password(passwordEncoder().encode(actuatorProperties.password()))
+                .roles(actuatorProperties.role())
+                .build();
+        return new InMemoryUserDetailsManager(user);
     }
 
     @Bean

--- a/src/main/java/org/dinosaur/foodbowl/global/presentation/MemberArgumentResolver.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/presentation/MemberArgumentResolver.java
@@ -1,13 +1,13 @@
 package org.dinosaur.foodbowl.global.presentation;
 
 import lombok.RequiredArgsConstructor;
-import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtUser;
 import org.dinosaur.foodbowl.domain.auth.exception.AuthExceptionType;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.exception.MemberExceptionType;
 import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
 import org.dinosaur.foodbowl.global.exception.AuthenticationException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.presentation.jwt.JwtUser;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/org/dinosaur/foodbowl/global/presentation/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/presentation/jwt/JwtAuthenticationFilter.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtConstant;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
-import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtUser;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/org/dinosaur/foodbowl/global/presentation/jwt/JwtUser.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/presentation/jwt/JwtUser.java
@@ -1,8 +1,7 @@
-package org.dinosaur.foodbowl.domain.auth.application.jwt;
+package org.dinosaur.foodbowl.global.presentation.jwt;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -18,7 +17,7 @@ public class JwtUser implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return roleNames.stream()
                 .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/src/main/java/org/dinosaur/foodbowl/global/presentation/security/ActuatorProperties.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/presentation/security/ActuatorProperties.java
@@ -1,0 +1,12 @@
+package org.dinosaur.foodbowl.global.presentation.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("monitor")
+public record ActuatorProperties(
+        String pattern,
+        String user,
+        String password,
+        String role
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,18 +34,27 @@ logging:
   level:
     org.hibernate.orm.jdbc.bind: trace
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, prometheus
-  metrics:
-    tags:
-      application: ${APPLICATION_NAME}
-
 springdoc:
   swagger-ui:
     enabled: ${SWAGGER_ENABLE}
+
+management:
+  endpoint:
+    health:
+      enabled: true
+    prometheus:
+      enabled: true
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: health, prometheus
+      base-path: ${ACTUATOR_BASE_PATH}
+  metrics:
+    tags:
+      application: ${ACTUATOR_APP_TAG}
+  server:
+    port: ${ACTUATOR_SERVER_PORT}
 
 openapi:
   dev_url: ${OPENAPI_DEV_URL}
@@ -63,3 +72,9 @@ oauth:
 
 file:
   dir: ${FILE_PATH}
+
+monitor:
+  pattern: ${MONITOR_PATTERN}
+  user: ${MONITOR_USER}
+  password: ${MONITOR_PASSWORD}
+  role: ${MONITOR_ROLE}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,15 @@ logging:
   level:
     org.hibernate.orm.jdbc.bind: trace
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  metrics:
+    tags:
+      application: ${APPLICATION_NAME}
+
 springdoc:
   swagger-ui:
     enabled: ${SWAGGER_ENABLE}

--- a/src/test/java/org/dinosaur/foodbowl/test/PresentationTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/PresentationTest.java
@@ -12,6 +12,7 @@ import org.dinosaur.foodbowl.global.config.SecurityConfig;
 import org.dinosaur.foodbowl.global.presentation.jwt.JwtAuthorizationExtractor;
 import org.dinosaur.foodbowl.global.presentation.security.CustomAccessDeniedHandler;
 import org.dinosaur.foodbowl.global.presentation.security.CustomAuthenticationEntryPoint;
+import org.dinosaur.foodbowl.test.config.TestPropertyConfig;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -20,6 +21,7 @@ import org.springframework.context.annotation.Import;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @Import(value = {
         SecurityConfig.class,
+        TestPropertyConfig.class,
         JwtTokenProvider.class,
         JwtAuthorizationExtractor.class,
         CustomAccessDeniedHandler.class,

--- a/src/test/java/org/dinosaur/foodbowl/test/config/TestPropertyConfig.java
+++ b/src/test/java/org/dinosaur/foodbowl/test/config/TestPropertyConfig.java
@@ -1,0 +1,8 @@
+package org.dinosaur.foodbowl.test.config;
+
+import org.dinosaur.foodbowl.global.presentation.security.ActuatorProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@EnableConfigurationProperties(ActuatorProperties.class)
+public class TestPropertyConfig {
+}


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #51

## 📝 작업 요약

프로메테우스, 그라파나 모니터링 환경 구성을 위한 `prometheus`, `actuator` 의존성을 추가하였습니다.

## 🔎 작업 상세 설명

- 추가적으로 프로메테우스 설정 파일이 필요한데, 해당 파일은 노출시키지 않는 것이 좋을 것 같아서 서버에 작성하는 방향으로 하였습니다.
- `CICD(DEV)` 노션 페이지를 확인하시면 `prometheus.yml`, `rule.yml` 파일을 확인할 수 있습니다.
- `docker-compose` 파일도 수정하여 프로메테우스와 그라파나 컨테이너가 동작하도록 수정하였습니다.
- 해당 `PR`이 머지되면 그라파나 포트를 열어서 확인해볼 예정입니다.

### PR 머지 후 추가적인 작업

- `application.yml` 파일 업데이트
- `.env` 업데이트
- 프로메테우스, 그라파나 동작 확인

## 🌟 리뷰 요구 사항

> 10분