### PR TITLE
Feature/#178 최신 게시글 목록 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
@@ -25,6 +25,14 @@ public class ReviewCustomService {
     }
 
     @Transactional(readOnly = true)
+    public List<Review> getReviewFeeds(
+            Long lastReviewId,
+            int pageSize
+    ) {
+        return reviewCustomRepository.findPaginationReviewsHavingPhoto(lastReviewId, pageSize);
+    }
+
+    @Transactional(readOnly = true)
     public List<Review> getReviewsByMemberInMapBounds(
             Long memberId,
             Long lastReviewId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
@@ -25,10 +25,7 @@ public class ReviewCustomService {
     }
 
     @Transactional(readOnly = true)
-    public List<Review> getReviewFeeds(
-            Long lastReviewId,
-            int pageSize
-    ) {
+    public List<Review> getReviewFeeds(Long lastReviewId, int pageSize) {
         return reviewCustomRepository.findPaginationReviewsHavingPhoto(lastReviewId, pageSize);
     }
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -22,6 +22,7 @@ import org.dinosaur.foodbowl.domain.review.dto.request.DeviceCoordinateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
+import org.dinosaur.foodbowl.domain.review.dto.response.ReviewFeedPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
@@ -74,6 +75,37 @@ public class ReviewService {
                 deviceCoordinateRequest.deviceX(),
                 deviceCoordinateRequest.deviceY(),
                 bookmarkQueryService.isBookmarkStoreByMember(loginMember, review.getStore())
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewFeedPageResponse getReviewFeeds(
+            Long lastReviewId,
+            int pageSize,
+            DeviceCoordinateRequest deviceCoordinateRequest,
+            Member loginMember
+    ) {
+        List<Review> reviews = reviewCustomService.getReviewFeeds(lastReviewId, pageSize);
+        return convertToReviewFeedResponse(reviews, loginMember, deviceCoordinateRequest);
+    }
+
+    private ReviewFeedPageResponse convertToReviewFeedResponse(
+            List<Review> reviews,
+            Member loginMember,
+            DeviceCoordinateRequest deviceCoordinateRequest
+    ) {
+        MemberToFollowerCountDto memberToFollowerCountDto =
+                followCustomService.getFollowerCountByMembers(getWriters(reviews));
+        ReviewToPhotoPathDto reviewToPhotoPathDto = reviewPhotoCustomService.getPhotoPathByReviews(reviews);
+        Set<Store> bookmarkStores = bookmarkQueryService.getBookmarkStoresByMember(loginMember);
+
+        return ReviewFeedPageResponse.of(
+                reviews,
+                memberToFollowerCountDto,
+                reviewToPhotoPathDto,
+                bookmarkStores,
+                deviceCoordinateRequest.deviceX(),
+                deviceCoordinateRequest.deviceY()
         );
     }
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewFeedPageResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewFeedPageResponse.java
@@ -1,0 +1,63 @@
+package org.dinosaur.foodbowl.domain.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import org.dinosaur.foodbowl.domain.follow.application.dto.MemberToFollowerCountDto;
+import org.dinosaur.foodbowl.domain.review.application.dto.ReviewToPhotoPathDto;
+import org.dinosaur.foodbowl.domain.review.domain.Review;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
+
+@Schema(description = "리뷰 피드 조회 페이지 응답")
+public record ReviewFeedPageResponse(
+        @Schema(description = "리뷰 피드 페이지 응답")
+        List<ReviewFeedResponse> reviewFeedResponses,
+
+        @Schema(description = "리뷰 조회 페이지 정보")
+        ReviewPageInfo reviewPageInfo
+) {
+
+    public static ReviewFeedPageResponse of(
+            List<Review> reviews,
+            MemberToFollowerCountDto memberToFollowerCountDto,
+            ReviewToPhotoPathDto reviewToPhotoPathDto,
+            Set<Store> bookmarkStores,
+            BigDecimal deviceX,
+            BigDecimal deviceY
+    ) {
+        return new ReviewFeedPageResponse(
+                convertToReviewFeedResponses(
+                        reviews,
+                        memberToFollowerCountDto,
+                        reviewToPhotoPathDto,
+                        bookmarkStores,
+                        deviceX,
+                        deviceY
+                ),
+                ReviewPageInfo.from(reviews)
+        );
+    }
+
+    private static List<ReviewFeedResponse> convertToReviewFeedResponses(
+            List<Review> reviews,
+            MemberToFollowerCountDto memberToFollowerCountDto,
+            ReviewToPhotoPathDto reviewToPhotoPathDto,
+            Set<Store> bookmarkStores,
+            BigDecimal deviceX,
+            BigDecimal deviceY
+    ) {
+        return reviews.stream()
+                .map(review ->
+                        ReviewFeedResponse.of(
+                                review,
+                                memberToFollowerCountDto,
+                                reviewToPhotoPathDto,
+                                bookmarkStores,
+                                deviceX,
+                                deviceY
+                        )
+                )
+                .toList();
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewFeedResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewFeedResponse.java
@@ -1,0 +1,55 @@
+package org.dinosaur.foodbowl.domain.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.Set;
+import org.dinosaur.foodbowl.domain.follow.application.dto.MemberToFollowerCountDto;
+import org.dinosaur.foodbowl.domain.review.application.dto.ReviewToPhotoPathDto;
+import org.dinosaur.foodbowl.domain.review.domain.Review;
+import org.dinosaur.foodbowl.domain.store.domain.Store;
+import org.dinosaur.foodbowl.global.util.PointUtils;
+
+public record ReviewFeedResponse(
+        @Schema(description = "리뷰 피드 썸네일 응답")
+        String reviewFeedThumbnail,
+
+        @Schema(description = "리뷰 작성자 응답")
+        ReviewWriterResponse writer,
+
+        @Schema(description = "리뷰 본문 응답")
+        ReviewContentResponse review,
+
+        @Schema(description = "리뷰 가게 응답")
+        ReviewStoreResponse store
+) {
+
+    public static ReviewFeedResponse of(
+            Review review,
+            MemberToFollowerCountDto memberToFollowerCountDto,
+            ReviewToPhotoPathDto reviewToPhotoPathDto,
+            Set<Store> bookmarkStores,
+            BigDecimal deviceX,
+            BigDecimal deviceY
+    ) {
+        String reviewFeedThumbnail = reviewToPhotoPathDto.getPhotoPath(review.getId()).get(0);
+        return new ReviewFeedResponse(
+                reviewFeedThumbnail,
+                ReviewWriterResponse.of(
+                        review.getMember(),
+                        memberToFollowerCountDto.getFollowCount(review.getMember().getId())
+                ),
+                ReviewContentResponse.of(
+                        review,
+                        reviewToPhotoPathDto.getPhotoPath(review.getId())
+                ),
+                ReviewStoreResponse.of(
+                        review.getStore(),
+                        PointUtils.calculateDistance(
+                                PointUtils.generate(deviceX, deviceY),
+                                review.getStore().getAddress().getCoordinate()
+                        ),
+                        bookmarkStores.contains(review.getStore())
+                )
+        );
+    }
+}

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewFeedResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewFeedResponse.java
@@ -9,8 +9,9 @@ import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.global.util.PointUtils;
 
+@Schema(description = "리뷰 피드 응답")
 public record ReviewFeedResponse(
-        @Schema(description = "리뷰 피드 썸네일 응답")
+        @Schema(description = "리뷰 피드 썸네일 응답", example = "https://image.food.com/1.jpg")
         String reviewFeedThumbnail,
 
         @Schema(description = "리뷰 작성자 응답")

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -4,6 +4,7 @@ import static org.dinosaur.foodbowl.domain.bookmark.domain.QBookmark.bookmark;
 import static org.dinosaur.foodbowl.domain.follow.domain.QFollow.follow;
 import static org.dinosaur.foodbowl.domain.member.domain.QMember.member;
 import static org.dinosaur.foodbowl.domain.review.domain.QReview.review;
+import static org.dinosaur.foodbowl.domain.review.domain.QReviewPhoto.*;
 import static org.dinosaur.foodbowl.domain.store.domain.QCategory.category;
 import static org.dinosaur.foodbowl.domain.store.domain.QStore.store;
 import static org.dinosaur.foodbowl.domain.store.domain.QStoreSchool.storeSchool;
@@ -29,6 +30,23 @@ import org.springframework.stereotype.Repository;
 public class ReviewCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Review> findPaginationReviewsHavingPhoto(Long lastReviewId, int pageSize) {
+        return jpaQueryFactory.selectDistinct(review)
+                .from(review)
+                .innerJoin(review.store, store).fetchJoin()
+                .innerJoin(review.member, member).fetchJoin()
+                .innerJoin(store.category, category).fetchJoin()
+                .innerJoin(reviewPhoto).on(
+                        review.id.eq(reviewPhoto.review.id)
+                )
+                .where(
+                        ltLastReviewId(lastReviewId)
+                )
+                .orderBy(review.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
 
     public List<StoreReviewCountDto> findReviewCountByStores(List<Store> stores) {
         return jpaQueryFactory.select(

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -4,7 +4,7 @@ import static org.dinosaur.foodbowl.domain.bookmark.domain.QBookmark.bookmark;
 import static org.dinosaur.foodbowl.domain.follow.domain.QFollow.follow;
 import static org.dinosaur.foodbowl.domain.member.domain.QMember.member;
 import static org.dinosaur.foodbowl.domain.review.domain.QReview.review;
-import static org.dinosaur.foodbowl.domain.review.domain.QReviewPhoto.*;
+import static org.dinosaur.foodbowl.domain.review.domain.QReviewPhoto.reviewPhoto;
 import static org.dinosaur.foodbowl.domain.store.domain.QCategory.category;
 import static org.dinosaur.foodbowl.domain.store.domain.QStore.store;
 import static org.dinosaur.foodbowl.domain.store.domain.QStoreSchool.storeSchool;

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -12,6 +12,7 @@ import org.dinosaur.foodbowl.domain.review.dto.request.DeviceCoordinateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
+import org.dinosaur.foodbowl.domain.review.dto.response.ReviewFeedPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
@@ -62,6 +63,24 @@ public class ReviewController implements ReviewControllerDocs {
                 loginMember
         );
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/feeds")
+    public ResponseEntity<ReviewFeedPageResponse> getReviewFeeds(
+            @RequestParam(name = "lastReviewId", required = false) @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long lastReviewId,
+            @RequestParam(name = "deviceX") BigDecimal deviceX,
+            @RequestParam(name = "deviceY") BigDecimal deviceY,
+            @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
+            @Auth Member loginMember
+    ) {
+        DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
+        ReviewFeedPageResponse reviewFeedPageResponse = reviewService.getReviewFeeds(
+                lastReviewId,
+                pageSize,
+                deviceCoordinateRequest,
+                loginMember
+        );
+        return ResponseEntity.ok(reviewFeedPageResponse);
     }
 
     @GetMapping("/bookmarks")

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -70,7 +70,7 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestParam(name = "lastReviewId", required = false) @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long lastReviewId,
             @RequestParam(name = "deviceX") BigDecimal deviceX,
             @RequestParam(name = "deviceY") BigDecimal deviceY,
-            @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
+            @RequestParam(name = "pageSize", defaultValue = "20") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
             @Auth Member loginMember
     ) {
         DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -13,13 +13,17 @@ import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.review.dto.request.DeviceCoordinateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
+import org.dinosaur.foodbowl.domain.review.dto.response.ReviewFeedPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
+import org.dinosaur.foodbowl.global.presentation.Auth;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "리뷰", description = "리뷰 API")
@@ -69,6 +73,59 @@ public interface ReviewControllerDocs {
 
             @Parameter(description = "사용자 위도", example = "32.3636")
             BigDecimal deviceY,
+
+            Member loginMember
+    );
+
+    @Operation(
+            summary = "리뷰 피드 조회",
+            description = """
+                    리뷰를 피드를 조회합니다.
+                    
+                    피드에서 조회되는 리뷰는, 사진이 포함된 리뷰만 조회됩니다.
+                    
+                    기존 리뷰 목록 조회와 동일한 응답에 리뷰 썸네일 필드(reviewFeedThumbnail)를 추가했습니다.
+                    
+                    피드 조회 결과는 최신 피드(리뷰) 순서대로 반환합니다.
+                    
+                    기존 페이징 조회와 다르게, 피드 조회 페이징의 pageSize default 값은 20입니다.
+                    
+                    피드 화면에서 기본으로 15개 이상의 리뷰가 한번에 보이기 때문에 20으로 설정했습니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "리뷰 피드 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.리뷰 ID가 양수가 아닌 경우
+                                                        
+                            2.디바이스 경도가 존재하지 않는 경우
+                                                        
+                            3.디바이스 위도가 존재하지 않는 경우
+                            
+                            4.페이지 크기가 양수가 아닌 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<ReviewFeedPageResponse> getReviewFeeds(
+            @Parameter(description = "리뷰 ID", example = "1")
+            @Positive(message = "리뷰 ID는 양수만 가능합니다.")
+            Long lastReviewId,
+
+            @Parameter(description = "사용자 경도", example = "123.3636")
+            BigDecimal deviceX,
+
+            @Parameter(description = "사용자 위도", example = "32.3636")
+            BigDecimal deviceY,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @Positive(message = "페이지 크기는 양수만 가능합니다.")
+            int pageSize,
 
             Member loginMember
     );

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -13,7 +13,6 @@ import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
-import org.dinosaur.foodbowl.domain.review.dto.request.DeviceCoordinateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewFeedPageResponse;
@@ -21,9 +20,7 @@ import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
-import org.dinosaur.foodbowl.global.presentation.Auth;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "리뷰", description = "리뷰 API")
@@ -81,15 +78,15 @@ public interface ReviewControllerDocs {
             summary = "리뷰 피드 조회",
             description = """
                     리뷰를 피드를 조회합니다.
-                    
+                                        
                     피드에서 조회되는 리뷰는, 사진이 포함된 리뷰만 조회됩니다.
-                    
+                                        
                     기존 리뷰 목록 조회와 동일한 응답에 리뷰 썸네일 필드(reviewFeedThumbnail)를 추가했습니다.
-                    
+                                        
                     피드 조회 결과는 최신 피드(리뷰) 순서대로 반환합니다.
-                    
+                                        
                     기존 페이징 조회와 다르게, 피드 조회 페이징의 pageSize default 값은 20입니다.
-                    
+                                        
                     피드 화면에서 기본으로 15개 이상의 리뷰가 한번에 보이기 때문에 20으로 설정했습니다.
                     """
     )
@@ -106,7 +103,7 @@ public interface ReviewControllerDocs {
                             2.디바이스 경도가 존재하지 않는 경우
                                                         
                             3.디바이스 위도가 존재하지 않는 경우
-                            
+                                                        
                             4.페이지 크기가 양수가 아닌 경우
                             """,
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.photo.domain.Photo;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
 import org.dinosaur.foodbowl.domain.review.application.dto.StoreToReviewCountDto;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
@@ -147,5 +148,17 @@ class ReviewCustomServiceTest extends IntegrationTest {
         );
 
         assertThat(result).containsExactly(review);
+    }
+
+    @Test
+    void 사진이_있는_리뷰_피드를_조회한다() {
+        Store store = storeTestPersister.builder().save();
+        Photo photo = photoTestPersister.builder().save();
+        Review review = reviewTestPersister.builder().store(store).save();
+        reviewPhotoTestPersister.builder().review(review).photo(photo).save();
+
+        List<Review> reviews = reviewCustomService.getReviewFeeds(null, 10);
+
+        assertThat(reviews).containsExactly(review);
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -80,7 +80,7 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
 
             List<Review> reviews = reviewCustomRepository.findPaginationReviewsHavingPhoto(null, 10);
 
-            assertThat(reviews).doesNotContain(reviewC, reviewB, reviewA);
+            assertThat(reviews).isEmpty();
         }
     }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -234,6 +234,23 @@ class ReviewControllerTest extends PresentationTest {
                     .andDo(print())
                     .andExpect(status().isBadRequest());
         }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 페이지_크기가_양수가_아니라면_400_응답을_반환한다(String pageSize) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/reviews/feeds")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("lastReviewId", "1")
+                            .param("deviceX", "123.3636")
+                            .param("deviceY", "32.3636")
+                            .param("pageSize", pageSize))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("페이지 크기는 양수만 가능합니다.")));
+        }
     }
 
     @Nested

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -185,7 +185,12 @@ class ReviewControllerTest extends PresentationTest {
                     ),
                     new ReviewPageInfo(10L, 1L, 10)
             );
-            given(reviewService.getReviewFeeds(any(Long.class), anyInt(), any(DeviceCoordinateRequest.class), any(Member.class)))
+            given(reviewService.getReviewFeeds(
+                    any(Long.class),
+                    anyInt(),
+                    any(DeviceCoordinateRequest.class),
+                    any(Member.class))
+            )
                     .willReturn(reviewFeedPageResponse);
 
             mockMvc.perform(get("/v1/reviews/feeds")


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #178 

## 📝 작업 요약

리뷰 피드 조회 기능을 구현했습니다.

## 🔎 작업 상세 설명

기존의 리뷰 조회(회원, 팔로우, 북마크)와 거의 동일한 로직입니다 😛

* 리뷰 피드 조회는 **사진이 포함된 리뷰만 조회**하도록 구현했습니다.
* 기존의 로직과 다른 부분은 `ReviewFeedResponse`를 생성해 **각 리뷰 피드 별로 썸네일(첫 번째 사진) 필드를 추가**했습니다.
* 기존 페이징 조회의 default page size는 10이지만, **피드 조회의 default는 20**으로 설정했습니다. 앱을 확인해보니 한 화면에 17개가 기본으로 들어오는 것 같아서 20으로 설정했습니다 !

기존 로직과 크게 다른 부분이 없어 리뷰에 큰 소요가 들진 않을 것 같네요 😃

## 🌟 리뷰 요구 사항

> 20분
