### PR TITLE
Feature/#196 가게 리뷰 조회 시 가게 정보도 함께 전달하도록 수정한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkQueryService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkQueryService.java
@@ -25,4 +25,10 @@ public class BookmarkQueryService {
                 .map(Bookmark::getStore)
                 .collect(toSet());
     }
+
+    @Transactional(readOnly = true)
+    public boolean isBookmarkStoreByMember(Member member, Store store) {
+        return bookmarkRepository.findByMemberAndStore(member, store)
+                .isPresent();
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -81,6 +81,7 @@ public class ReviewService {
             String filter,
             Long lastReviewId,
             int pageSize,
+            DeviceCoordinateRequest deviceCoordinateRequest,
             Member loginMember
     ) {
         Store store = storeService.findById(storeId);
@@ -96,9 +97,12 @@ public class ReviewService {
                 followCustomService.getFollowerCountByMembers(getWriters(reviews));
         ReviewToPhotoPathDto reviewToPhotoPathDto = reviewPhotoCustomService.getPhotoPathByReviews(reviews);
         return StoreReviewResponse.of(
+                store,
                 reviews,
                 reviewToPhotoPathDto,
-                memberToFollowerCountDto
+                memberToFollowerCountDto,
+                deviceCoordinateRequest,
+                bookmarkQueryService.isBookmarkStoreByMember(loginMember, store)
         );
     }
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/StoreReviewResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/StoreReviewResponse.java
@@ -5,9 +5,15 @@ import java.util.List;
 import org.dinosaur.foodbowl.domain.follow.application.dto.MemberToFollowerCountDto;
 import org.dinosaur.foodbowl.domain.review.application.dto.ReviewToPhotoPathDto;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
+import org.dinosaur.foodbowl.domain.review.dto.request.DeviceCoordinateRequest;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
+import org.dinosaur.foodbowl.global.util.PointUtils;
 
 @Schema(description = "가게 리뷰 조회 응답")
 public record StoreReviewResponse(
+        @Schema(description = "가게 정보")
+        ReviewStoreResponse reviewStoreResponse,
+
         @Schema(description = "가게에 대한 리뷰 내용")
         List<StoreReviewContentResponse> storeReviewContentResponses,
 
@@ -16,18 +22,27 @@ public record StoreReviewResponse(
 ) {
 
     public static StoreReviewResponse of(
+            Store store,
             List<Review> reviews,
             ReviewToPhotoPathDto reviewToPhotoPathDto,
-            MemberToFollowerCountDto memberToFollowerCountDto
+            MemberToFollowerCountDto memberToFollowerCountDto,
+            DeviceCoordinateRequest deviceCoordinateRequest,
+            boolean isBookmark
     ) {
         List<StoreReviewContentResponse> storeReviewContentResponses = convertStoreReviewContentResponses(
                 reviews,
                 reviewToPhotoPathDto,
                 memberToFollowerCountDto
         );
-
+        ReviewStoreResponse reviewStoreResponse = convertReviewStoreResponse(
+                store,
+                deviceCoordinateRequest,
+                isBookmark
+        );
         ReviewPageInfo reviewPageInfo = ReviewPageInfo.from(reviews);
+
         return new StoreReviewResponse(
+                reviewStoreResponse,
                 storeReviewContentResponses,
                 reviewPageInfo
         );
@@ -46,5 +61,20 @@ public record StoreReviewResponse(
                         memberToFollowerCountDto
                 ))
                 .toList();
+    }
+
+    private static ReviewStoreResponse convertReviewStoreResponse(
+            Store store,
+            DeviceCoordinateRequest deviceCoordinateRequest,
+            boolean isBookmark
+    ) {
+        return ReviewStoreResponse.of(
+                store,
+                PointUtils.calculateDistance(
+                        PointUtils.generate(deviceCoordinateRequest.deviceX(), deviceCoordinateRequest.deviceY()),
+                        store.getAddress().getCoordinate()
+                ),
+                isBookmark
+        );
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -143,13 +143,17 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestParam(name = "filter", defaultValue = "ALL") String filter,
             @RequestParam(name = "lastReviewId", required = false) @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long lastReviewId,
             @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
+            @RequestParam(name = "deviceX") BigDecimal deviceX,
+            @RequestParam(name = "deviceY") BigDecimal deviceY,
             @Auth Member loginMember
     ) {
+        DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
         StoreReviewResponse storeReviewResponse = reviewService.getReviewsByStore(
                 storeId,
                 filter,
                 lastReviewId,
                 pageSize,
+                deviceCoordinateRequest,
                 loginMember
         );
         return ResponseEntity.ok(storeReviewResponse);

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -181,6 +181,12 @@ public interface ReviewControllerDocs {
             @Positive(message = "페이지 크기는 양수만 가능합니다.")
             int pageSize,
 
+            @Parameter(description = "사용자 경도", example = "123.3636")
+            BigDecimal deviceX,
+
+            @Parameter(description = "사용자 위도", example = "32.3636")
+            BigDecimal deviceY,
+
             Member loginMember
     );
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkQueryServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkQueryServiceTest.java
@@ -7,6 +7,7 @@ import org.dinosaur.foodbowl.domain.bookmark.domain.Bookmark;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.test.IntegrationTest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -25,5 +26,26 @@ class BookmarkQueryServiceTest extends IntegrationTest {
         Set<Store> result = bookmarkQueryService.getBookmarkStoresByMember(member);
 
         assertThat(result).contains(bookmarkA.getStore(), bookmarkB.getStore());
+    }
+
+    @Nested
+    class 멤버의_가게_북마크_여부_조회_시 {
+
+        @Test
+        void 북마크_했다면_TRUE를_반환한다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+
+            assertThat(bookmarkQueryService.isBookmarkStoreByMember(member, store)).isTrue();
+        }
+
+        @Test
+        void 북마크_하지_않았다면_FALSE를_반환한다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+
+            assertThat(bookmarkQueryService.isBookmarkStoreByMember(member, store)).isFalse();
+        }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -302,6 +302,7 @@ class ReviewServiceTest extends IntegrationTest {
                     "ALL",
                     null,
                     10,
+                    new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
                     member
             );
 
@@ -333,6 +334,7 @@ class ReviewServiceTest extends IntegrationTest {
                     "FRIEND",
                     null,
                     10,
+                    new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
                     member
             );
 
@@ -362,6 +364,7 @@ class ReviewServiceTest extends IntegrationTest {
                     "ALL",
                     null,
                     10,
+                    new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
                     member
             );
 
@@ -387,6 +390,7 @@ class ReviewServiceTest extends IntegrationTest {
                     "ALL",
                     null,
                     10,
+                    new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
                     member
             );
 
@@ -409,6 +413,7 @@ class ReviewServiceTest extends IntegrationTest {
                     "ALL",
                     null,
                     10,
+                    null,
                     null
             ))
                     .isInstanceOf(NotFoundException.class)
@@ -425,6 +430,7 @@ class ReviewServiceTest extends IntegrationTest {
                     reviewFilter,
                     null,
                     10,
+                    null,
                     null
             ))
                     .isInstanceOf(InvalidArgumentException.class)

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -322,6 +322,43 @@ class ReviewServiceTest extends IntegrationTest {
                 softly.assertThat(reviewStoreResponse.id()).isEqualTo(store.getId());
                 softly.assertThat(reviewStoreResponse.name()).isEqualTo(store.getStoreName());
                 softly.assertThat(reviewStoreResponse.addressName()).isEqualTo(store.getAddress().getAddressName());
+                softly.assertThat(reviewStoreResponse.isBookmarked()).isFalse();
+            });
+        }
+
+        @Test
+        void 북마크한_가게는_북마크_여부가_TRUE_이다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            bookmarkTestPersister.builder().member(member).store(store).save();
+            Review reviewA = reviewTestPersister.builder().store(store).content("맛있어요").save();
+            Review reviewB = reviewTestPersister.builder().store(store).content("맛없어요").save();
+
+            StoreReviewResponse storeReviewResponse = reviewService.getReviewsByStore(
+                    store.getId(),
+                    "ALL",
+                    null,
+                    10,
+                    new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
+                    member
+            );
+
+            List<StoreReviewContentResponse> reviewContentResponses = storeReviewResponse.storeReviewContentResponses();
+            ReviewStoreResponse reviewStoreResponse = storeReviewResponse.reviewStoreResponse();
+            ReviewPageInfo reviewPageInfo = storeReviewResponse.page();
+            assertSoftly(softly -> {
+                softly.assertThat(reviewContentResponses).hasSize(2);
+                softly.assertThat(reviewContentResponses.get(0).review().id()).isEqualTo(reviewB.getId());
+                softly.assertThat(reviewContentResponses.get(0).review().content()).isEqualTo(reviewB.getContent());
+                softly.assertThat(reviewContentResponses.get(1).review().id()).isEqualTo(reviewA.getId());
+                softly.assertThat(reviewContentResponses.get(1).review().content()).isEqualTo(reviewA.getContent());
+                softly.assertThat(reviewPageInfo.size()).isEqualTo(2);
+                softly.assertThat(reviewPageInfo.firstId()).isEqualTo(reviewB.getId());
+                softly.assertThat(reviewPageInfo.lastId()).isEqualTo(reviewA.getId());
+                softly.assertThat(reviewStoreResponse.id()).isEqualTo(store.getId());
+                softly.assertThat(reviewStoreResponse.name()).isEqualTo(store.getStoreName());
+                softly.assertThat(reviewStoreResponse.addressName()).isEqualTo(store.getAddress().getAddressName());
+                softly.assertThat(reviewStoreResponse.isBookmarked()).isTrue();
             });
         }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -18,6 +18,7 @@ import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageInfo;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
