### PR TITLE
Feature/#200 리뷰 단건 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
@@ -24,7 +24,7 @@ public interface FollowRepository extends Repository<Follow, Long> {
 
     long countByFollower(Member follower);
 
-    long countByFollowing(Member follower);
+    long countByFollowing(Member following);
 
     Follow save(Follow follow);
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepository.java
@@ -24,6 +24,8 @@ public interface FollowRepository extends Repository<Follow, Long> {
 
     long countByFollower(Member follower);
 
+    long countByFollowing(Member follower);
+
     Follow save(Follow follow);
 
     void delete(Follow follow);

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -24,7 +24,6 @@ import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
-import org.dinosaur.foodbowl.domain.review.dto.response.ReviewWriterResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
 import org.dinosaur.foodbowl.domain.review.exception.ReviewExceptionType;
 import org.dinosaur.foodbowl.domain.review.persistence.ReviewRepository;
@@ -75,7 +74,7 @@ public class ReviewService {
                 deviceCoordinateRequest.deviceX(),
                 deviceCoordinateRequest.deviceY(),
                 bookmarkQueryService.isBookmarkStoreByMember(loginMember, review.getStore())
-                );
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.bookmark.application.BookmarkQueryService;
 import org.dinosaur.foodbowl.domain.follow.application.FollowCustomService;
 import org.dinosaur.foodbowl.domain.follow.application.dto.MemberToFollowerCountDto;
+import org.dinosaur.foodbowl.domain.follow.persistence.FollowRepository;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.exception.MemberExceptionType;
 import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
@@ -22,6 +23,8 @@ import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
+import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
+import org.dinosaur.foodbowl.domain.review.dto.response.ReviewWriterResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
 import org.dinosaur.foodbowl.domain.review.exception.ReviewExceptionType;
 import org.dinosaur.foodbowl.domain.review.persistence.ReviewRepository;
@@ -46,6 +49,7 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
     private final SchoolRepository schoolRepository;
+    private final FollowRepository followRepository;
     private final StoreService storeService;
     private final PhotoService photoService;
     private final ReviewPhotoService reviewPhotoService;
@@ -53,6 +57,26 @@ public class ReviewService {
     private final ReviewPhotoCustomService reviewPhotoCustomService;
     private final FollowCustomService followCustomService;
     private final BookmarkQueryService bookmarkQueryService;
+
+    @Transactional(readOnly = true)
+    public ReviewResponse getReview(
+            Long reviewId,
+            Member loginMember,
+            DeviceCoordinateRequest deviceCoordinateRequest
+    ) {
+        Review review = reviewRepository.findWithStoreAndMemberById(reviewId)
+                .orElseThrow(() -> new NotFoundException(ReviewExceptionType.NOT_FOUND));
+        List<Photo> reviewPhotos = reviewPhotoService.findPhotos(review);
+
+        return ReviewResponse.of(
+                review,
+                followRepository.countByFollowing(review.getMember()),
+                reviewPhotos,
+                deviceCoordinateRequest.deviceX(),
+                deviceCoordinateRequest.deviceY(),
+                bookmarkQueryService.isBookmarkStoreByMember(loginMember, review.getStore())
+                );
+    }
 
     @Transactional(readOnly = true)
     public ReviewPageResponse getReviewsByMemberInMapBounds(

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewResponse.java
@@ -2,8 +2,10 @@ package org.dinosaur.foodbowl.domain.review.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Set;
 import org.dinosaur.foodbowl.domain.follow.application.dto.MemberToFollowerCountDto;
+import org.dinosaur.foodbowl.domain.photo.domain.Photo;
 import org.dinosaur.foodbowl.domain.review.application.dto.ReviewToPhotoPathDto;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
@@ -20,6 +22,36 @@ public record ReviewResponse(
         @Schema(description = "리뷰 가게 응답")
         ReviewStoreResponse store
 ) {
+
+    public static ReviewResponse of(
+            Review review,
+            long memberFollowCount,
+            List<Photo> reviewPhotos,
+            BigDecimal deviceX,
+            BigDecimal deviceY,
+            boolean isBookmarked
+            ) {
+        return new ReviewResponse(
+                ReviewWriterResponse.of(
+                        review.getMember(),
+                        memberFollowCount
+                ),
+                ReviewContentResponse.of(
+                        review,
+                        reviewPhotos.stream()
+                                .map(Photo::getPath)
+                                .toList()
+                ),
+                ReviewStoreResponse.of(
+                        review.getStore(),
+                        PointUtils.calculateDistance(
+                                PointUtils.generate(deviceX, deviceY),
+                                review.getStore().getAddress().getCoordinate()
+                        ),
+                        isBookmarked
+                )
+        );
+    }
 
     public static ReviewResponse of(
             Review review,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewResponse.java
@@ -30,7 +30,7 @@ public record ReviewResponse(
             BigDecimal deviceX,
             BigDecimal deviceY,
             boolean isBookmarked
-            ) {
+    ) {
         return new ReviewResponse(
                 ReviewWriterResponse.of(
                         review.getMember(),

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewRepository.java
@@ -2,11 +2,15 @@ package org.dinosaur.foodbowl.domain.review.persistence;
 
 import java.util.Optional;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.Repository;
 
 public interface ReviewRepository extends Repository<Review, Long> {
 
     Optional<Review> findById(Long id);
+
+    @EntityGraph(attributePaths = {"member", "store"})
+    Optional<Review> findWithStoreAndMemberById(Long id);
 
     Review save(Review review);
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -161,7 +161,7 @@ public class ReviewController implements ReviewControllerDocs {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ReviewResponse> read(
+    public ResponseEntity<ReviewResponse> getReview(
             @PathVariable("id") @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long reviewId,
             @RequestParam(name = "deviceX") BigDecimal deviceX,
             @RequestParam(name = "deviceY") BigDecimal deviceY,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -13,6 +13,7 @@ import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
+import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
 import org.dinosaur.foodbowl.global.presentation.Auth;
 import org.springframework.http.MediaType;
@@ -157,6 +158,18 @@ public class ReviewController implements ReviewControllerDocs {
                 loginMember
         );
         return ResponseEntity.ok(storeReviewResponse);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ReviewResponse> read(
+            @PathVariable("id") @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long reviewId,
+            @RequestParam(name = "deviceX") BigDecimal deviceX,
+            @RequestParam(name = "deviceY") BigDecimal deviceY,
+            @Auth Member member
+    ) {
+        DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
+        ReviewResponse reviewResponse = reviewService.getReview(reviewId, member, deviceCoordinateRequest);
+        return ResponseEntity.ok(reviewResponse);
     }
 
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -29,9 +29,9 @@ public interface ReviewControllerDocs {
             summary = "단건 리뷰 주회",
             description = """
                     단건 리뷰를 조회합니다.
-                    
+                                        
                     리뷰 작성자, 리뷰 본문, 리뷰 가게 정보를 응답으로 반환합니다.
-                    
+                                        
                     리뷰 목록 조회 결과에서 리뷰 하나의 응답 데이터와 동일합니다.
                     """
     )

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -16,6 +16,7 @@ import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
+import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,54 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "리뷰", description = "리뷰 API")
 public interface ReviewControllerDocs {
+
+    @Operation(
+            summary = "단건 리뷰 주회",
+            description = """
+                    단건 리뷰를 조회합니다.
+                    
+                    리뷰 작성자, 리뷰 본문, 리뷰 가게 정보를 응답으로 반환합니다.
+                    
+                    리뷰 목록 조회 결과에서 리뷰 하나의 응답 데이터와 동일합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "단건 리뷰 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.리뷰 ID가 양수가 아닌 경우
+                                                        
+                            2.디바이스 경도가 존재하지 않는 경우
+                                                        
+                            3.디바이스 위도가 존재하지 않는 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            1.일치하는 리뷰가 존재하지 않는 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<ReviewResponse> read(
+            @Parameter(description = "리뷰 ID", example = "1")
+            @Positive(message = "리뷰 ID는 양수만 가능합니다.")
+            Long reviewId,
+
+            @Parameter(description = "사용자 경도", example = "123.3636")
+            BigDecimal deviceX,
+
+            @Parameter(description = "사용자 위도", example = "32.3636")
+            BigDecimal deviceY,
+
+            Member loginMember
+    );
 
     @Operation(
             summary = "멤버의 리뷰 목록 범위 기반 페이징 조회",

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -26,7 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ReviewControllerDocs {
 
     @Operation(
-            summary = "단건 리뷰 주회",
+            summary = "단건 리뷰 조회",
             description = """
                     단건 리뷰를 조회합니다.
                                         
@@ -59,7 +59,7 @@ public interface ReviewControllerDocs {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    ResponseEntity<ReviewResponse> read(
+    ResponseEntity<ReviewResponse> getReview(
             @Parameter(description = "리뷰 ID", example = "1")
             @Positive(message = "리뷰 ID는 양수만 가능합니다.")
             Long reviewId,

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/persistence/FollowRepositoryTest.java
@@ -130,6 +130,20 @@ class FollowRepositoryTest extends PersistenceTest {
         assertThat(result).isEqualTo(2);
     }
 
+    @Test
+    void 팔로워_수를_조회한다() {
+        Member following = memberTestPersister.builder().save();
+        Member followerA = memberTestPersister.builder().save();
+        Member followerB = memberTestPersister.builder().save();
+
+        followTestPersister.builder().following(following).follower(followerA).save();
+        followTestPersister.builder().following(following).follower(followerB).save();
+
+        long result = followRepository.countByFollowing(following);
+
+        assertThat(result).isEqualTo(2);
+    }
+
     @Nested
     class 멤버의_팔로우_데이터_삭제_시 {
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -4,14 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
-import org.dinosaur.foodbowl.domain.member.domain.MemberThumbnail;
 import org.dinosaur.foodbowl.domain.photo.domain.Photo;
-import org.dinosaur.foodbowl.domain.photo.domain.Thumbnail;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.domain.review.domain.ReviewPhoto;
 import org.dinosaur.foodbowl.domain.review.dto.request.DeviceCoordinateRequest;
@@ -68,7 +65,11 @@ class ReviewServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            ReviewResponse reviewResponse = reviewService.getReview(review.getId(), loginMember, deviceCoordinateRequest);
+            ReviewResponse reviewResponse = reviewService.getReview(
+                    review.getId(),
+                    loginMember,
+                    deviceCoordinateRequest
+            );
 
             assertSoftly(softly -> {
                 softly.assertThat(reviewResponse.store().id()).isEqualTo(store.getId());
@@ -97,7 +98,11 @@ class ReviewServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            ReviewResponse reviewResponse = reviewService.getReview(review.getId(), loginMember, deviceCoordinateRequest);
+            ReviewResponse reviewResponse = reviewService.getReview(
+                    review.getId(),
+                    loginMember,
+                    deviceCoordinateRequest
+            );
 
             assertSoftly(softly -> {
                 softly.assertThat(reviewResponse.store().id()).isEqualTo(store.getId());
@@ -126,7 +131,11 @@ class ReviewServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            ReviewResponse reviewResponse = reviewService.getReview(review.getId(), loginMember, deviceCoordinateRequest);
+            ReviewResponse reviewResponse = reviewService.getReview(
+                    review.getId(),
+                    loginMember,
+                    deviceCoordinateRequest
+            );
 
             assertSoftly(softly -> {
                 softly.assertThat(reviewResponse.store().id()).isEqualTo(store.getId());

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -4,11 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.domain.MemberThumbnail;
 import org.dinosaur.foodbowl.domain.photo.domain.Photo;
+import org.dinosaur.foodbowl.domain.photo.domain.Thumbnail;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.domain.review.domain.ReviewPhoto;
 import org.dinosaur.foodbowl.domain.review.dto.request.DeviceCoordinateRequest;
@@ -49,6 +52,108 @@ class ReviewServiceTest extends IntegrationTest {
 
     @Autowired
     private ReviewRepository reviewRepository;
+
+    @Nested
+    class 리뷰_단건_조회_시 {
+
+        @Test
+        void 가게_북마크_여부를_함께_조회한다() {
+            Member loginMember = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            bookmarkTestPersister.builder().member(loginMember).store(store).save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).content("꿀맛이에요").save();
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            ReviewResponse reviewResponse = reviewService.getReview(review.getId(), loginMember, deviceCoordinateRequest);
+
+            assertSoftly(softly -> {
+                softly.assertThat(reviewResponse.store().id()).isEqualTo(store.getId());
+                softly.assertThat(reviewResponse.store().isBookmarked()).isTrue();
+                softly.assertThat(reviewResponse.review().content()).isEqualTo(review.getContent());
+                softly.assertThat(reviewResponse.review().imagePaths()).isEmpty();
+                softly.assertThat(reviewResponse.writer().id()).isEqualTo(writer.getId());
+                softly.assertThat(reviewResponse.writer().nickname()).isEqualTo(writer.getNickname());
+                softly.assertThat(reviewResponse.writer().followerCount()).isEqualTo(0);
+            });
+        }
+
+        @Test
+        void 리뷰_작성자_팔로워_수를_함께_조회한다() {
+            Member loginMember = memberTestPersister.builder().save();
+            Member memberA = memberTestPersister.builder().save();
+            Member memberB = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            bookmarkTestPersister.builder().member(loginMember).store(store).save();
+            followTestPersister.builder().follower(memberA).following(writer).save();
+            followTestPersister.builder().follower(memberB).following(writer).save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).content("꿀맛이에요").save();
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            ReviewResponse reviewResponse = reviewService.getReview(review.getId(), loginMember, deviceCoordinateRequest);
+
+            assertSoftly(softly -> {
+                softly.assertThat(reviewResponse.store().id()).isEqualTo(store.getId());
+                softly.assertThat(reviewResponse.store().isBookmarked()).isTrue();
+                softly.assertThat(reviewResponse.review().content()).isEqualTo(review.getContent());
+                softly.assertThat(reviewResponse.review().imagePaths()).isEmpty();
+                softly.assertThat(reviewResponse.writer().id()).isEqualTo(writer.getId());
+                softly.assertThat(reviewResponse.writer().nickname()).isEqualTo(writer.getNickname());
+                softly.assertThat(reviewResponse.writer().followerCount()).isEqualTo(2);
+            });
+        }
+
+        @Test
+        void 리뷰_사진을_함께_조회한다() {
+            Member loginMember = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            bookmarkTestPersister.builder().member(loginMember).store(store).save();
+            Review review = reviewTestPersister.builder().member(writer).store(store).content("꿀맛이에요").save();
+            Photo photoA = photoTestPersister.builder().save();
+            Photo photoB = photoTestPersister.builder().save();
+            ReviewPhoto reviewPhotoA = reviewPhotoTestPersister.builder().review(review).photo(photoA).save();
+            ReviewPhoto reviewPhotoB = reviewPhotoTestPersister.builder().review(review).photo(photoB).save();
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            ReviewResponse reviewResponse = reviewService.getReview(review.getId(), loginMember, deviceCoordinateRequest);
+
+            assertSoftly(softly -> {
+                softly.assertThat(reviewResponse.store().id()).isEqualTo(store.getId());
+                softly.assertThat(reviewResponse.store().isBookmarked()).isTrue();
+                softly.assertThat(reviewResponse.review().content()).isEqualTo(review.getContent());
+                softly.assertThat(reviewResponse.review().imagePaths())
+                        .containsExactly(reviewPhotoA.getPhoto().getPath(), reviewPhotoB.getPhoto().getPath());
+                softly.assertThat(reviewResponse.writer().id()).isEqualTo(writer.getId());
+                softly.assertThat(reviewResponse.writer().nickname()).isEqualTo(writer.getNickname());
+                softly.assertThat(reviewResponse.writer().followerCount()).isEqualTo(0);
+            });
+        }
+
+        @Test
+        void 존재하지_않는_리뷰이면_예외를_던진다() {
+            Long wrongReviewId = -1L;
+            Member member = memberTestPersister.builder().save();
+            DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            assertThatThrownBy(() -> reviewService.getReview(wrongReviewId, member, deviceCoordinateRequest))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("일치하는 리뷰를 찾을 수 없습니다.");
+        }
+    }
 
     @Nested
     class 멤버_리뷰_목록_페이징_조회_시 {

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewRepositoryTest.java
@@ -1,7 +1,7 @@
 package org.dinosaur.foodbowl.domain.review.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.*;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.domain.Review;

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.dinosaur.foodbowl.domain.review.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.*;
 
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
@@ -27,6 +28,26 @@ class ReviewRepositoryTest extends PersistenceTest {
         Review saveReview = reviewRepository.save(review);
 
         assertThat(reviewRepository.findById(saveReview.getId())).isPresent();
+    }
+
+    @Test
+    void 리뷰를_조회할_때_가게와_작성를_함께_조회한다() {
+        Member member = memberTestPersister.builder().save();
+        Store store = storeTestPersister.builder().save();
+        Review review = Review.builder()
+                .member(member)
+                .store(store)
+                .content("정말 좋습니다.")
+                .build();
+        Review saveReview = reviewRepository.save(review);
+
+        Review foundReview = reviewRepository.findWithStoreAndMemberById(saveReview.getId()).get();
+
+        assertSoftly(softly -> {
+            softly.assertThat(foundReview.getId()).isPositive();
+            softly.assertThat(foundReview.getStore()).isEqualTo(store);
+            softly.assertThat(foundReview.getMember()).isEqualTo(member);
+        });
     }
 
     @Test


### PR DESCRIPTION
## 🔥 연관 이슈

close: #200 

## 📝 작업 요약

리뷰 단건 조회 기능을 구현했습니다.

## 🔎 작업 상세 설명

리뷰 목록 조회하던 기능에서 동일한 응답으로 단건 조회를 응답하는 기능을 추가했습니다.

응답 객체인 ReviewResponse가 기존에 List<Review>를 이용해서 `of` 메서드로 반환하고 있어서, 단건 review를 이용한 `of` 메서드 오버로딩을 했습니다 !

기존 `ReviewResponse`와 응답 데이터가 동일하기 때문에 재사용하려고 오버로딩했는데 다른 의견 있으시면 말씀해주세요 ㅎㅎ

## 🌟 리뷰 요구 사항

오랜만에 기능을 작성해서 놓친 부분이 있을 수도 있을 것 같아요 😅
잘 부탁드립니당

> 10분
