### PR TITLE
Feature/#211 리뷰 조회 친구 필터링에 사용자 리뷰를 포함시킨다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -122,7 +122,7 @@ public class ReviewCustomRepository {
             return null;
         }
         return review.member.id.eq(memberId)
-                .or(memberFollowingEq(memberId));
+                .or(follow.follower.id.eq(memberId));
     }
 
     public List<Review> findPaginationReviewsByBookmarkInMapBounds(
@@ -166,7 +166,7 @@ public class ReviewCustomRepository {
                 )
                 .where(
                         review.member.id.eq(followerId)
-                                .or(memberFollowingEq(followerId)),
+                                .or(follow.follower.id.eq(followerId)),
                         ltLastReviewId(lastReviewId),
                         containsPolygon(mapCoordinateBoundDto),
                         containsCategoryFilter(categoryType)
@@ -174,11 +174,6 @@ public class ReviewCustomRepository {
                 .orderBy(review.id.desc())
                 .limit(pageSize)
                 .fetch();
-    }
-
-    private BooleanExpression memberFollowingEq(Long followerId) {
-        return follow.follower.id.eq(followerId)
-                .and(review.member.id.eq(follow.following.id));
     }
 
     public List<Review> findPaginationReviewsBySchoolInMapBounds(

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -153,11 +153,12 @@ public class ReviewCustomRepository {
                 .innerJoin(review.store, store).fetchJoin()
                 .innerJoin(review.member, member).fetchJoin()
                 .innerJoin(store.category, category).fetchJoin()
-                .innerJoin(follow).on(
-                        review.member.id.eq(follow.following.id),
+                .leftJoin(follow).on(
                         follow.follower.id.eq(followerId)
                 )
                 .where(
+                        review.member.id.eq(followerId)
+                                .or(review.member.id.eq(follow.following.id)),
                         ltLastReviewId(lastReviewId),
                         containsPolygon(mapCoordinateBoundDto),
                         containsCategoryFilter(categoryType)

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -99,6 +99,7 @@ public class ReviewCustomRepository {
 
         setReviewFilterIfExists(jpaQuery, memberId, reviewFilter);
         return jpaQuery.where(
+                        applyReviewFilterIfExists(memberId, reviewFilter),
                         review.store.id.eq(storeId),
                         ltLastReviewId(lastReviewId)
                 )
@@ -111,10 +112,17 @@ public class ReviewCustomRepository {
         if (reviewFilter == ReviewFilter.ALL) {
             return;
         }
-        jpaQuery.innerJoin(follow).on(
-                review.member.id.eq(follow.following.id),
+        jpaQuery.leftJoin(follow).on(
                 follow.follower.id.eq(memberId)
         );
+    }
+
+    private BooleanExpression applyReviewFilterIfExists(Long memberId, ReviewFilter reviewFilter) {
+        if (reviewFilter == ReviewFilter.ALL) {
+            return null;
+        }
+        return review.member.id.eq(memberId)
+                .or(review.member.id.eq(follow.following.id));
     }
 
     public List<Review> findPaginationReviewsByBookmarkInMapBounds(

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
@@ -93,12 +93,20 @@ public class StoreCustomRepository {
                 .innerJoin(store.category, category).fetchJoin()
                 .innerJoin(review).on(review.store.eq(store))
                 .innerJoin(member).on(review.member.eq(member))
-                .innerJoin(follow).on(
-                        review.member.id.eq(follow.following.id),
-                        follow.follower.id.eq(memberId)
+                .leftJoin(follow).on(
+                        review.member.id.eq(follow.following.id)
                 )
-                .where(containsPolygon(mapCoordinateBoundDto))
+                .where(
+                        review.member.id.eq(memberId)
+                                        .or(memberFollowingEq(memberId)),
+                        containsPolygon(mapCoordinateBoundDto)
+                )
                 .fetch();
+    }
+
+    private BooleanExpression memberFollowingEq(Long followerId) {
+        return follow.follower.id.eq(followerId)
+                .and(review.member.id.eq(follow.following.id));
     }
 
     public List<Store> findStoresBySchoolInMapBounds(Long schoolId, MapCoordinateBoundDto mapCoordinateBoundDto) {

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
@@ -98,15 +98,10 @@ public class StoreCustomRepository {
                 )
                 .where(
                         review.member.id.eq(memberId)
-                                        .or(memberFollowingEq(memberId)),
+                                        .or(follow.follower.id.eq(memberId)),
                         containsPolygon(mapCoordinateBoundDto)
                 )
                 .fetch();
-    }
-
-    private BooleanExpression memberFollowingEq(Long followerId) {
-        return follow.follower.id.eq(followerId)
-                .and(review.member.id.eq(follow.following.id));
     }
 
     public List<Store> findStoresBySchoolInMapBounds(Long schoolId, MapCoordinateBoundDto mapCoordinateBoundDto) {

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -311,7 +311,7 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
         }
 
         @Test
-        void 친구_필터링이_있으면_팔로워_리뷰만_조회한다() {
+        void 친구_필터링이_있으면_사용자_및_팔로워_리뷰만_조회한다() {
             Member loginMember = memberTestPersister.builder().save();
             Member gray = memberTestPersister.builder().save();
             Member dazzle = memberTestPersister.builder().save();
@@ -320,6 +320,7 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
             Review reviewA = reviewTestPersister.builder().member(gray).store(store).save();
             Review reviewB = reviewTestPersister.builder().member(gray).store(store).save();
             Review reviewC = reviewTestPersister.builder().member(dazzle).store(store).save();
+            Review reviewD = reviewTestPersister.builder().member(loginMember).store(store).save();
 
             List<Review> reviews = reviewCustomRepository.findPaginationReviewsByStore(
                     store.getId(),
@@ -330,7 +331,7 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
             );
 
             assertSoftly(softly -> {
-                softly.assertThat(reviews).containsExactly(reviewB, reviewA);
+                softly.assertThat(reviews).containsExactly(reviewD, reviewB, reviewA);
                 softly.assertThat(reviews).doesNotContain(reviewC);
             });
         }
@@ -680,7 +681,57 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
         }
 
         @Test
-        void 팔로잉_하고있지_않은_유저의_리뷰는_조회하지_않는다() {
+        void 사용자의_리뷰도_함께_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            followTestPersister.builder().following(writer).follower(member).save();
+            Store store = storeTestPersister.builder().save();
+            Review review = reviewTestPersister.builder().store(store).member(writer).save();
+            Review reviewA = reviewTestPersister.builder().store(store).member(member).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByFollowingInMapBounds(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    null,
+                    10
+            );
+
+            assertThat(result).containsExactly(reviewA, review);
+        }
+
+        @Test
+        void 사용자의_팔로앙이_없는_경우에도_사용자의_리뷰는_조회된다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().store(store).member(member).save();
+            Review reviewB = reviewTestPersister.builder().store(store).member(member).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(3)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsByFollowingInMapBounds(
+                    member.getId(),
+                    null,
+                    mapCoordinateBoundDto,
+                    null,
+                    10
+            );
+
+            assertThat(result).containsExactly(reviewB, reviewA);
+        }
+
+        @Test
+        void 사용자가_아닌_팔로잉_하고있지_않은_유저의_리뷰는_조회하지_않는다() {
             Member member = memberTestPersister.builder().save();
             Member writer = memberTestPersister.builder().save();
             Store store = storeTestPersister.builder().save();

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -337,6 +337,50 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
         }
 
         @Test
+        void 친구_필터링이_있을_때_팔로워가_없어도_사용자_리뷰는_조회된다() {
+            Member loginMember = memberTestPersister.builder().save();
+            Member dazzle = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().member(dazzle).store(store).save();
+            Review reviewB = reviewTestPersister.builder().member(loginMember).store(store).save();
+            Review reviewC = reviewTestPersister.builder().member(loginMember).store(store).save();
+
+            List<Review> reviews = reviewCustomRepository.findPaginationReviewsByStore(
+                    store.getId(),
+                    ReviewFilter.FRIEND,
+                    loginMember.getId(),
+                    null,
+                    10
+            );
+
+            assertSoftly(softly -> {
+                softly.assertThat(reviews).containsExactly(reviewC, reviewB);
+                softly.assertThat(reviews).doesNotContain(reviewA);
+            });
+        }
+
+        @Test
+        void 친구_필터링이_있을_때_팔로워가_있지만_팔로워의_리뷰가_없어도_사용자_리뷰는_조회된다() {
+            Member loginMember = memberTestPersister.builder().save();
+            Member dazzle = memberTestPersister.builder().save();
+            followTestPersister.builder().follower(loginMember).following(dazzle).save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().member(loginMember).store(store).save();
+            Review reviewB = reviewTestPersister.builder().member(loginMember).store(store).save();
+
+            List<Review> reviews = reviewCustomRepository.findPaginationReviewsByStore(
+                    store.getId(),
+                    ReviewFilter.FRIEND,
+                    loginMember.getId(),
+                    null,
+                    10
+            );
+
+
+            assertThat(reviews).containsExactly(reviewB, reviewA);
+        }
+
+        @Test
         void 전체_필터링이_있으면_모든_리뷰를_조회한다() {
             Member loginMember = memberTestPersister.builder().save();
             Member gray = memberTestPersister.builder().save();

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -751,7 +751,7 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
         }
 
         @Test
-        void 사용자의_팔로앙이_없는_경우에도_사용자의_리뷰는_조회된다() {
+        void 사용자의_팔로잉이_없는_경우에도_사용자의_리뷰는_조회된다() {
             Member member = memberTestPersister.builder().save();
             Store store = storeTestPersister.builder().save();
             Review reviewA = reviewTestPersister.builder().store(store).member(member).save();

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
@@ -223,6 +223,66 @@ class StoreCustomRepositoryTest extends PersistenceTest {
         }
 
         @Test
+        void 팔로잉_유저의_리뷰가_작성된_가게를_조회할_때_사용자가_작성한_리뷰의_가게도_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            followTestPersister.builder().following(writer).follower(member).save();
+            Store storeA = storeTestPersister.builder().save();
+            Store storeB = storeTestPersister.builder().address(storeA.getAddress()).save();
+            reviewTestPersister.builder().member(writer).store(storeA).save();
+            reviewTestPersister.builder().member(member).store(storeB).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(storeA.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(storeA.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).containsExactly(storeA, storeB);
+        }
+
+        @Test
+        void 팔로잉_유저의_리뷰가_존재하지_않아도_사용자가_작성한_리뷰의_가게는_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Member writer = memberTestPersister.builder().save();
+            followTestPersister.builder().following(writer).follower(member).save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).containsExactly(store);
+        }
+
+        @Test
+        void 팔로잉_유저가_존재하지_않아도_사용자가_작성한_리뷰의_가게는_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByFollowingInMapBounds(member.getId(), mapCoordinateBoundDto);
+
+            assertThat(result).containsExactly(store);
+        }
+
+        @Test
         void 팔로잉_하는_유저가_작성한_리뷰가_동일한_가게인_경우_중복_조회_하지_않는다() {
             Member member = memberTestPersister.builder().save();
             Member writerA = memberTestPersister.builder().save();


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #211 

## 📝 작업 요약

친구의 리뷰를 조회하는 경우 사용자가 작성한 리뷰도 확인할 수 있도록 했습니다 !

## 🔎 작업 상세 설명

기존에 리뷰 조회 시 innerJoin을 이용해 팔로워의 리뷰를 가져오던 로직을 다음과 같이 변경했습니다.

* 기존
```sql
return jpaQueryFactory.selectDistinct(review)
                .from(review)
                .innerJoin(follow).on(
                        review.member.id.eq(follow.following.id),
                        follow.follower.id.eq(followerId)
                )
                .where(
                        ltLastReviewId(lastReviewId),
                        containsPolygon(mapCoordinateBoundDto),
                        containsCategoryFilter(categoryType)
                )
                .orderBy(review.id.desc())
                .limit(pageSize)
                .fetch();
```
* 현재
```sql
return jpaQueryFactory.selectDistinct(review)
                .from(review)
                .leftJoin(follow).on(
                        review.member.id.eq(follow.following.id)
                )
                .where(
                        review.member.id.eq(followerId)
                                .or(memberFollowingEq(followerId)),
                        ltLastReviewId(lastReviewId),
                        containsPolygon(mapCoordinateBoundDto),
                        containsCategoryFilter(categoryType)
                )
                .orderBy(review.id.desc())
                .limit(pageSize)
                .fetch();

private BooleanExpression memberFollowingEq(Long followerId) {
        return follow.follower.id.eq(followerId)
                .and(review.member.id.eq(follow.following.id));
}
```
우선 join의 on절에서 `review.member.id.eq(follow.following.id)` 판단하는 로직을 where 절로 옮겼습니다.
on 절에서 판단하는 경우 select 조건에 사용자의 리뷰를 포함시킬 수 없었어요.
leftJoin을 사용한 이유는 팔로워 정보가 아예 없는 경우 사용자가 작성한 리뷰를 가져오기 위함입니다.
그래서 우선적으로 모든 리뷰와 followerId에 해당하는 팔로우 정보를 가져온 후 `사용자 리뷰 + 팔로워 리뷰`를 where 절에서 필터링 했습니다 🌱

요구사항이 추가됨에 따라 여러 상황이 발생할 수 있어서(**기본 조회인 경우**, **팔로워가 있지만 팔로워들의 리뷰가 없는 경우**, **팔로워가 아예 없는 경우**) 관련 테스트를 추가했는데 함께 봐주시면 감사하겠습니다 :D
 
## 🌟 리뷰 요구 사항
쿼리문 최적화 해보려고 이것 저것 시도하다가 여기 까지 왔는데요..ㅎㅎ
자꾸 쓰고 지우고 하다보니 어지러워진 것 같기도 하네요...
쿼리 개선할 부분(실행 계획은 확인했고 큰 이상 없었어요 !)은 없는지, 테스트 추가할 부분은 없는지 봐주시면 짱짱입니당

추가) memberFollowingEq 메서드 명이 참 아쉬운데 괜찮은 거 없을까요?! 🥺
> 20분