+import org.dinosaur.foodbowl.domain.review.dto.response.ReviewStoreResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewContentResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
 import org.dinosaur.foodbowl.domain.review.persistence.ReviewRepository;
@@ -307,6 +308,7 @@ class ReviewServiceTest extends IntegrationTest {
             );
 
             List<StoreReviewContentResponse> reviewContentResponses = storeReviewResponse.storeReviewContentResponses();
+            ReviewStoreResponse reviewStoreResponse = storeReviewResponse.reviewStoreResponse();
             ReviewPageInfo reviewPageInfo = storeReviewResponse.page();
             assertSoftly(softly -> {
                 softly.assertThat(reviewContentResponses).hasSize(2);
@@ -317,6 +319,9 @@ class ReviewServiceTest extends IntegrationTest {
                 softly.assertThat(reviewPageInfo.size()).isEqualTo(2);
                 softly.assertThat(reviewPageInfo.firstId()).isEqualTo(reviewB.getId());
                 softly.assertThat(reviewPageInfo.lastId()).isEqualTo(reviewA.getId());
+                softly.assertThat(reviewStoreResponse.id()).isEqualTo(store.getId());
+                softly.assertThat(reviewStoreResponse.name()).isEqualTo(store.getStoreName());
+                softly.assertThat(reviewStoreResponse.addressName()).isEqualTo(store.getAddress().getAddressName());
             });
         }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -337,6 +337,14 @@ class ReviewControllerTest extends PresentationTest {
         void 필터링_조건_없이_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             StoreReviewResponse response = new StoreReviewResponse(
+                    new ReviewStoreResponse(
+                            1L,
+                            "한식",
+                            "바다회사랑",
+                            "서울시 마포구 동교로 123",
+                            3.12414,
+                            true
+                    ),
                     List.of(
                             new StoreReviewContentResponse(
                                     new ReviewWriterResponse(
@@ -361,6 +369,7 @@ class ReviewControllerTest extends PresentationTest {
                     any(),
                     any(),
                     anyInt(),
+                    any(DeviceCoordinateRequest.class),
                     any(Member.class)
             )).willReturn(response);
 
@@ -383,6 +392,14 @@ class ReviewControllerTest extends PresentationTest {
         void 필터링_조건과_함께_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             StoreReviewResponse response = new StoreReviewResponse(
+                    new ReviewStoreResponse(
+                            1L,
+                            "한식",
+                            "바다회사랑",
+                            "서울시 마포구 동교로 123",
+                            3.12414,
+                            true
+                    ),
                     List.of(
                             new StoreReviewContentResponse(
                                     new ReviewWriterResponse(
@@ -407,6 +424,7 @@ class ReviewControllerTest extends PresentationTest {
                     any(),
                     any(),
                     anyInt(),
+                    any(DeviceCoordinateRequest.class),
                     any(Member.class)
             )).willReturn(response);
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #196 

## 📝 작업 요약

가게 리뷰 조회 시 가게 정보 응답을 추가했습니다.

## 🔎 작업 상세 설명

가게와 관련된 정보와, 해당 가게를 조회한 유저가 북마크했는지 여부까지 함께 전달하도록 추가했습니다 !
docs는 따로 추가할 내용이 없어서 수정하지 않았어용

## 🌟 리뷰 요구 사항

> 5분 !
