### PR TITLE
Feature/#203 DB Replica 적용 시 OSIV에 의해 발생하는 문제를 해결한다.

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -1,14 +1,28 @@
 version: "3.8"
 
 services:
-  db:
-    image: mysql:8.0.33
-    container_name: foodbowl-db
+  source:
+    image: foodbowl-db
+    container_name: foodbowl-source
     ports:
-      - "3306:3306"
-    environment:
-      - MYSQL_DATABASE=foodbowl
-      - MYSQL_ROOT_PASSWORD=admin
+      - 3306:3306
+    env_file:
+      - .env.source
+    volumes:
+      - ./mysql-source.cnf:/etc/mysql/conf.d/mysql.cnf
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+
+  replica:
+    image: foodbowl-db
+    container_name: foodbowl-replica
+    ports:
+      - 3307:3306
+    env_file:
+      - .env.replica
+    volumes:
+      - ./mysql-replica.cnf:/etc/mysql/conf.d/mysql.cnf
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
@@ -17,4 +31,4 @@ services:
     image: redis:7.0.12
     container_name: foodbowl-redis
     ports:
-      - "6379:6379"
+      - 6379:6379

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -15,6 +15,7 @@ import org.dinosaur.foodbowl.domain.member.domain.vo.Nickname;
 import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
 import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
 import org.dinosaur.foodbowl.global.exception.AuthenticationException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -73,8 +74,8 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(Member loginMember) {
-        redisTemplate.delete(String.valueOf(loginMember.getId()));
+    public void logout(LoginMember loginMember) {
+        redisTemplate.delete(String.valueOf(loginMember.id()));
     }
 
     @Transactional

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthController.java
@@ -6,8 +6,8 @@ import org.dinosaur.foodbowl.domain.auth.application.AuthService;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.AppleLoginRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.RenewTokenRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.response.TokenResponse;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,7 +28,7 @@ public class AuthController implements AuthControllerDocs {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@Auth Member loginMember) {
+    public ResponseEntity<Void> logout(@Auth LoginMember loginMember) {
         authService.logout(loginMember);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerDocs.java
@@ -9,8 +9,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.AppleLoginRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.RenewTokenRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.response.TokenResponse;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "인증", description = "인증 API")
@@ -43,7 +43,7 @@ public interface AuthControllerDocs {
             responseCode = "204",
             description = "로그아웃 성공"
     )
-    ResponseEntity<Void> logout(Member loginMember);
+    ResponseEntity<Void> logout(LoginMember loginMember);
 
     @Operation(summary = "인증 토큰 갱신", description = "갱신 토큰을 통해 인증 토큰을 갱신한다.")
     @ApiResponses({

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/application/BlameService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/application/BlameService.java
@@ -12,10 +12,12 @@ import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
 import org.dinosaur.foodbowl.domain.blame.exception.BlameExceptionType;
 import org.dinosaur.foodbowl.domain.blame.persistence.BlameRepository;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.domain.member.exception.MemberExceptionType;
 import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
 import org.dinosaur.foodbowl.domain.review.persistence.ReviewRepository;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,11 +58,13 @@ public class BlameService {
     }
 
     @Transactional
-    public void blame(BlameRequest blameRequest, Member loginMember) {
+    public void blame(BlameRequest blameRequest, LoginMember loginMember) {
+        Member reporter = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
         BlameTarget blameTarget = BlameTarget.from(blameRequest.blameTarget());
-        validateBlame(blameTarget, blameRequest.targetId(), loginMember);
+        validateBlame(blameTarget, blameRequest.targetId(), reporter);
         Blame blame = Blame.builder()
-                .member(loginMember)
+                .member(reporter)
                 .targetId(blameRequest.targetId())
                 .blameTarget(blameTarget)
                 .description(blameRequest.description())

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameController.java
@@ -4,8 +4,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.blame.application.BlameService;
 import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +20,7 @@ public class BlameController implements BlameControllerDocs {
     private final BlameService blameService;
 
     @PostMapping
-    public ResponseEntity<Void> blame(@RequestBody @Valid BlameRequest blameRequest, @Auth Member loginMember) {
+    public ResponseEntity<Void> blame(@RequestBody @Valid BlameRequest blameRequest, @Auth LoginMember loginMember) {
         blameService.blame(blameRequest, loginMember);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerDocs.java
@@ -7,8 +7,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "신고", description = "신고 API")
@@ -54,5 +54,5 @@ public interface BlameControllerDocs {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    ResponseEntity<Void> blame(BlameRequest blameRequest, Member loginMember);
+    ResponseEntity<Void> blame(BlameRequest blameRequest, LoginMember loginMember);
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/presentation/BookmarkController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/presentation/BookmarkController.java
@@ -3,8 +3,8 @@ package org.dinosaur.foodbowl.domain.bookmark.presentation;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.bookmark.application.BookmarkService;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,18 +24,18 @@ public class BookmarkController implements BookmarkControllerDocs {
     @PostMapping
     public ResponseEntity<Void> create(
             @RequestParam @Positive(message = "가게 ID는 양수만 가능합니다.") Long storeId,
-            @Auth Member member
+            @Auth LoginMember loginMember
     ) {
-        bookmarkService.save(storeId, member);
+        bookmarkService.save(storeId, loginMember);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping
     public ResponseEntity<Void> delete(
             @RequestParam @Positive(message = "가게 ID는 양수만 가능합니다.") Long storeId,
-            @Auth Member member
+            @Auth LoginMember loginMember
     ) {
-        bookmarkService.delete(storeId, member);
+        bookmarkService.delete(storeId, loginMember);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/bookmark/presentation/BookmarkControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/bookmark/presentation/BookmarkControllerDocs.java
@@ -8,8 +8,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "북마크", description = "북마크 API")
@@ -43,7 +43,7 @@ public interface BookmarkControllerDocs {
             @Positive(message = "가게 ID는 양수만 가능합니다.")
             Long storeId,
 
-            Member member
+            LoginMember loginMember
     );
 
     @Operation(summary = "북마크 삭제", description = "가게를 사용자의 북마크에서 제거합니다.")
@@ -74,6 +74,6 @@ public interface BookmarkControllerDocs {
             @Positive(message = "가게 ID는 양수만 가능합니다.")
             Long storeId,
 
-            Member member
+            LoginMember loginMember
     );
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowController.java
@@ -8,9 +8,9 @@ import org.dinosaur.foodbowl.domain.follow.dto.response.FollowerResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.FollowingResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowerResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowingResponse;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -33,7 +33,7 @@ public class FollowController implements FollowControllerDocs {
     public ResponseEntity<PageResponse<FollowingResponse>> getFollowings(
             @RequestParam(defaultValue = "0") @PositiveOrZero(message = "페이지는 0이상만 가능합니다.") int page,
             @RequestParam(defaultValue = "15") @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.") int size,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         PageResponse<FollowingResponse> response = followService.getFollowings(page, size, loginMember);
         return ResponseEntity.ok(response);
@@ -44,7 +44,7 @@ public class FollowController implements FollowControllerDocs {
             @PathVariable("memberId") @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
             @RequestParam(defaultValue = "0") @PositiveOrZero(message = "페이지는 0이상만 가능합니다.") int page,
             @RequestParam(defaultValue = "15") @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.") int size,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         PageResponse<OtherUserFollowingResponse> response =
                 followService.getOtherUserFollowings(targetMemberId, page, size, loginMember);
@@ -55,7 +55,7 @@ public class FollowController implements FollowControllerDocs {
     public ResponseEntity<PageResponse<FollowerResponse>> getFollowers(
             @RequestParam(defaultValue = "0") @PositiveOrZero(message = "페이지는 0이상만 가능합니다.") int page,
             @RequestParam(defaultValue = "15") @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.") int size,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         PageResponse<FollowerResponse> response = followService.getFollowers(page, size, loginMember);
         return ResponseEntity.ok(response);
@@ -66,7 +66,7 @@ public class FollowController implements FollowControllerDocs {
             @PathVariable("memberId") @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
             @RequestParam(defaultValue = "0") @PositiveOrZero(message = "페이지는 0이상만 가능합니다.") int page,
             @RequestParam(defaultValue = "15") @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.") int size,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         PageResponse<OtherUserFollowerResponse> response =
                 followService.getOtherUserFollowers(targetMemberId, page, size, loginMember);
@@ -76,7 +76,7 @@ public class FollowController implements FollowControllerDocs {
     @PostMapping("/{memberId}/follow")
     public ResponseEntity<Void> follow(
             @PathVariable(name = "memberId") @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         followService.follow(targetMemberId, loginMember);
         return ResponseEntity.ok().build();
@@ -85,7 +85,7 @@ public class FollowController implements FollowControllerDocs {
     @DeleteMapping("/{memberId}/unfollow")
     public ResponseEntity<Void> unfollow(
             @PathVariable(name = "memberId") @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         followService.unfollow(targetMemberId, loginMember);
         return ResponseEntity.noContent().build();
@@ -94,7 +94,7 @@ public class FollowController implements FollowControllerDocs {
     @DeleteMapping("/followers/{memberId}")
     public ResponseEntity<Void> deleteFollower(
             @PathVariable(name = "memberId") @Positive(message = "ID는 양수만 가능합니다.") Long targetMemberId,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         followService.deleteFollower(targetMemberId, loginMember);
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerDocs.java
@@ -13,9 +13,9 @@ import org.dinosaur.foodbowl.domain.follow.dto.response.FollowerResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.FollowingResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowerResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowingResponse;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "팔로우", description = "팔로우 API")
@@ -50,7 +50,7 @@ public interface FollowControllerDocs {
             @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.")
             int size,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(summary = "다른 회원 팔로잉 목록 조회", description = "정해진 개수만큼 다른 회원의 팔로잉 목록을 조회한다.")
@@ -95,7 +95,7 @@ public interface FollowControllerDocs {
             @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.")
             int size,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(summary = "팔로워 목록 조회", description = "정해진 개수만큼 팔로워 목록을 조회한다.")
@@ -127,7 +127,7 @@ public interface FollowControllerDocs {
             @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.")
             int size,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(summary = "다른 회원 팔로워 목록 조회", description = "정해진 개수만큼 다른 회원의 팔로워 목록을 조회한다.")
@@ -172,7 +172,7 @@ public interface FollowControllerDocs {
             @PositiveOrZero(message = "페이지 크기는 0이상만 가능합니다.")
             int size,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(summary = "팔로우", description = "다른 회원에게 팔로우를 요청한다.")
@@ -205,7 +205,7 @@ public interface FollowControllerDocs {
             @Positive(message = "ID는 양수만 가능합니다.")
             Long targetMemberId,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(summary = "언팔로우", description = "팔로우 되어있는 회원을 언팔로우한다.")
@@ -236,7 +236,7 @@ public interface FollowControllerDocs {
             @Positive(message = "ID는 양수만 가능합니다.")
             Long targetMemberId,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(summary = "팔로워 삭제", description = "나를 팔로워 중인 회원의 팔로우를 삭제한다.")
@@ -267,6 +267,6 @@ public interface FollowControllerDocs {
             @Positive(message = "ID는 양수만 가능합니다.")
             Long targetMemberId,
 
-            Member loginMember
+            LoginMember loginMember
     );
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckController.java
@@ -3,8 +3,8 @@ package org.dinosaur.foodbowl.domain.healthcheck.presentation;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.healthcheck.application.HealthCheckService;
 import org.dinosaur.foodbowl.domain.healthcheck.dto.response.HealthCheckResponse;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,7 +24,7 @@ public class HealthCheckController implements HealthCheckControllerDocs {
     }
 
     @GetMapping("/auth")
-    public ResponseEntity<HealthCheckResponse> authCheck(@Auth Member member) {
-        return ResponseEntity.ok(new HealthCheckResponse("good: " + member.getNickname()));
+    public ResponseEntity<HealthCheckResponse> authCheck(@Auth LoginMember loginMember) {
+        return ResponseEntity.ok(new HealthCheckResponse("good: " + loginMember.id()));
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerDocs.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.dinosaur.foodbowl.domain.healthcheck.dto.response.HealthCheckResponse;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "헬스 체크", description = "헬스 체크 API")
@@ -22,5 +22,5 @@ public interface HealthCheckControllerDocs {
             responseCode = "200",
             description = "회원 인증 성공"
     )
-    ResponseEntity<HealthCheckResponse> authCheck(Member member);
+    ResponseEntity<HealthCheckResponse> authCheck(LoginMember loginMember);
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
@@ -7,13 +7,13 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileImageResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponses;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
 import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -39,14 +39,14 @@ public class MemberController implements MemberControllerDocs {
     @GetMapping("/{id}/profile")
     public ResponseEntity<MemberProfileResponse> getProfile(
             @PathVariable("id") @PositiveOrZero(message = "회원 ID는 양수만 가능합니다.") Long memberId,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MemberProfileResponse response = memberService.getProfile(memberId, loginMember);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/me/profile")
-    public ResponseEntity<MemberProfileResponse> getMyProfile(@Auth Member loginMember) {
+    public ResponseEntity<MemberProfileResponse> getMyProfile(@Auth LoginMember loginMember) {
         MemberProfileResponse response = memberService.getMyProfile(loginMember);
         return ResponseEntity.ok(response);
     }
@@ -56,7 +56,7 @@ public class MemberController implements MemberControllerDocs {
             @RequestParam @NotBlank(message = "검색어는 빈 값이 될 수 없습니다.") String name,
             @RequestParam(defaultValue = "10") @Positive(message = "조회 크기는 1이상만 가능합니다.")
             @Max(value = 50, message = "최대 50개까지 조회가능합니다.") int size,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MemberSearchResponses response = memberService.search(name, size, loginMember);
         return ResponseEntity.ok(response);
@@ -73,7 +73,7 @@ public class MemberController implements MemberControllerDocs {
     @PatchMapping("/profile")
     public ResponseEntity<Void> updateProfile(
             @RequestBody @Valid UpdateProfileRequest updateProfileRequest,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         memberService.updateProfile(updateProfileRequest, loginMember);
         return ResponseEntity.noContent().build();
@@ -82,20 +82,20 @@ public class MemberController implements MemberControllerDocs {
     @PatchMapping(value = "/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<MemberProfileImageResponse> updateProfileImage(
             @RequestPart(name = "image") MultipartFile image,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MemberProfileImageResponse response = memberService.updateProfileImage(image, loginMember);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping(value = "/profile/image")
-    public ResponseEntity<Void> deleteProfileImage(@Auth Member loginMember) {
+    public ResponseEntity<Void> deleteProfileImage(@Auth LoginMember loginMember) {
         memberService.deleteProfileImage(loginMember);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/deactivate")
-    public ResponseEntity<Void> deactivate(@Auth Member loginMember) {
+    public ResponseEntity<Void> deactivate(@Auth LoginMember loginMember) {
         memberService.deactivate(loginMember);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
@@ -12,14 +12,13 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileImageResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponses;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
-import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -52,7 +51,7 @@ public interface MemberControllerDocs {
             @PositiveOrZero(message = "회원 ID는 양수만 가능합니다.")
             Long memberId,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(summary = "나의 프로필 조회", description = "나의 프로필을 조회한다.")
@@ -60,7 +59,7 @@ public interface MemberControllerDocs {
             responseCode = "200",
             description = "나의 프로필 조회 성공"
     )
-    ResponseEntity<MemberProfileResponse> getMyProfile(Member loginMember);
+    ResponseEntity<MemberProfileResponse> getMyProfile(LoginMember loginMember);
 
     @Operation(
             summary = "회원 검색",
@@ -103,7 +102,7 @@ public interface MemberControllerDocs {
             @Positive(message = "조회 크기는 1이상만 가능합니다.")
             @Max(value = 50, message = "최대 50개까지 조회가능합니다.") int size,
 
-            @Auth Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(summary = "닉네임 존재 여부 확인", description = "닉네임이 존재하는지 여부를 확인한다.")
@@ -148,7 +147,7 @@ public interface MemberControllerDocs {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    ResponseEntity<Void> updateProfile(@Valid UpdateProfileRequest updateProfileRequest, Member loginMember);
+    ResponseEntity<Void> updateProfile(@Valid UpdateProfileRequest updateProfileRequest, LoginMember loginMember);
 
     @Operation(
             summary = "프로필 이미지 수정",
@@ -183,7 +182,7 @@ public interface MemberControllerDocs {
             @Parameter(description = "수정할 프로필 이미지")
             MultipartFile thumbnail,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -207,7 +206,7 @@ public interface MemberControllerDocs {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
             )
     })
-    ResponseEntity<Void> deleteProfileImage(Member loginMember);
+    ResponseEntity<Void> deleteProfileImage(LoginMember loginMember);
 
     @Operation(
             summary = "회원 탈퇴",
@@ -217,5 +216,5 @@ public interface MemberControllerDocs {
             responseCode = "204",
             description = "회원 탈퇴 성공"
     )
-    ResponseEntity<Void> deactivate(Member loginMember);
+    ResponseEntity<Void> deactivate(LoginMember loginMember);
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.ReviewService;
 import org.dinosaur.foodbowl.domain.review.dto.request.DeviceCoordinateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
@@ -17,6 +16,7 @@ import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
 import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -50,7 +50,7 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestParam(name = "deviceX") BigDecimal deviceX,
             @RequestParam(name = "deviceY") BigDecimal deviceY,
             @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
         DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
@@ -71,7 +71,7 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestParam(name = "deviceX") BigDecimal deviceX,
             @RequestParam(name = "deviceY") BigDecimal deviceY,
             @RequestParam(name = "pageSize", defaultValue = "20") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
         ReviewFeedPageResponse reviewFeedPageResponse = reviewService.getReviewFeeds(
@@ -93,7 +93,7 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestParam(name = "deviceX") BigDecimal deviceX,
             @RequestParam(name = "deviceY") BigDecimal deviceY,
             @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
         DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
@@ -117,7 +117,7 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestParam(name = "deviceX") BigDecimal deviceX,
             @RequestParam(name = "deviceY") BigDecimal deviceY,
             @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
         DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
@@ -142,7 +142,7 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestParam(name = "deviceX") BigDecimal deviceX,
             @RequestParam(name = "deviceY") BigDecimal deviceY,
             @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
         DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
@@ -165,7 +165,7 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
             @RequestParam(name = "deviceX") BigDecimal deviceX,
             @RequestParam(name = "deviceY") BigDecimal deviceY,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
         StoreReviewResponse storeReviewResponse = reviewService.getReviewsByStore(
@@ -184,10 +184,10 @@ public class ReviewController implements ReviewControllerDocs {
             @PathVariable("id") @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long reviewId,
             @RequestParam(name = "deviceX") BigDecimal deviceX,
             @RequestParam(name = "deviceY") BigDecimal deviceY,
-            @Auth Member member
+            @Auth LoginMember loginMember
     ) {
         DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
-        ReviewResponse reviewResponse = reviewService.getReview(reviewId, member, deviceCoordinateRequest);
+        ReviewResponse reviewResponse = reviewService.getReview(reviewId, loginMember, deviceCoordinateRequest);
         return ResponseEntity.ok(reviewResponse);
     }
 
@@ -196,9 +196,9 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestPart(name = "request") @Valid ReviewCreateRequest reviewCreateRequest,
             @RequestPart(name = "images", required = false)
             @Size(max = 4, message = "사진의 개수는 최대 4개까지 가능합니다.") List<MultipartFile> imageFiles,
-            @Auth Member member
+            @Auth LoginMember loginMember
     ) {
-        reviewService.create(reviewCreateRequest, imageFiles, member);
+        reviewService.create(reviewCreateRequest, imageFiles, loginMember);
         return ResponseEntity.ok().build();
     }
 
@@ -211,18 +211,18 @@ public class ReviewController implements ReviewControllerDocs {
             @RequestPart(name = "request") @Valid ReviewUpdateRequest reviewUpdateRequest,
             @RequestPart(name = "images", required = false)
             @Size(max = 4, message = "사진의 개수는 최대 4개까지 가능합니다.") List<MultipartFile> imageFiles,
-            @Auth Member member
+            @Auth LoginMember loginMember
     ) {
-        reviewService.update(reviewId, reviewUpdateRequest, imageFiles, member);
+        reviewService.update(reviewId, reviewUpdateRequest, imageFiles, loginMember);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(
             @PathVariable("id") @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long reviewId,
-            @Auth Member member
+            @Auth LoginMember loginMember
     ) {
-        reviewService.delete(reviewId, member);
+        reviewService.delete(reviewId, loginMember);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -12,7 +12,6 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.List;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewCreateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.request.ReviewUpdateRequest;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewFeedPageResponse;
@@ -20,6 +19,7 @@ import org.dinosaur.foodbowl.domain.review.dto.response.ReviewPageResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -71,7 +71,7 @@ public interface ReviewControllerDocs {
             @Parameter(description = "사용자 위도", example = "32.3636")
             BigDecimal deviceY,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -124,7 +124,7 @@ public interface ReviewControllerDocs {
             @Positive(message = "페이지 크기는 양수만 가능합니다.")
             int pageSize,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -215,7 +215,7 @@ public interface ReviewControllerDocs {
             @Positive(message = "페이지 크기는 양수만 가능합니다.")
             int pageSize,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -290,7 +290,7 @@ public interface ReviewControllerDocs {
             @Parameter(description = "사용자 위도", example = "32.3636")
             BigDecimal deviceY,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -373,7 +373,7 @@ public interface ReviewControllerDocs {
             @Positive(message = "페이지 크기는 양수만 가능합니다.")
             int pageSize,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -456,7 +456,7 @@ public interface ReviewControllerDocs {
             @Positive(message = "페이지 크기는 양수만 가능합니다.")
             int pageSize,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -552,7 +552,7 @@ public interface ReviewControllerDocs {
             @Positive(message = "페이지 크기는 양수만 가능합니다.")
             int pageSize,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(summary = "리뷰 등록", description = "가게에 해당하는 리뷰를 등록합니다.")
@@ -586,7 +586,7 @@ public interface ReviewControllerDocs {
     ResponseEntity<Void> create(
             @Valid ReviewCreateRequest reviewCreateRequest,
             @Size(max = 4, message = "사진의 개수는 최대 4개까지 가능합니다.") List<MultipartFile> imageFiles,
-            Member member
+            LoginMember loginMember
     );
 
     @Operation(summary = "리뷰 수정",
@@ -638,7 +638,7 @@ public interface ReviewControllerDocs {
 
             @Size(max = 4, message = "사진의 개수는 최대 4개까지 가능합니다.") List<MultipartFile> imageFiles,
 
-            Member member
+            LoginMember loginMember
     );
 
     @Operation(summary = "리뷰 삭제", description = "사용자가 작성한 리뷰를 삭제합니다.")
@@ -669,6 +669,6 @@ public interface ReviewControllerDocs {
             @Positive(message = "리뷰 ID는 양수만 가능합니다.")
             Long reviewId,
 
-            Member member
+            LoginMember loginMember
     );
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
@@ -31,6 +31,7 @@ import org.dinosaur.foodbowl.domain.store.persistence.StoreCustomRepository;
 import org.dinosaur.foodbowl.domain.store.persistence.StoreRepository;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
@@ -87,50 +88,62 @@ public class StoreService {
     public StoreMapBoundResponses getStoresByMemberInMapBounds(
             Long memberId,
             MapCoordinateRequest mapCoordinateRequest,
-            Member loginMember
+            LoginMember loginMember
     ) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+        Member viewer = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+
         MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
         List<Store> stores =
                 storeCustomService.getStoresByMemberInMapBounds(member.getId(), mapCoordinateBoundDto);
-        return convertToStoreMapBoundResponses(stores, loginMember);
+        return convertToStoreMapBoundResponses(stores, viewer);
     }
 
     @Transactional(readOnly = true)
     public StoreMapBoundResponses getStoresByBookmarkInMapBounds(
             MapCoordinateRequest mapCoordinateRequest,
-            Member loginMember
+            LoginMember loginMember
     ) {
+        Member viewer = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+
         MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
         List<Store> stores =
-                storeCustomService.getStoresByBookmarkInMapBounds(loginMember.getId(), mapCoordinateBoundDto);
-        return convertToStoreMapBoundResponses(stores, loginMember);
+                storeCustomService.getStoresByBookmarkInMapBounds(viewer.getId(), mapCoordinateBoundDto);
+        return convertToStoreMapBoundResponses(stores, viewer);
     }
 
     @Transactional(readOnly = true)
     public StoreMapBoundResponses getStoresByFollowingInMapBounds(
             MapCoordinateRequest mapCoordinateRequest,
-            Member loginMember
+            LoginMember loginMember
     ) {
+        Member viewer = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+
         MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
         List<Store> stores =
-                storeCustomService.getStoresByFollowingInMapBounds(loginMember.getId(), mapCoordinateBoundDto);
-        return convertToStoreMapBoundResponses(stores, loginMember);
+                storeCustomService.getStoresByFollowingInMapBounds(viewer.getId(), mapCoordinateBoundDto);
+        return convertToStoreMapBoundResponses(stores, viewer);
     }
 
     @Transactional(readOnly = true)
     public StoreMapBoundResponses getStoresBySchoolInMapBounds(
             Long schoolId,
             MapCoordinateRequest mapCoordinateRequest,
-            Member loginMember
+            LoginMember loginMember
     ) {
         School school = schoolRepository.findById(schoolId)
                 .orElseThrow(() -> new NotFoundException(SchoolExceptionType.NOT_FOUND));
+        Member viewer = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+
         MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
         List<Store> stores =
                 storeCustomService.getStoresBySchoolInMapBounds(school.getId(), mapCoordinateBoundDto);
-        return convertToStoreMapBoundResponses(stores, loginMember);
+        return convertToStoreMapBoundResponses(stores, viewer);
     }
 
     private MapCoordinateBoundDto convertToMapCoordinateBound(MapCoordinateRequest mapCoordinateRequest) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/domain/vo/Address.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/domain/vo/Address.java
@@ -45,6 +45,23 @@ public class Address {
     @Column(name = "coordinate", columnDefinition = "geometry(Point, 4326)")
     private Point coordinate;
 
+    @Builder
+    private Address(
+            String addressName,
+            String region1depthName,
+            String region2depthName,
+            String region3depthName,
+            String roadName,
+            Point coordinate
+    ) {
+        this.addressName = addressName;
+        this.region1depthName = region1depthName;
+        this.region2depthName = region2depthName;
+        this.region3depthName = region3depthName;
+        this.roadName = roadName;
+        this.coordinate = coordinate;
+    }
+
     public static Address of(String storeAddress, Point coordinate) {
         if (storeAddress == null) {
             throw new InvalidArgumentException(StoreExceptionType.ADDRESS_NOT_FOUND);
@@ -63,22 +80,5 @@ public class Address {
                 .roadName(roadName)
                 .coordinate(coordinate)
                 .build();
-    }
-
-    @Builder
-    private Address(
-            String addressName,
-            String region1depthName,
-            String region2depthName,
-            String region3depthName,
-            String roadName,
-            Point coordinate
-    ) {
-        this.addressName = addressName;
-        this.region1depthName = region1depthName;
-        this.region2depthName = region2depthName;
-        this.region3depthName = region3depthName;
-        this.roadName = roadName;
-        this.coordinate = coordinate;
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
@@ -6,13 +6,13 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
 import org.dinosaur.foodbowl.domain.store.application.StoreService;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoriesResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponses;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponses;
 import org.dinosaur.foodbowl.global.presentation.Auth;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -53,7 +53,7 @@ public class StoreController implements StoreControllerDocs {
             @RequestParam(name = "y") BigDecimal y,
             @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
             @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
         StoreMapBoundResponses response =
@@ -67,7 +67,7 @@ public class StoreController implements StoreControllerDocs {
             @RequestParam(name = "y") BigDecimal y,
             @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
             @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
         StoreMapBoundResponses response =
@@ -81,7 +81,7 @@ public class StoreController implements StoreControllerDocs {
             @RequestParam(name = "y") BigDecimal y,
             @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
             @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
         StoreMapBoundResponses response =
@@ -96,7 +96,7 @@ public class StoreController implements StoreControllerDocs {
             @RequestParam(name = "y") BigDecimal y,
             @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
             @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
-            @Auth Member loginMember
+            @Auth LoginMember loginMember
     ) {
         MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
         StoreMapBoundResponses response =

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
@@ -12,11 +12,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoriesResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponses;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponses;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "가게", description = "가게 API")
@@ -144,7 +144,7 @@ public interface StoreControllerDocs {
             @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
             BigDecimal deltaY,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -193,7 +193,7 @@ public interface StoreControllerDocs {
             @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
             BigDecimal deltaY,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -242,7 +242,7 @@ public interface StoreControllerDocs {
             @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
             BigDecimal deltaY,
 
-            Member loginMember
+            LoginMember loginMember
     );
 
     @Operation(
@@ -304,6 +304,6 @@ public interface StoreControllerDocs {
             @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
             BigDecimal deltaY,
 
-            Member loginMember
+            LoginMember loginMember
     );
 }

--- a/src/main/java/org/dinosaur/foodbowl/global/presentation/LoginMember.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/presentation/LoginMember.java
@@ -1,0 +1,4 @@
+package org.dinosaur.foodbowl.global.presentation;
+
+public record LoginMember(Long id) {
+}

--- a/src/main/java/org/dinosaur/foodbowl/global/presentation/MemberArgumentResolver.java
+++ b/src/main/java/org/dinosaur/foodbowl/global/presentation/MemberArgumentResolver.java
@@ -2,7 +2,6 @@ package org.dinosaur.foodbowl.global.presentation;
 
 import lombok.RequiredArgsConstructor;
 import org.dinosaur.foodbowl.domain.auth.exception.AuthExceptionType;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.exception.MemberExceptionType;
 import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
 import org.dinosaur.foodbowl.global.exception.AuthenticationException;
@@ -25,11 +24,11 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.getParameterType().equals(Member.class) && parameter.hasParameterAnnotation(Auth.class);
+        return parameter.getParameterType().equals(LoginMember.class) && parameter.hasParameterAnnotation(Auth.class);
     }
 
     @Override
-    public Object resolveArgument(
+    public LoginMember resolveArgument(
             MethodParameter parameter,
             ModelAndViewContainer mavContainer,
             NativeWebRequest webRequest,
@@ -42,8 +41,11 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
         }
         JwtUser jwtUser = (JwtUser) authentication.getPrincipal();
         Long memberId = parseToLong(jwtUser.getUsername());
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+        return new LoginMember(
+                memberRepository.findById(memberId)
+                        .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND))
+                        .getId()
+        );
     }
 
     private Long parseToLong(String memberId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
         default_batch_fetch_size: 50
         create_empty_composites:
           enabled: true
+    open-in-view: false
 
   servlet:
     multipart:

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
@@ -19,6 +19,7 @@ import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
 import org.dinosaur.foodbowl.domain.member.domain.vo.SocialType;
 import org.dinosaur.foodbowl.domain.member.persistence.MemberRepository;
 import org.dinosaur.foodbowl.global.exception.AuthenticationException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -99,7 +100,7 @@ class AuthServiceTest extends IntegrationTest {
         redisTemplate.opsForValue().set("1", "refreshToken", 10000, TimeUnit.MILLISECONDS);
         ReflectionTestUtils.setField(member, "id", 1L);
 
-        authService.logout(member);
+        authService.logout(new LoginMember(member.getId()));
 
         assertThat(redisTemplate.opsForValue().get("1")).isNull();
     }

--- a/src/test/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/auth/presentation/AuthControllerTest.java
@@ -16,8 +16,8 @@ import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.AppleLoginRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.reqeust.RenewTokenRequest;
 import org.dinosaur.foodbowl.domain.auth.dto.response.TokenResponse;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.PresentationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -82,7 +82,7 @@ class AuthControllerTest extends PresentationTest {
     @Test
     void 로그아웃에_성공하면_204_응답을_반환한다() throws Exception {
         mockingAuthMemberInResolver();
-        willDoNothing().given(authService).logout(any(Member.class));
+        willDoNothing().given(authService).logout(any(LoginMember.class));
 
         mockMvc.perform(post("/v1/auth/logout")
                         .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원)))

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
@@ -10,6 +10,7 @@ import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ class BlameServiceTest extends IntegrationTest {
             Member target = memberTestPersister.builder().save();
             BlameRequest request = new BlameRequest(target.getId(), BlameTarget.MEMBER.name(), "부적절한 닉네임");
 
-            assertThatNoException().isThrownBy(() -> blameService.blame(request, loginMember));
+            assertThatNoException().isThrownBy(() -> blameService.blame(request, new LoginMember(loginMember.getId())));
         }
 
         @Test
@@ -39,7 +40,7 @@ class BlameServiceTest extends IntegrationTest {
             Member target = memberTestPersister.builder().save();
             BlameRequest request = new BlameRequest(target.getId(), "HELLO", "부적절한 닉네임");
 
-            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+            assertThatThrownBy(() -> blameService.blame(request, new LoginMember(loginMember.getId())))
                     .isInstanceOf(InvalidArgumentException.class)
                     .hasMessage("존재하지 않는 신고 타입입니다.");
         }
@@ -50,7 +51,7 @@ class BlameServiceTest extends IntegrationTest {
             Long invalidMemberId = loginMember.getId() + 1;
             BlameRequest request = new BlameRequest(invalidMemberId, BlameTarget.MEMBER.name(), "부적절한 닉네임");
 
-            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+            assertThatThrownBy(() -> blameService.blame(request, new LoginMember(loginMember.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("존재하지 않는 신고 대상입니다.");
         }
@@ -60,7 +61,7 @@ class BlameServiceTest extends IntegrationTest {
             Member loginMember = memberTestPersister.builder().save();
             BlameRequest request = new BlameRequest(1L, BlameTarget.REVIEW.name(), "부적절한 리뷰 내용");
 
-            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+            assertThatThrownBy(() -> blameService.blame(request, new LoginMember(loginMember.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("존재하지 않는 신고 대상입니다.");
         }
@@ -70,7 +71,7 @@ class BlameServiceTest extends IntegrationTest {
             Member loginMember = memberTestPersister.builder().save();
             BlameRequest request = new BlameRequest(loginMember.getId(), BlameTarget.MEMBER.name(), "부적절한 닉네임");
 
-            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+            assertThatThrownBy(() -> blameService.blame(request, new LoginMember(loginMember.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("본인을 신고할 수 없습니다.");
         }
@@ -81,7 +82,7 @@ class BlameServiceTest extends IntegrationTest {
             Review review = reviewTestPersister.builder().member(loginMember).save();
             BlameRequest request = new BlameRequest(review.getId(), BlameTarget.REVIEW.name(), "부적절한 닉네임");
 
-            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+            assertThatThrownBy(() -> blameService.blame(request, new LoginMember(loginMember.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("본인을 신고할 수 없습니다.");
         }
@@ -91,9 +92,9 @@ class BlameServiceTest extends IntegrationTest {
             Member loginMember = memberTestPersister.builder().save();
             Member target = memberTestPersister.builder().save();
             BlameRequest request = new BlameRequest(target.getId(), BlameTarget.MEMBER.name(), "부적절한 닉네임");
-            blameService.blame(request, loginMember);
+            blameService.blame(request, new LoginMember(loginMember.getId()));
 
-            assertThatThrownBy(() -> blameService.blame(request, loginMember))
+            assertThatThrownBy(() -> blameService.blame(request, new LoginMember(loginMember.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("신고 대상에 대한 신고 이력이 존재합니다.");
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/application/BlameServiceTest.java
@@ -35,6 +35,16 @@ class BlameServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 등록되지_않은_회원의_신고라면_예외를_던진다() {
+            Member target = memberTestPersister.builder().save();
+            BlameRequest request = new BlameRequest(target.getId(), "HELLO", "부적절한 닉네임");
+
+            assertThatThrownBy(() -> blameService.blame(request, new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
         void 정상적이지_않은_신고_타입이라면_예외를_던진다() {
             Member loginMember = memberTestPersister.builder().save();
             Member target = memberTestPersister.builder().save();

--- a/src/test/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/blame/presentation/BlameControllerTest.java
@@ -13,8 +13,8 @@ import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.blame.application.BlameService;
 import org.dinosaur.foodbowl.domain.blame.domain.vo.BlameTarget;
 import org.dinosaur.foodbowl.domain.blame.dto.request.BlameRequest;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.PresentationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -52,7 +52,7 @@ class BlameControllerTest extends PresentationTest {
         void 정상적인_요청이라면_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             BlameRequest request = new BlameRequest(1L, BlameTarget.MEMBER.name(), "부적절한 닉네임");
-            willDoNothing().given(blameService).blame(any(BlameRequest.class), any(Member.class));
+            willDoNothing().given(blameService).blame(any(BlameRequest.class), any(LoginMember.class));
 
             mockMvc.perform(post("/v1/blames")
                             .header(AUTHORIZATION, BEARER + accessToken)

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkServiceTest.java
@@ -46,6 +46,15 @@ class BookmarkServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 등록되지_회원의_북마크_추가라면_예외를_던진다() {
+            Store store = storeTestPersister.builder().save();
+
+            assertThatThrownBy(() -> bookmarkService.save(store.getId(), new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
         void 이미_북마크에_추가된_가게라면_예외가_발생한다() {
             Store store = storeTestPersister.builder().save();
             Member member = memberTestPersister.builder().save();
@@ -78,6 +87,15 @@ class BookmarkServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> bookmarkService.delete(-1L, new LoginMember(member.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("일치하는 가게를 찾을 수 없습니다.");
+        }
+
+        @Test
+        void 등록되지_않은_회원의_북마크_삭제라면_예외를_던진다() {
+            Store store = storeTestPersister.builder().save();
+
+            assertThatThrownBy(() -> bookmarkService.delete(store.getId(), new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/application/BookmarkServiceTest.java
@@ -8,6 +8,7 @@ import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.store.domain.Store;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ class BookmarkServiceTest extends IntegrationTest {
             Store store = storeTestPersister.builder().save();
             Member member = memberTestPersister.builder().save();
 
-            bookmarkService.save(store.getId(), member);
+            bookmarkService.save(store.getId(), new LoginMember(member.getId()));
 
             assertThat(bookmarkRepository.findByMemberAndStore(member, store)).isPresent();
         }
@@ -39,7 +40,7 @@ class BookmarkServiceTest extends IntegrationTest {
         void 가게가_존재하지_않으면_예외가_발생한다() {
             Member member = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> bookmarkService.save(-1L, member))
+            assertThatThrownBy(() -> bookmarkService.save(-1L, new LoginMember(member.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("일치하는 가게를 찾을 수 없습니다.");
         }
@@ -48,9 +49,9 @@ class BookmarkServiceTest extends IntegrationTest {
         void 이미_북마크에_추가된_가게라면_예외가_발생한다() {
             Store store = storeTestPersister.builder().save();
             Member member = memberTestPersister.builder().save();
-            bookmarkService.save(store.getId(), member);
+            bookmarkService.save(store.getId(), new LoginMember(member.getId()));
 
-            assertThatThrownBy(() -> bookmarkService.save(store.getId(), member))
+            assertThatThrownBy(() -> bookmarkService.save(store.getId(), new LoginMember(member.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("이미 북마크에 추가된 가게입니다.");
         }
@@ -63,9 +64,9 @@ class BookmarkServiceTest extends IntegrationTest {
         void 북마크_삭제에_성공하면_북마크가_삭제된다() {
             Store store = storeTestPersister.builder().save();
             Member member = memberTestPersister.builder().save();
-            bookmarkService.save(store.getId(), member);
+            bookmarkService.save(store.getId(), new LoginMember(member.getId()));
 
-            bookmarkService.delete(store.getId(), member);
+            bookmarkService.delete(store.getId(), new LoginMember(member.getId()));
 
             assertThat(bookmarkRepository.findByMemberAndStore(member, store)).isEmpty();
         }
@@ -74,7 +75,7 @@ class BookmarkServiceTest extends IntegrationTest {
         void 가게가_존재하지_않으면_예외가_발생한다() {
             Member member = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> bookmarkService.delete(-1L, member))
+            assertThatThrownBy(() -> bookmarkService.delete(-1L, new LoginMember(member.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("일치하는 가게를 찾을 수 없습니다.");
         }
@@ -84,7 +85,7 @@ class BookmarkServiceTest extends IntegrationTest {
             Store store = storeTestPersister.builder().save();
             Member member = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> bookmarkService.delete(store.getId(), member))
+            assertThatThrownBy(() -> bookmarkService.delete(store.getId(), new LoginMember(member.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("해당 가게는 사용자의 북마크에 추가되어 있지 않습니다.");
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/bookmark/presentation/BookmarkControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/bookmark/presentation/BookmarkControllerTest.java
@@ -12,8 +12,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.bookmark.application.BookmarkService;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.PresentationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,7 +45,7 @@ class BookmarkControllerTest extends PresentationTest {
         @Test
         void 정상적으로_추가되면_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
-            willDoNothing().given(bookmarkService).save(anyLong(), any(Member.class));
+            willDoNothing().given(bookmarkService).save(anyLong(), any(LoginMember.class));
 
             mockMvc.perform(post("/v1/bookmarks")
                             .param("storeId", "1")
@@ -90,7 +90,7 @@ class BookmarkControllerTest extends PresentationTest {
         @Test
         void 정상적으로_삭제되면_204_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
-            willDoNothing().given(bookmarkService).delete(anyLong(), any(Member.class));
+            willDoNothing().given(bookmarkService).delete(anyLong(), any(LoginMember.class));
 
             mockMvc.perform(delete("/v1/bookmarks")
                             .param("storeId", "1")

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
@@ -31,32 +31,45 @@ class FollowServiceTest extends IntegrationTest {
     @Autowired
     private FollowRepository followRepository;
 
-    @Test
-    void 나의_팔로잉_목록을_페이징_조회한다() {
-        Member follower = memberTestPersister.builder().save();
-        Member followingA = memberTestPersister.builder().save();
-        Member followingB = memberTestPersister.builder().save();
+    @Nested
+    class 나의_팔로잉_목록_페이징_조회_시 {
 
-        Follow followA = followTestPersister.builder().following(followingA).follower(follower).save();
-        Follow followB = followTestPersister.builder().following(followingB).follower(follower).save();
+        @Test
+        void 나의_팔로잉_목록을_페이징_조회한다() {
+            Member follower = memberTestPersister.builder().save();
+            Member followingA = memberTestPersister.builder().save();
+            Member followingB = memberTestPersister.builder().save();
 
-        PageResponse<FollowingResponse> response = followService.getFollowings(0, 2, new LoginMember(follower.getId()));
+            Follow followA = followTestPersister.builder().following(followingA).follower(follower).save();
+            Follow followB = followTestPersister.builder().following(followingB).follower(follower).save();
 
-        assertSoftly(softly -> {
-            softly.assertThat(response.content())
-                    .usingRecursiveComparison()
-                    .isEqualTo(
-                            List.of(
-                                    FollowingResponse.from(followB.getFollowing()),
-                                    FollowingResponse.from(followA.getFollowing())
-                            )
-                    );
-            softly.assertThat(response.isFirst()).isTrue();
-            softly.assertThat(response.isLast()).isTrue();
-            softly.assertThat(response.hasNext()).isFalse();
-            softly.assertThat(response.currentPage()).isEqualTo(0);
-            softly.assertThat(response.currentSize()).isEqualTo(2);
-        });
+            PageResponse<FollowingResponse> response = followService.getFollowings(0, 2,
+                    new LoginMember(follower.getId()));
+
+            assertSoftly(softly -> {
+                softly.assertThat(response.content())
+                        .usingRecursiveComparison()
+                        .isEqualTo(
+                                List.of(
+                                        FollowingResponse.from(followB.getFollowing()),
+                                        FollowingResponse.from(followA.getFollowing())
+                                )
+                        );
+                softly.assertThat(response.isFirst()).isTrue();
+                softly.assertThat(response.isLast()).isTrue();
+                softly.assertThat(response.hasNext()).isFalse();
+                softly.assertThat(response.currentPage()).isEqualTo(0);
+                softly.assertThat(response.currentSize()).isEqualTo(2);
+            });
+        }
+
+        @Test
+        void 등록되지_않은_회원의_팔로잉_목록_조회라면_예외를_던진다() {
+            assertThatThrownBy(
+                    () -> followService.getFollowings(0, 2, new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
     }
 
     @Nested
@@ -108,34 +121,57 @@ class FollowServiceTest extends IntegrationTest {
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
+
+        @Test
+        void 등록되지_않은_회원의_팔로잉_목록_조회라면_예외를_던진다() {
+            Member targetMember = memberTestPersister.builder().save();
+
+            assertThatThrownBy(
+                    () -> followService.getOtherUserFollowings(targetMember.getId(), 0, 2, new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
     }
 
-    @Test
-    void 나의_팔로워_목록을_페이징_조회한다() {
-        Member following = memberTestPersister.builder().save();
-        Member followerA = memberTestPersister.builder().save();
-        Member followerB = memberTestPersister.builder().save();
+    @Nested
+    class 나의_팔로워_목록_페이징_조회_시 {
 
-        Follow followA = followTestPersister.builder().following(following).follower(followerA).save();
-        Follow followB = followTestPersister.builder().following(following).follower(followerB).save();
+        @Test
+        void 나의_팔로워_목록을_페이징_조회한다() {
+            Member following = memberTestPersister.builder().save();
+            Member followerA = memberTestPersister.builder().save();
+            Member followerB = memberTestPersister.builder().save();
 
-        PageResponse<FollowerResponse> response = followService.getFollowers(0, 2, new LoginMember(following.getId()));
+            Follow followA = followTestPersister.builder().following(following).follower(followerA).save();
+            Follow followB = followTestPersister.builder().following(following).follower(followerB).save();
 
-        assertSoftly(softly -> {
-            softly.assertThat(response.content())
-                    .usingRecursiveComparison()
-                    .isEqualTo(
-                            List.of(
-                                    FollowerResponse.from(followB.getFollower()),
-                                    FollowerResponse.from(followA.getFollower())
-                            )
-                    );
-            softly.assertThat(response.isFirst()).isTrue();
-            softly.assertThat(response.isLast()).isTrue();
-            softly.assertThat(response.hasNext()).isFalse();
-            softly.assertThat(response.currentPage()).isEqualTo(0);
-            softly.assertThat(response.currentSize()).isEqualTo(2);
-        });
+            PageResponse<FollowerResponse> response = followService.getFollowers(0, 2,
+                    new LoginMember(following.getId()));
+
+            assertSoftly(softly -> {
+                softly.assertThat(response.content())
+                        .usingRecursiveComparison()
+                        .isEqualTo(
+                                List.of(
+                                        FollowerResponse.from(followB.getFollower()),
+                                        FollowerResponse.from(followA.getFollower())
+                                )
+                        );
+                softly.assertThat(response.isFirst()).isTrue();
+                softly.assertThat(response.isLast()).isTrue();
+                softly.assertThat(response.hasNext()).isFalse();
+                softly.assertThat(response.currentPage()).isEqualTo(0);
+                softly.assertThat(response.currentSize()).isEqualTo(2);
+            });
+        }
+
+        @Test
+        void 등록되지_않은_회원의_팔로워_목록_조회라면_예외를_던진다() {
+            assertThatThrownBy(
+                    () -> followService.getFollowers(0, 2, new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
     }
 
     @Nested
@@ -186,6 +222,16 @@ class FollowServiceTest extends IntegrationTest {
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
+
+        @Test
+        void 등록되지_않은_회원의_팔로워_목록_조회라면_예외를_던진다() {
+            Member targetMember = memberTestPersister.builder().save();
+
+            assertThatThrownBy(
+                    () -> followService.getOtherUserFollowers(targetMember.getId(), 0, 2, new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
     }
 
     @Nested
@@ -208,6 +254,16 @@ class FollowServiceTest extends IntegrationTest {
 
             assertThatThrownBy(
                     () -> followService.follow(-1L, new LoginMember(loginMember.getId())))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
+        void 등록되지_않은_회원의_팔로우_등록이라면_예외를_던진다() {
+            Member member = memberTestPersister.builder().save();
+
+            assertThatThrownBy(
+                    () -> followService.follow(member.getId(), new LoginMember(-1L)))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
@@ -266,6 +322,16 @@ class FollowServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 등록되지_않은_회원의_팔로우_취소라면_예외를_던진다() {
+            Member member = memberTestPersister.builder().save();
+
+            assertThatThrownBy(
+                    () -> followService.unfollow(member.getId(), new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
         void 팔로우_하지_않은_회원이라면_예외를_던진다() {
             Member loginMember = memberTestPersister.builder().save();
             Member followMember = memberTestPersister.builder().save();
@@ -300,6 +366,16 @@ class FollowServiceTest extends IntegrationTest {
 
             assertThatThrownBy(
                     () -> followService.deleteFollower(-1L, new LoginMember(loginMember.getId())))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
+        void 등록되지_않은_회원의_팔로워_삭제라면_예외를_던진다() {
+            Member member = memberTestPersister.builder().save();
+
+            assertThatThrownBy(
+                    () -> followService.deleteFollower(member.getId(), new LoginMember(-1L)))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/application/FollowServiceTest.java
@@ -16,6 +16,7 @@ import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.common.response.PageResponse;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class FollowServiceTest extends IntegrationTest {
         Follow followA = followTestPersister.builder().following(followingA).follower(follower).save();
         Follow followB = followTestPersister.builder().following(followingB).follower(follower).save();
 
-        PageResponse<FollowingResponse> response = followService.getFollowings(0, 2, follower);
+        PageResponse<FollowingResponse> response = followService.getFollowings(0, 2, new LoginMember(follower.getId()));
 
         assertSoftly(softly -> {
             softly.assertThat(response.content())
@@ -74,7 +75,7 @@ class FollowServiceTest extends IntegrationTest {
             followTestPersister.builder().following(followingA).follower(member).save();
 
             PageResponse<OtherUserFollowingResponse> response =
-                    followService.getOtherUserFollowings(follower.getId(), 0, 10, member);
+                    followService.getOtherUserFollowings(follower.getId(), 0, 10, new LoginMember(member.getId()));
 
             assertSoftly(softly -> {
                 softly.assertThat(response.content()).hasSize(3);
@@ -102,7 +103,8 @@ class FollowServiceTest extends IntegrationTest {
         void 등록되지_않은_회원이라면_예외를_던진다() {
             Member loginMember = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> followService.getOtherUserFollowings(-1L, 0, 2, loginMember))
+            assertThatThrownBy(
+                    () -> followService.getOtherUserFollowings(-1L, 0, 2, new LoginMember(loginMember.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
@@ -117,7 +119,7 @@ class FollowServiceTest extends IntegrationTest {
         Follow followA = followTestPersister.builder().following(following).follower(followerA).save();
         Follow followB = followTestPersister.builder().following(following).follower(followerB).save();
 
-        PageResponse<FollowerResponse> response = followService.getFollowers(0, 2, following);
+        PageResponse<FollowerResponse> response = followService.getFollowers(0, 2, new LoginMember(following.getId()));
 
         assertSoftly(softly -> {
             softly.assertThat(response.content())
@@ -152,7 +154,7 @@ class FollowServiceTest extends IntegrationTest {
             followTestPersister.builder().following(followerA).follower(member).save();
 
             PageResponse<OtherUserFollowerResponse> response =
-                    followService.getOtherUserFollowers(following.getId(), 0, 10, member);
+                    followService.getOtherUserFollowers(following.getId(), 0, 10, new LoginMember(member.getId()));
 
             assertSoftly(softly -> {
                 softly.assertThat(response.content()).hasSize(3);
@@ -179,7 +181,8 @@ class FollowServiceTest extends IntegrationTest {
         void 등록되지_않은_회원이라면_예외를_던진다() {
             Member loginMember = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> followService.getOtherUserFollowers(-1L, 0, 2, loginMember))
+            assertThatThrownBy(
+                    () -> followService.getOtherUserFollowers(-1L, 0, 2, new LoginMember(loginMember.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
@@ -193,7 +196,7 @@ class FollowServiceTest extends IntegrationTest {
             Member loginMember = memberTestPersister.builder().save();
             Member other = memberTestPersister.builder().save();
 
-            followService.follow(other.getId(), loginMember);
+            followService.follow(other.getId(), new LoginMember(loginMember.getId()));
 
             Optional<Follow> follow = followRepository.findByFollowingAndFollower(other, loginMember);
             assertThat(follow).isPresent();
@@ -203,7 +206,8 @@ class FollowServiceTest extends IntegrationTest {
         void 등록되지_않은_회원이라면_예외를_던진다() {
             Member loginMember = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> followService.follow(-1L, loginMember))
+            assertThatThrownBy(
+                    () -> followService.follow(-1L, new LoginMember(loginMember.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
@@ -212,7 +216,8 @@ class FollowServiceTest extends IntegrationTest {
         void 자신을_팔로우한다면_예외를_던진다() {
             Member loginMember = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> followService.follow(loginMember.getId(), loginMember))
+            assertThatThrownBy(
+                    () -> followService.follow(loginMember.getId(), new LoginMember(loginMember.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("본인을 팔로우할 수 없습니다.");
         }
@@ -226,7 +231,8 @@ class FollowServiceTest extends IntegrationTest {
                     .follower(loginMember)
                     .save();
 
-            assertThatThrownBy(() -> followService.follow(other.getId(), loginMember))
+            assertThatThrownBy(
+                    () -> followService.follow(other.getId(), new LoginMember(loginMember.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("이미 팔로우한 회원입니다.");
         }
@@ -244,7 +250,7 @@ class FollowServiceTest extends IntegrationTest {
                     .follower(loginMember)
                     .save();
 
-            followService.unfollow(followMember.getId(), loginMember);
+            followService.unfollow(followMember.getId(), new LoginMember(loginMember.getId()));
 
             assertThat(followRepository.findById(follow.getId())).isNotPresent();
         }
@@ -253,7 +259,8 @@ class FollowServiceTest extends IntegrationTest {
         void 등록되지_않은_회원이라면_에외를_던진다() {
             Member loginMember = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> followService.unfollow(-1L, loginMember))
+            assertThatThrownBy(
+                    () -> followService.unfollow(-1L, new LoginMember(loginMember.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
@@ -263,7 +270,8 @@ class FollowServiceTest extends IntegrationTest {
             Member loginMember = memberTestPersister.builder().save();
             Member followMember = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> followService.unfollow(followMember.getId(), loginMember))
+            assertThatThrownBy(
+                    () -> followService.unfollow(followMember.getId(), new LoginMember(loginMember.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("팔로우 하지 않은 회원입니다.");
         }
@@ -281,7 +289,7 @@ class FollowServiceTest extends IntegrationTest {
                     .follower(followMember)
                     .save();
 
-            followService.deleteFollower(followMember.getId(), loginMember);
+            followService.deleteFollower(followMember.getId(), new LoginMember(loginMember.getId()));
 
             assertThat(followRepository.findById(follow.getId())).isNotPresent();
         }
@@ -290,7 +298,8 @@ class FollowServiceTest extends IntegrationTest {
         void 등록되지_않은_회원이라면_예외를_던진다() {
             Member loginMember = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> followService.deleteFollower(-1L, loginMember))
+            assertThatThrownBy(
+                    () -> followService.deleteFollower(-1L, new LoginMember(loginMember.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
@@ -300,7 +309,8 @@ class FollowServiceTest extends IntegrationTest {
             Member loginMember = memberTestPersister.builder().save();
             Member followMember = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> followService.deleteFollower(followMember.getId(), loginMember))
+            assertThatThrownBy(
+                    () -> followService.deleteFollower(followMember.getId(), new LoginMember(loginMember.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("나를 팔로우 하지 않은 회원입니다.");
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/follow/presentation/FollowControllerTest.java
@@ -24,8 +24,8 @@ import org.dinosaur.foodbowl.domain.follow.dto.response.FollowerResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.FollowingResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowerResponse;
 import org.dinosaur.foodbowl.domain.follow.dto.response.OtherUserFollowingResponse;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.global.common.response.PageResponse;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.PresentationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -75,7 +75,7 @@ class FollowControllerTest extends PresentationTest {
                     0,
                     1
             );
-            given(followService.getFollowings(anyInt(), anyInt(), any(Member.class))).willReturn(response);
+            given(followService.getFollowings(anyInt(), anyInt(), any(LoginMember.class))).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/follows/followings")
                             .header(AUTHORIZATION, BEARER + accessToken)
@@ -174,7 +174,7 @@ class FollowControllerTest extends PresentationTest {
                     0,
                     1
             );
-            given(followService.getOtherUserFollowings(anyLong(), anyInt(), anyInt(), any(Member.class)))
+            given(followService.getOtherUserFollowings(anyLong(), anyInt(), anyInt(), any(LoginMember.class)))
                     .willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/follows/{memberId}/followings", 1L)
@@ -300,7 +300,7 @@ class FollowControllerTest extends PresentationTest {
                     0,
                     1
             );
-            given(followService.getFollowers(anyInt(), anyInt(), any(Member.class))).willReturn(response);
+            given(followService.getFollowers(anyInt(), anyInt(), any(LoginMember.class))).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/follows/followers")
                             .header(AUTHORIZATION, BEARER + accessToken)
@@ -399,7 +399,7 @@ class FollowControllerTest extends PresentationTest {
                     0,
                     1
             );
-            given(followService.getOtherUserFollowers(anyLong(), anyInt(), anyInt(), any(Member.class)))
+            given(followService.getOtherUserFollowers(anyLong(), anyInt(), anyInt(), any(LoginMember.class)))
                     .willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/follows/{memberId}/followers", 1L)
@@ -512,7 +512,7 @@ class FollowControllerTest extends PresentationTest {
         void 팔로우를_수행하면_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             willDoNothing().given(followService)
-                    .follow(anyLong(), any(Member.class));
+                    .follow(anyLong(), any(LoginMember.class));
 
             mockMvc.perform(post("/v1/follows/{memberId}/follow", 1L)
                             .header(AUTHORIZATION, BEARER + accessToken))
@@ -554,7 +554,7 @@ class FollowControllerTest extends PresentationTest {
         void 언팔로우를_수행하면_204_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             willDoNothing().given(followService)
-                    .unfollow(anyLong(), any(Member.class));
+                    .unfollow(anyLong(), any(LoginMember.class));
 
             mockMvc.perform(delete("/v1/follows/{memberId}/unfollow", 1L)
                             .header(AUTHORIZATION, BEARER + accessToken))
@@ -596,7 +596,7 @@ class FollowControllerTest extends PresentationTest {
         void 팔로워_삭제를_수행하면_204_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             willDoNothing().given(followService)
-                    .follow(anyLong(), any(Member.class));
+                    .follow(anyLong(), any(LoginMember.class));
 
             mockMvc.perform(delete("/v1/follows/followers/{memberId}", 1L)
                             .header(AUTHORIZATION, BEARER + accessToken))

--- a/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/healthcheck/presentation/HealthCheckControllerTest.java
@@ -48,7 +48,7 @@ class HealthCheckControllerTest extends PresentationTest {
         mockMvc.perform(get("/v1/health-check/auth")
                         .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, ROLE_회원)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("good: " + member.getNickname()))
+                .andExpect(jsonPath("$.status").value("good: " + member.getId()))
                 .andDo(print());
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberServiceTest.java
@@ -30,6 +30,7 @@ import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.FileException;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.dinosaur.foodbowl.test.file.FileTestUtils;
 import org.junit.jupiter.api.Nested;
@@ -62,7 +63,8 @@ class MemberServiceTest extends IntegrationTest {
         void 나의_프로필이라면_나의_프로필_여부는_true_팔로잉_여부는_false_이다() {
             Member loginMember = memberTestPersister.builder().save();
 
-            MemberProfileResponse response = memberService.getProfile(loginMember.getId(), loginMember);
+            MemberProfileResponse response =
+                    memberService.getProfile(loginMember.getId(), new LoginMember(loginMember.getId()));
 
             assertSoftly(softly -> {
                 softly.assertThat(response.id()).isEqualTo(loginMember.getId());
@@ -79,7 +81,8 @@ class MemberServiceTest extends IntegrationTest {
             Member profileTargetMember = memberTestPersister.builder().save();
             followTestPersister.builder().following(profileTargetMember).follower(loginMember).save();
 
-            MemberProfileResponse response = memberService.getProfile(profileTargetMember.getId(), loginMember);
+            MemberProfileResponse response =
+                    memberService.getProfile(profileTargetMember.getId(), new LoginMember(loginMember.getId()));
 
             assertSoftly(softly -> {
                 softly.assertThat(response.id()).isEqualTo(profileTargetMember.getId());
@@ -95,7 +98,8 @@ class MemberServiceTest extends IntegrationTest {
             Member loginMember = memberTestPersister.builder().save();
             Member profileTargetMember = memberTestPersister.builder().save();
 
-            MemberProfileResponse response = memberService.getProfile(profileTargetMember.getId(), loginMember);
+            MemberProfileResponse response =
+                    memberService.getProfile(profileTargetMember.getId(), new LoginMember(loginMember.getId()));
 
             assertSoftly(softly -> {
                 softly.assertThat(response.id()).isEqualTo(profileTargetMember.getId());
@@ -110,7 +114,7 @@ class MemberServiceTest extends IntegrationTest {
         void 등록되지_않은_회원이라면_예외를_던진다() {
             Member loginMember = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> memberService.getProfile(-1L, loginMember))
+            assertThatThrownBy(() -> memberService.getProfile(-1L, new LoginMember(loginMember.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
@@ -122,7 +126,7 @@ class MemberServiceTest extends IntegrationTest {
         Member otherMember = memberTestPersister.builder().save();
         followTestPersister.builder().following(otherMember).follower(loginMember).save();
 
-        MemberProfileResponse response = memberService.getMyProfile(loginMember);
+        MemberProfileResponse response = memberService.getMyProfile(new LoginMember(loginMember.getId()));
 
         assertSoftly(softly -> {
             softly.assertThat(response.id()).isEqualTo(loginMember.getId());
@@ -146,7 +150,7 @@ class MemberServiceTest extends IntegrationTest {
             Member memberB = memberTestPersister.builder().nickname("gray").save();
             followTestPersister.builder().follower(dazzle).following(memberB).save();
 
-            MemberSearchResponses responses = memberService.search(name, 10, dazzle);
+            MemberSearchResponses responses = memberService.search(name, 10, new LoginMember(dazzle.getId()));
             List<MemberSearchResponse> memberSearchResponses = responses.memberSearchResponses();
 
             assertSoftly(softly -> {
@@ -172,7 +176,7 @@ class MemberServiceTest extends IntegrationTest {
             String name = "gray";
             Member member = memberTestPersister.builder().nickname("gray").save();
 
-            MemberSearchResponses responses = memberService.search(name, 10, member);
+            MemberSearchResponses responses = memberService.search(name, 10, new LoginMember(member.getId()));
             List<MemberSearchResponse> memberSearchResponses = responses.memberSearchResponses();
 
             assertSoftly(softly -> {
@@ -215,7 +219,7 @@ class MemberServiceTest extends IntegrationTest {
             Member member = memberTestPersister.builder().save();
             UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("hello", "friend");
 
-            memberService.updateProfile(updateProfileRequest, member);
+            memberService.updateProfile(updateProfileRequest, new LoginMember(member.getId()));
 
             assertSoftly(softly -> {
                 softly.assertThat(member.getNickname()).isEqualTo("hello");
@@ -228,7 +232,7 @@ class MemberServiceTest extends IntegrationTest {
             Member member = memberTestPersister.builder().nickname("hello").save();
             UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("hello", "friend");
 
-            memberService.updateProfile(updateProfileRequest, member);
+            memberService.updateProfile(updateProfileRequest, new LoginMember(member.getId()));
 
             assertSoftly(softly -> {
                 softly.assertThat(member.getNickname()).isEqualTo("hello");
@@ -241,7 +245,7 @@ class MemberServiceTest extends IntegrationTest {
             Member member = memberTestPersister.builder().save();
             UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("하 이", "friend");
 
-            assertThatThrownBy(() -> memberService.updateProfile(updateProfileRequest, member))
+            assertThatThrownBy(() -> memberService.updateProfile(updateProfileRequest, new LoginMember(member.getId())))
                     .isInstanceOf(InvalidArgumentException.class)
                     .hasMessage("한글, 영어, 숫자로 구성된 1글자 이상, 10글자 이하의 닉네임이 아닙니다.");
         }
@@ -251,7 +255,7 @@ class MemberServiceTest extends IntegrationTest {
             Member member = memberTestPersister.builder().save();
             UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("hello", "  ");
 
-            assertThatThrownBy(() -> memberService.updateProfile(updateProfileRequest, member))
+            assertThatThrownBy(() -> memberService.updateProfile(updateProfileRequest, new LoginMember(member.getId())))
                     .isInstanceOf(InvalidArgumentException.class)
                     .hasMessage("공백만으로 이루어지지 않은 1글자 이상, 100글자 이하의 한 줄 소개가 아닙니다.");
         }
@@ -262,7 +266,7 @@ class MemberServiceTest extends IntegrationTest {
             Member member = memberTestPersister.builder().save();
             UpdateProfileRequest updateProfileRequest = new UpdateProfileRequest("hello", "friend");
 
-            assertThatThrownBy(() -> memberService.updateProfile(updateProfileRequest, member))
+            assertThatThrownBy(() -> memberService.updateProfile(updateProfileRequest, new LoginMember(member.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("이미 존재하는 닉네임입니다.");
         }
@@ -276,7 +280,8 @@ class MemberServiceTest extends IntegrationTest {
             Member member = memberTestPersister.builder().save();
             MultipartFile multipartFile = FileTestUtils.generateMultiPartFile("image");
 
-            MemberProfileImageResponse response = memberService.updateProfileImage(multipartFile, member);
+            MemberProfileImageResponse response =
+                    memberService.updateProfileImage(multipartFile, new LoginMember(member.getId()));
 
             Optional<MemberThumbnail> memberThumbnail = memberThumbnailRepository.findByMember(member);
             assertSoftly(softly -> {
@@ -295,7 +300,8 @@ class MemberServiceTest extends IntegrationTest {
             memberThumbnailTestPersister.builder().member(member).thumbnail(thumbnail).save();
 
             MultipartFile newFile = FileTestUtils.generateMultiPartFile("image");
-            MemberProfileImageResponse response = memberService.updateProfileImage(newFile, member);
+            MemberProfileImageResponse response =
+                    memberService.updateProfileImage(newFile, new LoginMember(member.getId()));
 
             Optional<MemberThumbnail> memberThumbnail = memberThumbnailRepository.findByMember(member);
             assertSoftly(softly -> {
@@ -311,7 +317,7 @@ class MemberServiceTest extends IntegrationTest {
         void 요청_프로필_이미지가_없으면_예외를_던진다() {
             Member member = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> memberService.updateProfileImage(null, member))
+            assertThatThrownBy(() -> memberService.updateProfileImage(null, new LoginMember(member.getId())))
                     .isInstanceOf(FileException.class)
                     .hasMessage("파일이 존재하지 않습니다.");
         }
@@ -324,7 +330,7 @@ class MemberServiceTest extends IntegrationTest {
         void 기존_프로필_이미지가_없으면_없는_상태를_유지한다() {
             Member member = memberTestPersister.builder().save();
 
-            memberService.deleteProfileImage(member);
+            memberService.deleteProfileImage(new LoginMember(member.getId()));
 
             Optional<MemberThumbnail> memberThumbnail = memberThumbnailRepository.findByMember(member);
             assertThat(memberThumbnail).isNotPresent();
@@ -337,7 +343,7 @@ class MemberServiceTest extends IntegrationTest {
             Thumbnail thumbnail = thumbnailService.save(multipartFile);
             memberThumbnailTestPersister.builder().member(member).thumbnail(thumbnail).save();
 
-            memberService.deleteProfileImage(member);
+            memberService.deleteProfileImage(new LoginMember(member.getId()));
 
             Optional<MemberThumbnail> memberThumbnail = memberThumbnailRepository.findByMember(member);
             assertSoftly(softly -> {
@@ -371,7 +377,7 @@ class MemberServiceTest extends IntegrationTest {
         Review review = reviewTestPersister.builder().member(member).save();
         reviewPhotoTestPersister.builder().review(review).photo(photo).save();
 
-        assertThatNoException().isThrownBy(() -> memberService.deactivate(member));
+        assertThatNoException().isThrownBy(() -> memberService.deactivate(new LoginMember(member.getId())));
         assertSoftly(softly -> {
             softly.assertThat(new File(thumbnail.getPath())).doesNotExist();
             softly.assertThat(new File(photo.getPath())).doesNotExist();

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
 import org.dinosaur.foodbowl.domain.member.application.MemberService;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.member.domain.vo.RoleType;
 import org.dinosaur.foodbowl.domain.member.dto.request.UpdateProfileRequest;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileImageResponse;
@@ -29,6 +28,7 @@ import org.dinosaur.foodbowl.domain.member.dto.response.MemberProfileResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponse;
 import org.dinosaur.foodbowl.domain.member.dto.response.MemberSearchResponses;
 import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.PresentationTest;
 import org.dinosaur.foodbowl.test.file.FileTestUtils;
 import org.junit.jupiter.api.Nested;
@@ -82,7 +82,7 @@ class MemberControllerTest extends PresentationTest {
                     true,
                     false
             );
-            given(memberService.getProfile(anyLong(), any(Member.class))).willReturn(response);
+            given(memberService.getProfile(anyLong(), any(LoginMember.class))).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/members/{memberId}/profile", 1L)
                             .header(AUTHORIZATION, BEARER + accessToken))
@@ -133,7 +133,7 @@ class MemberControllerTest extends PresentationTest {
                 true,
                 false
         );
-        given(memberService.getMyProfile(any(Member.class))).willReturn(response);
+        given(memberService.getMyProfile(any(LoginMember.class))).willReturn(response);
 
         MvcResult mvcResult = mockMvc.perform(get("/v1/members/me/profile")
                         .header(AUTHORIZATION, BEARER + jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원)))
@@ -157,7 +157,7 @@ class MemberControllerTest extends PresentationTest {
             MemberSearchResponses response = new MemberSearchResponses(
                     List.of(new MemberSearchResponse(1L, "gray", "https://image.com", 10, true, false))
             );
-            given(memberService.search(anyString(), anyInt(), any(Member.class)))
+            given(memberService.search(anyString(), anyInt(), any(LoginMember.class)))
                     .willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/members/search")
@@ -288,7 +288,7 @@ class MemberControllerTest extends PresentationTest {
         void 프로필_정보_수정에_성공하면_204_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             UpdateProfileRequest request = new UpdateProfileRequest("coby5502", "동네 맛집 탐험을 좋아하는 아저씨에요.");
-            willDoNothing().given(memberService).updateProfile(any(UpdateProfileRequest.class), any(Member.class));
+            willDoNothing().given(memberService).updateProfile(any(UpdateProfileRequest.class), any(LoginMember.class));
 
             mockMvc.perform(patch("/v1/members/profile")
                             .header(AUTHORIZATION, BEARER + accessToken)
@@ -323,7 +323,8 @@ class MemberControllerTest extends PresentationTest {
             mockingAuthMemberInResolver();
             MockMultipartFile file = (MockMultipartFile) FileTestUtils.generateMultiPartFile("image");
             MemberProfileImageResponse expected = new MemberProfileImageResponse("http://justdoeat.shop/image.png");
-            given(memberService.updateProfileImage(any(MultipartFile.class), any(Member.class))).willReturn(expected);
+            given(memberService.updateProfileImage(any(MultipartFile.class), any(LoginMember.class))).willReturn(
+                    expected);
 
             MvcResult mvcResult = mockMvc.perform(multipart(HttpMethod.PATCH, "/v1/members/profile/image")
                             .file(file)
@@ -353,7 +354,7 @@ class MemberControllerTest extends PresentationTest {
     @Test
     void 프로필_이미지_삭제에_성공하면_204_응답을_반환한다() throws Exception {
         mockingAuthMemberInResolver();
-        willDoNothing().given(memberService).deleteProfileImage(any(Member.class));
+        willDoNothing().given(memberService).deleteProfileImage(any(LoginMember.class));
         String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
 
         mockMvc.perform(delete("/v1/members/profile/image")
@@ -365,7 +366,7 @@ class MemberControllerTest extends PresentationTest {
     @Test
     void 회원_탈퇴에_성공하면_204_응답을_반환한다() throws Exception {
         mockingAuthMemberInResolver();
-        willDoNothing().given(memberService).deactivate(any(Member.class));
+        willDoNothing().given(memberService).deactivate(any(LoginMember.class));
         String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
 
         mockMvc.perform(delete("/v1/members/deactivate")

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewServiceTest.java
@@ -30,6 +30,7 @@ import org.dinosaur.foodbowl.domain.store.domain.vo.Address;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.dinosaur.foodbowl.test.file.FileTestUtils;
@@ -69,7 +70,7 @@ class ReviewServiceTest extends IntegrationTest {
 
             ReviewResponse reviewResponse = reviewService.getReview(
                     review.getId(),
-                    loginMember,
+                    new LoginMember(loginMember.getId()),
                     deviceCoordinateRequest
             );
 
@@ -103,7 +104,7 @@ class ReviewServiceTest extends IntegrationTest {
 
             ReviewResponse reviewResponse = reviewService.getReview(
                     review.getId(),
-                    loginMember,
+                    new LoginMember(loginMember.getId()),
                     deviceCoordinateRequest
             );
 
@@ -136,7 +137,7 @@ class ReviewServiceTest extends IntegrationTest {
 
             ReviewResponse reviewResponse = reviewService.getReview(
                     review.getId(),
-                    loginMember,
+                    new LoginMember(loginMember.getId()),
                     deviceCoordinateRequest
             );
 
@@ -161,7 +162,12 @@ class ReviewServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            assertThatThrownBy(() -> reviewService.getReview(wrongReviewId, member, deviceCoordinateRequest))
+            assertThatThrownBy(() ->
+                    reviewService.getReview(
+                            wrongReviewId,
+                            new LoginMember(member.getId()),
+                            deviceCoordinateRequest
+                    ))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("일치하는 리뷰를 찾을 수 없습니다.");
         }
@@ -189,7 +195,7 @@ class ReviewServiceTest extends IntegrationTest {
                     null,
                     10,
                     deviceCoordinateRequest,
-                    writer
+                    new LoginMember(writer.getId())
             );
 
             List<ReviewFeedResponse> reviewFeedResponses = reviewFeedPageResponse.reviewFeedResponses();
@@ -219,7 +225,7 @@ class ReviewServiceTest extends IntegrationTest {
                     null,
                     10,
                     deviceCoordinateRequest,
-                    writer
+                    new LoginMember(writer.getId())
             );
 
             assertThat(reviewFeedPageResponse.reviewFeedResponses()).isEmpty();
@@ -250,7 +256,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             ))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
@@ -281,7 +287,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -318,7 +324,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -367,7 +373,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -415,7 +421,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -452,7 +458,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             assertSoftly(softly -> {
@@ -480,7 +486,7 @@ class ReviewServiceTest extends IntegrationTest {
                     null,
                     10,
                     new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<StoreReviewContentResponse> reviewContentResponses = storeReviewResponse.storeReviewContentResponses();
@@ -517,7 +523,7 @@ class ReviewServiceTest extends IntegrationTest {
                     null,
                     10,
                     new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<StoreReviewContentResponse> reviewContentResponses = storeReviewResponse.storeReviewContentResponses();
@@ -554,7 +560,7 @@ class ReviewServiceTest extends IntegrationTest {
                     null,
                     10,
                     new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<StoreReviewContentResponse> reviewContentResponses = storeReviewResponse.storeReviewContentResponses();
@@ -584,7 +590,7 @@ class ReviewServiceTest extends IntegrationTest {
                     null,
                     10,
                     new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<StoreReviewContentResponse> result = storeReviewResponse.storeReviewContentResponses();
@@ -610,7 +616,7 @@ class ReviewServiceTest extends IntegrationTest {
                     null,
                     10,
                     new DeviceCoordinateRequest(BigDecimal.valueOf(124.124), BigDecimal.valueOf(37.41424)),
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<StoreReviewContentResponse> result = storeReviewResponse.storeReviewContentResponses();
@@ -643,6 +649,7 @@ class ReviewServiceTest extends IntegrationTest {
         @ValueSource(strings = {"", " ", "test", "all", "friend"})
         void 일치하는_리뷰_필터링_조건이_없으면_예외가_발생한다(String reviewFilter) {
             Store store = storeTestPersister.builder().save();
+            Member member = memberTestPersister.builder().save();
 
             assertThatThrownBy(() -> reviewService.getReviewsByStore(
                     store.getId(),
@@ -650,7 +657,7 @@ class ReviewServiceTest extends IntegrationTest {
                     null,
                     10,
                     null,
-                    null
+                    new LoginMember(member.getId())
             ))
                     .isInstanceOf(InvalidArgumentException.class)
                     .hasMessage("일치하는 리뷰 필터링 조건이 없습니다.");
@@ -685,7 +692,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -721,7 +728,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -771,7 +778,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -815,7 +822,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -852,7 +859,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -901,7 +908,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -949,7 +956,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -989,7 +996,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             ))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("존재하지 않는 학교입니다.");
@@ -1022,7 +1029,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -1060,7 +1067,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -1110,7 +1117,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -1159,7 +1166,7 @@ class ReviewServiceTest extends IntegrationTest {
                     mapCoordinateRequest,
                     deviceCoordinateRequest,
                     10,
-                    member
+                    new LoginMember(member.getId())
             );
 
             List<ReviewResponse> result = response.reviews();
@@ -1183,7 +1190,8 @@ class ReviewServiceTest extends IntegrationTest {
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
 
-            Long reviewId = reviewService.create(reviewCreateRequest, null, member).getId();
+            Long reviewId = reviewService.create(reviewCreateRequest, null, new LoginMember(member.getId()))
+                    .getId();
 
             assertThat(reviewId).isNotNull();
         }
@@ -1194,7 +1202,8 @@ class ReviewServiceTest extends IntegrationTest {
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
 
-            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, member).getId();
+            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()))
+                    .getId();
 
             assertThat(reviewId).isNotNull();
             FileTestUtils.cleanUp();
@@ -1204,11 +1213,13 @@ class ReviewServiceTest extends IntegrationTest {
         void 이미_생성된_가게인_경우에도_정상적으로_저장한다() {
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
-            reviewService.create(reviewCreateRequest, null, member);
+            reviewService.create(reviewCreateRequest, null, new LoginMember(member.getId()));
             ReviewCreateRequest otherReviewCreateRequest = generateReviewCreateRequest();
             Member otherMember = memberTestPersister.builder().save();
 
-            Long savedReviewId = reviewService.create(otherReviewCreateRequest, null, otherMember).getId();
+            Long savedReviewId =
+                    reviewService.create(otherReviewCreateRequest, null, new LoginMember(otherMember.getId()))
+                            .getId();
 
             assertThat(savedReviewId).isNotNull();
         }
@@ -1219,7 +1230,8 @@ class ReviewServiceTest extends IntegrationTest {
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> reviewService.create(reviewCreateRequest, multipartFiles, member))
+            assertThatThrownBy(
+                    () -> reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("리뷰에 사진은 최대 4장까지 가능합니다.");
         }
@@ -1233,10 +1245,11 @@ class ReviewServiceTest extends IntegrationTest {
             List<MultipartFile> multipartFiles = FileTestUtils.generateMultipartFiles(2, "images");
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
-            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, member).getId();
+            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()))
+                    .getId();
             ReviewUpdateRequest reviewUpdateRequest = generateReviewUpdateRequest(Collections.emptyList());
 
-            reviewService.update(reviewId, reviewUpdateRequest, null, member);
+            reviewService.update(reviewId, reviewUpdateRequest, null, new LoginMember(member.getId()));
 
             Review updateReview = reviewRepository.findById(reviewId).get();
             assertSoftly(softly -> {
@@ -1251,11 +1264,12 @@ class ReviewServiceTest extends IntegrationTest {
             List<MultipartFile> multipartFiles = FileTestUtils.generateMultipartFiles(2, "images");
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
-            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, member).getId();
+            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()))
+                    .getId();
             ReviewUpdateRequest reviewUpdateRequest = generateReviewUpdateRequest(Collections.emptyList());
             List<MultipartFile> updateImages = FileTestUtils.generateMultipartFiles(2, "images");
 
-            reviewService.update(reviewId, reviewUpdateRequest, updateImages, member);
+            reviewService.update(reviewId, reviewUpdateRequest, updateImages, new LoginMember(member.getId()));
 
             Review updateReview = reviewRepository.findById(reviewId).get();
             int updatePhotoSize = multipartFiles.size() + updateImages.size();
@@ -1271,12 +1285,12 @@ class ReviewServiceTest extends IntegrationTest {
             List<MultipartFile> multipartFiles = FileTestUtils.generateMultipartFiles(2, "images");
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
-            Review review = reviewService.create(reviewCreateRequest, multipartFiles, member);
+            Review review = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()));
             List<Photo> reviewPhotos = reviewPhotoService.findPhotos(review);
             List<Long> deletePhotoIds = List.of(reviewPhotos.get(0).getId());
             ReviewUpdateRequest reviewUpdateRequest = generateReviewUpdateRequest(deletePhotoIds);
 
-            reviewService.update(review.getId(), reviewUpdateRequest, null, member);
+            reviewService.update(review.getId(), reviewUpdateRequest, null, new LoginMember(member.getId()));
 
             Review updateReview = reviewRepository.findById(review.getId()).get();
             int updatePhotoSize = multipartFiles.size() - deletePhotoIds.size();
@@ -1292,13 +1306,13 @@ class ReviewServiceTest extends IntegrationTest {
             List<MultipartFile> multipartFiles = FileTestUtils.generateMultipartFiles(2, "images");
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
-            Review review = reviewService.create(reviewCreateRequest, multipartFiles, member);
+            Review review = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()));
             List<Photo> reviewPhotos = reviewPhotoService.findPhotos(review);
             List<Long> deletePhotoIds = List.of(reviewPhotos.get(0).getId());
             ReviewUpdateRequest reviewUpdateRequest = generateReviewUpdateRequest(deletePhotoIds);
             List<MultipartFile> updateImages = FileTestUtils.generateMultipartFiles(2, "images");
 
-            reviewService.update(review.getId(), reviewUpdateRequest, updateImages, member);
+            reviewService.update(review.getId(), reviewUpdateRequest, updateImages, new LoginMember(member.getId()));
 
             Review updateReview = reviewRepository.findById(review.getId()).get();
             int updatePhotoSize = multipartFiles.size() + updateImages.size() - deletePhotoIds.size();
@@ -1314,7 +1328,8 @@ class ReviewServiceTest extends IntegrationTest {
             Member member = memberTestPersister.builder().save();
             ReviewUpdateRequest reviewUpdateRequest = generateReviewUpdateRequest(Collections.emptyList());
 
-            assertThatThrownBy(() -> reviewService.update(-1L, reviewUpdateRequest, null, member))
+            assertThatThrownBy(
+                    () -> reviewService.update(-1L, reviewUpdateRequest, null, new LoginMember(member.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("일치하는 리뷰를 찾을 수 없습니다.");
         }
@@ -1325,10 +1340,17 @@ class ReviewServiceTest extends IntegrationTest {
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
             Member otherMember = memberTestPersister.builder().save();
-            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, member).getId();
+            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()))
+                    .getId();
             ReviewUpdateRequest reviewUpdateRequest = generateReviewUpdateRequest(Collections.emptyList());
 
-            assertThatThrownBy(() -> reviewService.update(reviewId, reviewUpdateRequest, null, otherMember))
+            assertThatThrownBy(() ->
+                    reviewService.update(
+                            reviewId,
+                            reviewUpdateRequest,
+                            null,
+                            new LoginMember(otherMember.getId())
+                    ))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("본인이 작성한 리뷰가 아닙니다.");
         }
@@ -1338,11 +1360,18 @@ class ReviewServiceTest extends IntegrationTest {
             List<MultipartFile> multipartFiles = FileTestUtils.generateMultipartFiles(2, "images");
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
-            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, member).getId();
+            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()))
+                    .getId();
             ReviewUpdateRequest reviewUpdateRequest = generateReviewUpdateRequest(List.of(-1L));
             List<MultipartFile> updateImages = FileTestUtils.generateMultipartFiles(3, "images");
 
-            assertThatThrownBy(() -> reviewService.update(reviewId, reviewUpdateRequest, updateImages, member))
+            assertThatThrownBy(() ->
+                    reviewService.update(
+                            reviewId,
+                            reviewUpdateRequest,
+                            updateImages,
+                            new LoginMember(member.getId())
+                    ))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("삭제하려는 사진이 현재 리뷰에 존재하지 않습니다.");
         }
@@ -1352,11 +1381,18 @@ class ReviewServiceTest extends IntegrationTest {
             List<MultipartFile> multipartFiles = FileTestUtils.generateMultipartFiles(2, "images");
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
-            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, member).getId();
+            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()))
+                    .getId();
             ReviewUpdateRequest reviewUpdateRequest = generateReviewUpdateRequest(Collections.emptyList());
             List<MultipartFile> updateImages = FileTestUtils.generateMultipartFiles(3, "images");
 
-            assertThatThrownBy(() -> reviewService.update(reviewId, reviewUpdateRequest, updateImages, member))
+            assertThatThrownBy(() ->
+                    reviewService.update(
+                            reviewId,
+                            reviewUpdateRequest,
+                            updateImages,
+                            new LoginMember(member.getId())
+                    ))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("리뷰에 사진은 최대 4장까지 가능합니다.");
         }
@@ -1370,9 +1406,10 @@ class ReviewServiceTest extends IntegrationTest {
             List<MultipartFile> multipartFiles = FileTestUtils.generateMultipartFiles(2, "images");
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
-            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, member).getId();
+            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()))
+                    .getId();
 
-            reviewService.delete(reviewId, member);
+            reviewService.delete(reviewId, new LoginMember(member.getId()));
 
             assertThat(reviewRepository.findById(reviewId)).isEmpty();
         }
@@ -1381,7 +1418,7 @@ class ReviewServiceTest extends IntegrationTest {
         void 등록된_리뷰가_아니면_예외를_던진다() {
             Member member = memberTestPersister.builder().save();
 
-            assertThatThrownBy(() -> reviewService.delete(-1L, member))
+            assertThatThrownBy(() -> reviewService.delete(-1L, new LoginMember(member.getId())))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("일치하는 리뷰를 찾을 수 없습니다.");
         }
@@ -1392,9 +1429,10 @@ class ReviewServiceTest extends IntegrationTest {
             ReviewCreateRequest reviewCreateRequest = generateReviewCreateRequest();
             Member member = memberTestPersister.builder().save();
             Member otherMember = memberTestPersister.builder().save();
-            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, member).getId();
+            Long reviewId = reviewService.create(reviewCreateRequest, multipartFiles, new LoginMember(member.getId()))
+                    .getId();
 
-            assertThatThrownBy(() -> reviewService.delete(reviewId, otherMember))
+            assertThatThrownBy(() -> reviewService.delete(reviewId, new LoginMember(otherMember.getId())))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("본인이 작성한 리뷰가 아닙니다.");
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerTest.java
@@ -24,7 +24,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.application.ReviewService;
 import org.dinosaur.foodbowl.domain.review.domain.Review;
 import org.dinosaur.foodbowl.domain.review.dto.request.DeviceCoordinateRequest;
@@ -41,6 +40,7 @@ import org.dinosaur.foodbowl.domain.review.dto.response.ReviewStoreResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.ReviewWriterResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewContentResponse;
 import org.dinosaur.foodbowl.domain.review.dto.response.StoreReviewResponse;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.PresentationTest;
 import org.dinosaur.foodbowl.test.file.FileTestUtils;
 import org.junit.jupiter.api.Nested;
@@ -105,7 +105,7 @@ class ReviewControllerTest extends PresentationTest {
                             false
                     )
             );
-            given(reviewService.getReview(any(Long.class), any(Member.class), any(DeviceCoordinateRequest.class)))
+            given(reviewService.getReview(any(Long.class), any(LoginMember.class), any(DeviceCoordinateRequest.class)))
                     .willReturn(reviewResponse);
 
             mockMvc.perform(get("/v1/reviews/{id}", 1L)
@@ -191,7 +191,7 @@ class ReviewControllerTest extends PresentationTest {
                     any(Long.class),
                     anyInt(),
                     any(DeviceCoordinateRequest.class),
-                    any(Member.class))
+                    any(LoginMember.class))
             )
                     .willReturn(reviewFeedPageResponse);
 
@@ -298,7 +298,7 @@ class ReviewControllerTest extends PresentationTest {
                     any(MapCoordinateRequest.class),
                     any(DeviceCoordinateRequest.class),
                     anyInt(),
-                    any(Member.class)
+                    any(LoginMember.class)
             )).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/reviews/members")
@@ -561,7 +561,7 @@ class ReviewControllerTest extends PresentationTest {
                     any(),
                     anyInt(),
                     any(DeviceCoordinateRequest.class),
-                    any(Member.class)
+                    any(LoginMember.class)
             )).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/reviews/stores")
@@ -617,7 +617,7 @@ class ReviewControllerTest extends PresentationTest {
                     any(),
                     anyInt(),
                     any(DeviceCoordinateRequest.class),
-                    any(Member.class)
+                    any(LoginMember.class)
             )).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/reviews/stores")
@@ -736,7 +736,7 @@ class ReviewControllerTest extends PresentationTest {
                     any(MapCoordinateRequest.class),
                     any(DeviceCoordinateRequest.class),
                     anyInt(),
-                    any(Member.class)
+                    any(LoginMember.class)
             )).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/reviews/bookmarks")
@@ -962,7 +962,7 @@ class ReviewControllerTest extends PresentationTest {
                     any(MapCoordinateRequest.class),
                     any(DeviceCoordinateRequest.class),
                     anyInt(),
-                    any(Member.class)
+                    any(LoginMember.class)
             )).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/reviews/following")
@@ -1189,7 +1189,7 @@ class ReviewControllerTest extends PresentationTest {
                     any(MapCoordinateRequest.class),
                     any(DeviceCoordinateRequest.class),
                     anyInt(),
-                    any(Member.class)
+                    any(LoginMember.class)
             )).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/reviews/schools")
@@ -1426,7 +1426,7 @@ class ReviewControllerTest extends PresentationTest {
             );
             MockMultipartFile multipartFile1 = (MockMultipartFile) FileTestUtils.generateMultiPartFile("images");
             MockMultipartFile multipartFile2 = (MockMultipartFile) FileTestUtils.generateMultiPartFile("images");
-            given(reviewService.create(any(ReviewCreateRequest.class), anyList(), any(Member.class)))
+            given(reviewService.create(any(ReviewCreateRequest.class), anyList(), any(LoginMember.class)))
                     .willReturn(Review.builder().content(reviewCreateRequest.reviewContent()).build());
 
             mockMvc.perform(multipart(HttpMethod.POST, "/v1/reviews")
@@ -1449,7 +1449,7 @@ class ReviewControllerTest extends PresentationTest {
                     "application/json",
                     objectMapper.writeValueAsBytes(reviewCreateRequest)
             );
-            given(reviewService.create(any(ReviewCreateRequest.class), any(), any(Member.class)))
+            given(reviewService.create(any(ReviewCreateRequest.class), any(), any(LoginMember.class)))
                     .willReturn(Review.builder().content(reviewCreateRequest.reviewContent()).build());
 
             mockMvc.perform(multipart("/v1/reviews")
@@ -1502,7 +1502,7 @@ class ReviewControllerTest extends PresentationTest {
                     objectMapper.writeValueAsBytes(reviewCreateRequest)
             );
             MockMultipartFile multipartFile = (MockMultipartFile) FileTestUtils.generateMultiPartFile("images");
-            given(reviewService.create(any(ReviewCreateRequest.class), anyList(), any(Member.class)))
+            given(reviewService.create(any(ReviewCreateRequest.class), anyList(), any(LoginMember.class)))
                     .willThrow(new MaxUploadSizeExceededException(5));
 
             mockMvc.perform(multipart("/v1/reviews")
@@ -1817,7 +1817,7 @@ class ReviewControllerTest extends PresentationTest {
                     objectMapper.writeValueAsBytes(reviewUpdateRequest)
             );
             willDoNothing().given(reviewService)
-                    .update(anyLong(), any(ReviewUpdateRequest.class), anyList(), any(Member.class));
+                    .update(anyLong(), any(ReviewUpdateRequest.class), anyList(), any(LoginMember.class));
 
             mockMvc.perform(multipart(HttpMethod.PATCH, "/v1/reviews/{reviewId}", 1L)
                             .file(request)
@@ -1839,7 +1839,7 @@ class ReviewControllerTest extends PresentationTest {
                     objectMapper.writeValueAsBytes(reviewUpdateRequest)
             );
             willDoNothing().given(reviewService)
-                    .update(anyLong(), any(ReviewUpdateRequest.class), anyList(), any(Member.class));
+                    .update(anyLong(), any(ReviewUpdateRequest.class), anyList(), any(LoginMember.class));
 
             mockMvc.perform(multipart(HttpMethod.PATCH, "/v1/reviews/{reviewId}", 1L)
                             .file(request)
@@ -2000,7 +2000,7 @@ class ReviewControllerTest extends PresentationTest {
         @Test
         void 정상적으로_삭제되면_204_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
-            willDoNothing().given(reviewService).delete(anyLong(), any(Member.class));
+            willDoNothing().given(reviewService).delete(anyLong(), any(LoginMember.class));
 
             mockMvc.perform(delete("/v1/reviews/{reviewId}", 1L)
                             .header(AUTHORIZATION, BEARER + accessToken))

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -174,6 +174,27 @@ class StoreServiceTest extends IntegrationTest {
         }
 
         @Test
+        void 등록되지_않은_회원의_멤버_리뷰가_존재하는_가게_목록_조회라면_예외를_던진다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            assertThatThrownBy(() ->
+                    storeService.getStoresByMemberInMapBounds(
+                            member.getId(),
+                            mapCoordinateRequest,
+                            new LoginMember(-1L)
+                    ))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
+
+        @Test
         void 가게_리뷰_수도_함께_조회한다() {
             Member member = memberTestPersister.builder().save();
             Member writer = memberTestPersister.builder().save();
@@ -329,6 +350,22 @@ class StoreServiceTest extends IntegrationTest {
 
             assertThat(response.stores()).isEmpty();
         }
+
+        @Test
+        void 등록되지_않은_회원의_북마크한_가게_목록_조회라면_예외를_던진다() {
+            Store store = storeTestPersister.builder().save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            assertThatThrownBy(
+                    () -> storeService.getStoresByBookmarkInMapBounds(mapCoordinateRequest, new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
     }
 
     @Nested
@@ -407,6 +444,22 @@ class StoreServiceTest extends IntegrationTest {
 
             assertThat(response.stores()).isEmpty();
         }
+
+        @Test
+        void 등록되지_않은_회원의_팔로잉_유저의_리뷰가_존재하는_가게_목록_조회라면_예외를_던진다() {
+            Store store = storeTestPersister.builder().save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            assertThatThrownBy(
+                    () -> storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, new LoginMember(-1L)))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
+        }
     }
 
     @Nested
@@ -431,6 +484,28 @@ class StoreServiceTest extends IntegrationTest {
                     ))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("존재하지 않는 학교입니다.");
+        }
+
+        @Test
+        void 등록되지_않은_회원의_학교_근처_가게_목록_조회라면_예외를_던진다() {
+            Store store = storeTestPersister.builder().save();
+            School school = schoolTestPersister.builder().save();
+            storeSchoolTestPersister.builder().store(store).school(school).save();
+            MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            assertThatThrownBy(() ->
+                    storeService.getStoresBySchoolInMapBounds(
+                            school.getId(),
+                            mapCoordinateRequest,
+                            new LoginMember(-1L)
+                    ))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("등록되지 않은 회원입니다.");
         }
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreServiceTest.java
@@ -22,6 +22,7 @@ import org.dinosaur.foodbowl.domain.store.persistence.StoreSchoolRepository;
 import org.dinosaur.foodbowl.global.exception.BadRequestException;
 import org.dinosaur.foodbowl.global.exception.InvalidArgumentException;
 import org.dinosaur.foodbowl.global.exception.NotFoundException;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.global.util.PointUtils;
 import org.dinosaur.foodbowl.test.IntegrationTest;
 import org.junit.jupiter.api.Nested;
@@ -162,7 +163,12 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            assertThatThrownBy(() -> storeService.getStoresByMemberInMapBounds(-1L, mapCoordinateRequest, member))
+            assertThatThrownBy(() ->
+                    storeService.getStoresByMemberInMapBounds(
+                            -1L,
+                            mapCoordinateRequest,
+                            new LoginMember(member.getId())
+                    ))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("등록되지 않은 회원입니다.");
         }
@@ -181,8 +187,11 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            StoreMapBoundResponses response =
-                    storeService.getStoresByMemberInMapBounds(member.getId(), mapCoordinateRequest, member);
+            StoreMapBoundResponses response = storeService.getStoresByMemberInMapBounds(
+                    member.getId(),
+                    mapCoordinateRequest,
+                    new LoginMember(member.getId())
+            );
 
             List<StoreMapBoundResponse> result = response.stores();
             assertSoftly(softly -> {
@@ -212,8 +221,11 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            StoreMapBoundResponses response =
-                    storeService.getStoresByMemberInMapBounds(member.getId(), mapCoordinateRequest, member);
+            StoreMapBoundResponses response = storeService.getStoresByMemberInMapBounds(
+                    member.getId(),
+                    mapCoordinateRequest,
+                    new LoginMember(member.getId())
+            );
 
             List<StoreMapBoundResponse> result = response.stores();
             assertSoftly(softly -> {
@@ -233,8 +245,11 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            StoreMapBoundResponses response =
-                    storeService.getStoresByMemberInMapBounds(member.getId(), mapCoordinateRequest, member);
+            StoreMapBoundResponses response = storeService.getStoresByMemberInMapBounds(
+                    member.getId(),
+                    mapCoordinateRequest,
+                    new LoginMember(member.getId())
+            );
 
             assertThat(response.stores()).isEmpty();
         }
@@ -258,7 +273,8 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            StoreMapBoundResponses response = storeService.getStoresByBookmarkInMapBounds(mapCoordinateRequest, member);
+            StoreMapBoundResponses response =
+                    storeService.getStoresByBookmarkInMapBounds(mapCoordinateRequest, new LoginMember(member.getId()));
 
             List<StoreMapBoundResponse> result = response.stores();
             assertSoftly(softly -> {
@@ -287,7 +303,8 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            StoreMapBoundResponses response = storeService.getStoresByBookmarkInMapBounds(mapCoordinateRequest, member);
+            StoreMapBoundResponses response =
+                    storeService.getStoresByBookmarkInMapBounds(mapCoordinateRequest, new LoginMember(member.getId()));
 
             List<StoreMapBoundResponse> result = response.stores();
             assertSoftly(softly -> {
@@ -307,7 +324,8 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            StoreMapBoundResponses response = storeService.getStoresByBookmarkInMapBounds(mapCoordinateRequest, member);
+            StoreMapBoundResponses response =
+                    storeService.getStoresByBookmarkInMapBounds(mapCoordinateRequest, new LoginMember(member.getId()));
 
             assertThat(response.stores()).isEmpty();
         }
@@ -332,7 +350,7 @@ class StoreServiceTest extends IntegrationTest {
             );
 
             StoreMapBoundResponses response =
-                    storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, member);
+                    storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, new LoginMember(member.getId()));
 
             List<StoreMapBoundResponse> result = response.stores();
             assertSoftly(softly -> {
@@ -365,7 +383,7 @@ class StoreServiceTest extends IntegrationTest {
             );
 
             StoreMapBoundResponses response =
-                    storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, member);
+                    storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, new LoginMember(member.getId()));
 
             List<StoreMapBoundResponse> result = response.stores();
             assertSoftly(softly -> {
@@ -385,7 +403,7 @@ class StoreServiceTest extends IntegrationTest {
             );
 
             StoreMapBoundResponses response =
-                    storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, member);
+                    storeService.getStoresByFollowingInMapBounds(mapCoordinateRequest, new LoginMember(member.getId()));
 
             assertThat(response.stores()).isEmpty();
         }
@@ -405,7 +423,12 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            assertThatThrownBy(() -> storeService.getStoresBySchoolInMapBounds(-1L, mapCoordinateRequest, member))
+            assertThatThrownBy(() ->
+                    storeService.getStoresBySchoolInMapBounds(
+                            -1L,
+                            mapCoordinateRequest,
+                            new LoginMember(member.getId())
+                    ))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("존재하지 않는 학교입니다.");
         }
@@ -428,8 +451,11 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            StoreMapBoundResponses response =
-                    storeService.getStoresBySchoolInMapBounds(school.getId(), mapCoordinateRequest, member);
+            StoreMapBoundResponses response = storeService.getStoresBySchoolInMapBounds(
+                    school.getId(),
+                    mapCoordinateRequest,
+                    new LoginMember(member.getId())
+            );
 
             List<StoreMapBoundResponse> result = response.stores();
             assertSoftly(softly -> {
@@ -469,8 +495,11 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            StoreMapBoundResponses response =
-                    storeService.getStoresBySchoolInMapBounds(school.getId(), mapCoordinateRequest, member);
+            StoreMapBoundResponses response = storeService.getStoresBySchoolInMapBounds(
+                    school.getId(),
+                    mapCoordinateRequest,
+                    new LoginMember(member.getId())
+            );
 
             List<StoreMapBoundResponse> result = response.stores();
             assertSoftly(softly -> {
@@ -491,8 +520,11 @@ class StoreServiceTest extends IntegrationTest {
                     BigDecimal.valueOf(1)
             );
 
-            StoreMapBoundResponses response =
-                    storeService.getStoresBySchoolInMapBounds(school.getId(), mapCoordinateRequest, member);
+            StoreMapBoundResponses response = storeService.getStoresBySchoolInMapBounds(
+                    school.getId(),
+                    mapCoordinateRequest,
+                    new LoginMember(member.getId())
+            );
 
             assertThat(response.stores()).isEmpty();
         }

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
@@ -18,7 +18,6 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.dinosaur.foodbowl.domain.auth.application.jwt.JwtTokenProvider;
-import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.domain.review.dto.request.MapCoordinateRequest;
 import org.dinosaur.foodbowl.domain.store.application.StoreService;
 import org.dinosaur.foodbowl.domain.store.dto.response.CategoriesResponse;
@@ -27,6 +26,7 @@ import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreMapBoundResponses;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponse;
 import org.dinosaur.foodbowl.domain.store.dto.response.StoreSearchResponses;
+import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.dinosaur.foodbowl.test.PresentationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -228,7 +228,7 @@ class StoreControllerTest extends PresentationTest {
             given(storeService.getStoresByMemberInMapBounds(
                     anyLong(),
                     any(MapCoordinateRequest.class),
-                    any(Member.class))
+                    any(LoginMember.class))
             ).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/stores/members")
@@ -367,7 +367,7 @@ class StoreControllerTest extends PresentationTest {
         void 정상적인_요청이라면_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             StoreMapBoundResponses response = mockStoreMapBoundResponses();
-            given(storeService.getStoresByBookmarkInMapBounds(any(MapCoordinateRequest.class), any(Member.class)))
+            given(storeService.getStoresByBookmarkInMapBounds(any(MapCoordinateRequest.class), any(LoginMember.class)))
                     .willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/stores/bookmarks")
@@ -481,7 +481,7 @@ class StoreControllerTest extends PresentationTest {
         void 정상적인_요청이라면_200_응답을_반환한다() throws Exception {
             mockingAuthMemberInResolver();
             StoreMapBoundResponses response = mockStoreMapBoundResponses();
-            given(storeService.getStoresByFollowingInMapBounds(any(MapCoordinateRequest.class), any(Member.class)))
+            given(storeService.getStoresByFollowingInMapBounds(any(MapCoordinateRequest.class), any(LoginMember.class)))
                     .willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/stores/followings")
@@ -598,7 +598,7 @@ class StoreControllerTest extends PresentationTest {
             given(storeService.getStoresBySchoolInMapBounds(
                     anyLong(),
                     any(MapCoordinateRequest.class),
-                    any(Member.class))
+                    any(LoginMember.class))
             ).willReturn(response);
 
             MvcResult mvcResult = mockMvc.perform(get("/v1/stores/schools")


### PR DESCRIPTION
## 🔥 연관 이슈

close: #203

## 📝 작업 요약

osiv를 `false`로 바꾸고 argumentresolver에서 조회한 멤버 도메인을 바로 사용하지 않도록 수정하였습니다.

## 🔎 작업 상세 설명

- `spring.jpa.open-in-view` 속성을 `false`로 수정하였습니다.
- `Member`를 파라미터로 받는 기존 로직에서 `LoginMember`를 받도록 수정하였습니다.
- 멤버의 데이터로 `ID`만 전달하기에 영속성 컨텍스트에 멤버 도메인을 넣기위해 조회 로직을 추가하였습니다.

## 🌟 리뷰 요구 사항

> 30분
> 수정 과정에서 빠진 부분이 있는지 한번 더 확인해주시면 감사합니다. 🙇🏻‍♂️
> 중복된 조회 로직을 처리할 수 있는 방법에 대해 의견 있다면 자유롭게 주셔도 좋습니다!