### PR TITLE
Chore/#207 가게 조회, 검색 및 타인의 팔로워, 팔로잉 조회 시 응답 필드를 추가한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
@@ -54,7 +54,11 @@ public class FollowService {
                 .map(Follow::getFollowing)
                 .map(following -> {
                     Optional<Follow> follow = followRepository.findByFollowingAndFollower(following, loginMember);
-                    return OtherUserFollowingResponse.of(following, follow.isPresent());
+                    return OtherUserFollowingResponse.of(
+                            following,
+                            follow.isPresent(),
+                            Objects.equals(loginMember, following)
+                    );
                 });
         return PageResponse.from(followings);
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/application/FollowService.java
@@ -87,7 +87,11 @@ public class FollowService {
                 .map(Follow::getFollower)
                 .map(follower -> {
                     Optional<Follow> follow = followRepository.findByFollowingAndFollower(follower, loginMember);
-                    return OtherUserFollowerResponse.of(follower, follow.isPresent());
+                    return OtherUserFollowerResponse.of(
+                            follower,
+                            follow.isPresent(),
+                            Objects.equals(loginMember, follower)
+                    );
                 });
         return PageResponse.from(followers);
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/dto/response/OtherUserFollowerResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/dto/response/OtherUserFollowerResponse.java
@@ -18,16 +18,20 @@ public record OtherUserFollowerResponse(
         int followerCount,
 
         @Schema(description = "팔로잉 여부", example = "true")
-        boolean isFollowing
+        boolean isFollowing,
+
+        @Schema(description = "본인(사용자) 여부", example = "true")
+        boolean isMe
 ) {
 
-    public static OtherUserFollowerResponse of(Member follower, boolean isFollowing) {
+    public static OtherUserFollowerResponse of(Member follower, boolean isFollowing, boolean isMe) {
         return new OtherUserFollowerResponse(
                 follower.getId(),
                 follower.getProfileImageUrl(),
                 follower.getNickname(),
                 follower.getFollowerCount(),
-                isFollowing
+                isFollowing,
+                isMe
         );
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/dto/response/OtherUserFollowingResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/dto/response/OtherUserFollowingResponse.java
@@ -18,16 +18,20 @@ public record OtherUserFollowingResponse(
         int followerCount,
 
         @Schema(description = "팔로잉 여부", example = "true")
-        boolean isFollowing
+        boolean isFollowing,
+
+        @Schema(description = "본인(사용자) 여부", example = "true")
+        boolean isMe
 ) {
 
-    public static OtherUserFollowingResponse of(Member following, boolean isFollowing) {
+    public static OtherUserFollowingResponse of(Member following, boolean isFollowing, boolean isMe) {
         return new OtherUserFollowingResponse(
                 following.getId(),
                 following.getProfileImageUrl(),
                 following.getNickname(),
                 following.getFollowerCount(),
-                isFollowing
+                isFollowing,
+                isMe
         );
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewStoreResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/dto/response/ReviewStoreResponse.java
@@ -17,6 +17,9 @@ public record ReviewStoreResponse(
         @Schema(description = "가게 주소", example = "부산광역시 금정구 40-4")
         String addressName,
 
+        @Schema(description = "가게 URL", example = "map.kakao.stores/1")
+        String storeUrl,
+
         @Schema(description = "디바이스와 가게와의 거리(m)", example = "511.1313")
         double distance,
 
@@ -30,6 +33,7 @@ public record ReviewStoreResponse(
                 store.getCategory().getName(),
                 store.getStoreName(),
                 store.getAddress().getAddressName(),
+                store.getStoreUrl(),
                 distance,
                 isBookmarked
         );

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/dto/response/StoreSearchResponse.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/dto/response/StoreSearchResponse.java
@@ -11,6 +11,12 @@ public record StoreSearchResponse(
         @Schema(description = "가게 이름", example = "김밥나라 부산대점")
         String storeName,
 
+        @Schema(description = "가게 주소", example = "부산시 금정구 장전동 부산대학로 31")
+        String address,
+
+        @Schema(description = "카테고리", example = "한식")
+        String category,
+
         @Schema(description = "사용자로 부터 거리(단위: 미터)", example = "1250.234")
         double distance,
 

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
@@ -34,12 +34,15 @@ public class StoreCustomRepository {
                         new QStoreSearchResponse(
                                 store.id,
                                 store.storeName,
+                                store.address.addressName,
+                                store.category.categoryType.stringValue(),
                                 calculateDistance(x, y),
                                 review.id.count()
                         )
                 )
                 .from(store)
                 .leftJoin(review).on(review.store.id.eq(store.id))
+                .innerJoin(store.category, category)
                 .where(store.storeName.contains(name))
                 .groupBy(store.id)
                 .orderBy(calculateDistance(x, y).asc())

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
@@ -146,26 +146,32 @@ class FollowServiceTest extends IntegrationTest {
             Member followerA = memberTestPersister.builder().save();
             Member followerB = memberTestPersister.builder().save();
 
+            followTestPersister.builder().following(following).follower(member).save();
             followTestPersister.builder().following(following).follower(followerA).save();
             followTestPersister.builder().following(following).follower(followerB).save();
             followTestPersister.builder().following(followerA).follower(member).save();
 
             PageResponse<OtherUserFollowerResponse> response =
-                    followService.getOtherUserFollowers(following.getId(), 0, 2, member);
+                    followService.getOtherUserFollowers(following.getId(), 0, 10, member);
 
             assertSoftly(softly -> {
-                softly.assertThat(response.content()).hasSize(2);
+                softly.assertThat(response.content()).hasSize(3);
                 softly.assertThat(response.content().get(0).memberId()).isEqualTo(followerB.getId());
                 softly.assertThat(response.content().get(0).nickname()).isEqualTo(followerB.getNickname());
                 softly.assertThat(response.content().get(0).isFollowing()).isFalse();
+                softly.assertThat(response.content().get(0).isMe()).isFalse();
                 softly.assertThat(response.content().get(1).memberId()).isEqualTo(followerA.getId());
                 softly.assertThat(response.content().get(1).nickname()).isEqualTo(followerA.getNickname());
                 softly.assertThat(response.content().get(1).isFollowing()).isTrue();
+                softly.assertThat(response.content().get(1).isMe()).isFalse();
+                softly.assertThat(response.content().get(2).memberId()).isEqualTo(member.getId());
+                softly.assertThat(response.content().get(2).nickname()).isEqualTo(member.getNickname());
+                softly.assertThat(response.content().get(2).isMe()).isTrue();
                 softly.assertThat(response.isFirst()).isTrue();
                 softly.assertThat(response.isLast()).isTrue();
                 softly.assertThat(response.hasNext()).isFalse();
                 softly.assertThat(response.currentPage()).isEqualTo(0);
-                softly.assertThat(response.currentSize()).isEqualTo(2);
+                softly.assertThat(response.currentSize()).isEqualTo(10);
             });
         }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
@@ -68,26 +68,33 @@ class FollowServiceTest extends IntegrationTest {
             Member followingA = memberTestPersister.builder().save();
             Member followingB = memberTestPersister.builder().save();
 
+            followTestPersister.builder().following(member).follower(follower).save();
             followTestPersister.builder().following(followingA).follower(follower).save();
             followTestPersister.builder().following(followingB).follower(follower).save();
             followTestPersister.builder().following(followingA).follower(member).save();
 
             PageResponse<OtherUserFollowingResponse> response =
-                    followService.getOtherUserFollowings(follower.getId(), 0, 2, member);
+                    followService.getOtherUserFollowings(follower.getId(), 0, 10, member);
 
             assertSoftly(softly -> {
-                softly.assertThat(response.content()).hasSize(2);
+                softly.assertThat(response.content()).hasSize(3);
                 softly.assertThat(response.content().get(0).memberId()).isEqualTo(followingB.getId());
                 softly.assertThat(response.content().get(0).nickname()).isEqualTo(followingB.getNickname());
                 softly.assertThat(response.content().get(0).isFollowing()).isFalse();
+                softly.assertThat(response.content().get(0).isMe()).isFalse();
                 softly.assertThat(response.content().get(1).memberId()).isEqualTo(followingA.getId());
                 softly.assertThat(response.content().get(1).nickname()).isEqualTo(followingA.getNickname());
                 softly.assertThat(response.content().get(1).isFollowing()).isTrue();
+                softly.assertThat(response.content().get(1).isMe()).isFalse();
+                softly.assertThat(response.content().get(2).memberId()).isEqualTo(member.getId());
+                softly.assertThat(response.content().get(2).nickname()).isEqualTo(member.getNickname());
+                softly.assertThat(response.content().get(2).isFollowing()).isFalse();
+                softly.assertThat(response.content().get(2).isMe()).isTrue();
                 softly.assertThat(response.isFirst()).isTrue();
                 softly.assertThat(response.isLast()).isTrue();
                 softly.assertThat(response.hasNext()).isFalse();
                 softly.assertThat(response.currentPage()).isEqualTo(0);
-                softly.assertThat(response.currentSize()).isEqualTo(2);
+                softly.assertThat(response.currentSize()).isEqualTo(10);
             });
         }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
@@ -165,7 +165,8 @@ class FollowControllerTest extends PresentationTest {
                             "http://justdoeat.shop/static/images/profile.png",
                             "coby5502",
                             20,
-                            true
+                            true,
+                            false
                     )),
                     true,
                     true,

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
@@ -390,7 +390,8 @@ class FollowControllerTest extends PresentationTest {
                             "http://justdoeat.shop/static/images/profile.png",
                             "coby5502",
                             20,
-                            true
+                            true,
+                            false
                     )),
                     true,
                     true,

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -76,6 +76,7 @@ class ReviewServiceTest extends IntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(reviewResponse.store().id()).isEqualTo(store.getId());
                 softly.assertThat(reviewResponse.store().isBookmarked()).isTrue();
+                softly.assertThat(reviewResponse.store().storeUrl()).isEqualTo(store.getStoreUrl());
                 softly.assertThat(reviewResponse.review().content()).isEqualTo(review.getContent());
                 softly.assertThat(reviewResponse.review().imagePaths()).isEmpty();
                 softly.assertThat(reviewResponse.writer().id()).isEqualTo(writer.getId());
@@ -199,6 +200,7 @@ class ReviewServiceTest extends IntegrationTest {
                 softly.assertThat(reviewFeedResponses.get(0).reviewFeedThumbnail()).isEqualTo(photoA.getPath());
                 softly.assertThat(reviewFeedResponses.get(0).writer().id()).isEqualTo(writer.getId());
                 softly.assertThat(reviewFeedResponses.get(0).store().id()).isEqualTo(store.getId());
+                softly.assertThat(reviewFeedResponses.get(0).store().storeUrl()).isEqualTo(store.getStoreUrl());
                 softly.assertThat(reviewFeedResponses.get(0).store().isBookmarked()).isTrue();
             });
         }
@@ -496,6 +498,7 @@ class ReviewServiceTest extends IntegrationTest {
                 softly.assertThat(reviewStoreResponse.id()).isEqualTo(store.getId());
                 softly.assertThat(reviewStoreResponse.name()).isEqualTo(store.getStoreName());
                 softly.assertThat(reviewStoreResponse.addressName()).isEqualTo(store.getAddress().getAddressName());
+                softly.assertThat(reviewStoreResponse.storeUrl()).isEqualTo(store.getStoreUrl());
                 softly.assertThat(reviewStoreResponse.isBookmarked()).isFalse();
             });
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -100,6 +100,7 @@ class ReviewControllerTest extends PresentationTest {
                             "한식",
                             "김밥천국",
                             "서울시 종로구 익선동 1234",
+                            "stores.kakao.com",
                             12.1234,
                             false
                     )
@@ -178,6 +179,7 @@ class ReviewControllerTest extends PresentationTest {
                                             "카페",
                                             "가게",
                                             "가게주소",
+                                            "stores.kakao.com",
                                             100.13,
                                             false
                                     )
@@ -282,6 +284,7 @@ class ReviewControllerTest extends PresentationTest {
                                             "카페",
                                             "가게",
                                             "가게주소",
+                                            "stores.kakao.com",
                                             100.13,
                                             false
                                     )
@@ -529,6 +532,7 @@ class ReviewControllerTest extends PresentationTest {
                             "한식",
                             "바다회사랑",
                             "서울시 마포구 동교로 123",
+                            "stores.kakao.com",
                             3.12414,
                             true
                     ),
@@ -584,6 +588,7 @@ class ReviewControllerTest extends PresentationTest {
                             "한식",
                             "바다회사랑",
                             "서울시 마포구 동교로 123",
+                            "stores.kakao.com",
                             3.12414,
                             true
                     ),
@@ -718,6 +723,7 @@ class ReviewControllerTest extends PresentationTest {
                                             "카페",
                                             "가게",
                                             "가게주소",
+                                            "stores.kakao.com",
                                             100.13,
                                             false
                                     )
@@ -943,6 +949,7 @@ class ReviewControllerTest extends PresentationTest {
                                             "카페",
                                             "가게",
                                             "가게주소",
+                                            "stores.kakao.com",
                                             100.13,
                                             false
                                     )
@@ -1168,6 +1175,7 @@ class ReviewControllerTest extends PresentationTest {
                                             "카페",
                                             "가게",
                                             "가게주소",
+                                            "stores.kakao.com",
                                             100.13,
                                             false
                                     )

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
@@ -2,14 +2,17 @@ package org.dinosaur.foodbowl.domain.store.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.dinosaur.foodbowl.domain.store.domain.vo.CategoryType.*;
 
 import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
+import org.dinosaur.foodbowl.domain.store.domain.Category;
 import org.dinosaur.foodbowl.domain.store.domain.School;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.domain.store.domain.vo.Address;
+import org.dinosaur.foodbowl.domain.store.domain.vo.CategoryType;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponse;
 import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.dinosaur.foodbowl.test.PersistenceTest;
@@ -42,7 +45,8 @@ class StoreCustomRepositoryTest extends PersistenceTest {
                 .save();
         Store storeD = storeTestPersister.builder()
                 .address(createAddress(x + 0.04, y))
-                .storeName("김밥세상").save();
+                .storeName("김밥세상")
+                .save();
 
         List<StoreSearchResponse> responses = storeCustomRepository.search(name, x, y, 10);
 
@@ -53,6 +57,8 @@ class StoreCustomRepositoryTest extends PersistenceTest {
             assertThat(responseStoreIds).containsExactly(storeB.getId(), storeD.getId(), storeA.getId());
             assertThat(responseStoreIds).hasSize(3);
             assertThat(responseStoreIds).doesNotContain(storeC.getId());
+            assertThat(responses.get(0).category()).isEqualTo(카페.name());
+            assertThat(responses.get(0).address()).isEqualTo("서울시 서초구 방배동 1234");
         });
     }
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
@@ -2,17 +2,15 @@ package org.dinosaur.foodbowl.domain.store.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.dinosaur.foodbowl.domain.store.domain.vo.CategoryType.*;
+import static org.dinosaur.foodbowl.domain.store.domain.vo.CategoryType.카페;
 
 import java.math.BigDecimal;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.dto.MapCoordinateBoundDto;
-import org.dinosaur.foodbowl.domain.store.domain.Category;
 import org.dinosaur.foodbowl.domain.store.domain.School;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.domain.store.domain.vo.Address;
-import org.dinosaur.foodbowl.domain.store.domain.vo.CategoryType;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponse;
 import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.dinosaur.foodbowl.test.PersistenceTest;

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
@@ -82,7 +82,14 @@ class StoreControllerTest extends PresentationTest {
         @Test
         void 검색_키워드를_포함하는_검색_결과와_200_응답을_반환한다() throws Exception {
             StoreSearchResponses response = StoreSearchResponses.from(
-                    List.of(new StoreSearchResponse(1L, "김밥나라", 1250, 10))
+                    List.of(new StoreSearchResponse(
+                            1L,
+                            "김밥나라",
+                            "서울시 강남구 강남로",
+                            "한식",
+                            1250,
+                            10)
+                    )
             );
             given(storeService.search(anyString(), any(BigDecimal.class), any(BigDecimal.class), anyInt()))
                     .willReturn(response);


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #207 

## 📝 작업 요약

클라이언트에서 요청한 응답 필드 추가

## 🔎 작업 상세 설명

- 가게 조회 시 가게 URL 필드 추가
- 가게 검색 시 주소, 카테고리 필드 추가
- 타인의 팔로워/팔로잉 조회 시 isMe 필드 추가

## 🌟 리뷰 요구 사항

> 10분 !
