### PR TITLE
Feature/#213 리뷰 많은 순으로 유저 목록을 조회한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberCustomService.java
@@ -17,4 +17,9 @@ public class MemberCustomService {
     public List<Member> search(String name, int size) {
         return memberCustomRepository.search(name, size);
     }
+
+    @Transactional(readOnly = true)
+    public List<Member> getMembersSortByReviewCounts(int page, int size) {
+        return memberCustomRepository.getMembersSortByReviewCounts(page, size);
+    }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/application/MemberService.java
@@ -106,6 +106,23 @@ public class MemberService {
         return new NicknameExistResponse(isExist);
     }
 
+    @Transactional(readOnly = true)
+    public MemberSearchResponses getMembersSortByReviewCounts(int page, int size, LoginMember loginMember) {
+        Member viewer = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+        List<Member> members = memberCustomService.getMembersSortByReviewCounts(page, size);
+
+        MemberToFollowerCountDto followerCountByMembers = followCustomService.getFollowerCountByMembers(members);
+        MemberToFollowingsDto followingsByMember = followCustomService.getFollowInMembers(members, viewer);
+
+        return MemberSearchResponses.of(
+                members,
+                viewer,
+                followerCountByMembers,
+                followingsByMember
+        );
+    }
+
     @Transactional
     public void updateProfile(UpdateProfileRequest updateProfileRequest, LoginMember loginMember) {
         Member member = memberRepository.findById(loginMember.id())

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberCustomRepository.java
@@ -1,6 +1,7 @@
 package org.dinosaur.foodbowl.domain.member.persistence;
 
 import static org.dinosaur.foodbowl.domain.member.domain.QMember.member;
+import static org.dinosaur.foodbowl.domain.review.domain.QReview.review;
 
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
@@ -27,6 +28,17 @@ public class MemberCustomRepository {
                 .orderBy(nameSort.asc())
                 .limit(size)
                 .offset(0)
+                .fetch();
+    }
+
+    public List<Member> getMembersSortByReviewCounts(int page, int size) {
+        return jpaQueryFactory.select(member)
+                .from(review)
+                .innerJoin(review.member, member)
+                .groupBy(member)
+                .orderBy(review.count().desc())
+                .limit(size)
+                .offset((long) page * size)
                 .fetch();
     }
 }

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/persistence/MemberCustomRepository.java
@@ -35,7 +35,7 @@ public class MemberCustomRepository {
         return jpaQueryFactory.select(member)
                 .from(review)
                 .innerJoin(review.member, member)
-                .groupBy(member)
+                .groupBy(member.id)
                 .orderBy(review.count().desc())
                 .limit(size)
                 .offset((long) page * size)

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberController.java
@@ -70,6 +70,17 @@ public class MemberController implements MemberControllerDocs {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/by-reviews")
+    public ResponseEntity<MemberSearchResponses> getMembersSortByReviewCounts(
+            @RequestParam(defaultValue = "0") @PositiveOrZero(message = "조회 페이지는 0이상만 가능합니다.") int page,
+            @RequestParam(defaultValue = "20") @Positive(message = "조회 크기는 1이상만 가능합니다.")
+            @Max(value = 20, message = "최대 20개까지 조회가능합니다.") int size,
+            @Auth LoginMember loginMember
+    ) {
+        MemberSearchResponses response = memberService.getMembersSortByReviewCounts(page, size, loginMember);
+        return ResponseEntity.ok(response);
+    }
+
     @PatchMapping("/profile")
     public ResponseEntity<Void> updateProfile(
             @RequestBody @Valid UpdateProfileRequest updateProfileRequest,

--- a/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerDocs.java
@@ -20,6 +20,7 @@ import org.dinosaur.foodbowl.domain.member.dto.response.NicknameExistResponse;
 import org.dinosaur.foodbowl.global.exception.response.ExceptionResponse;
 import org.dinosaur.foodbowl.global.presentation.LoginMember;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "회원", description = "회원 API")
@@ -125,6 +126,49 @@ public interface MemberControllerDocs {
             @Parameter(description = "닉네임", example = "coby5502")
             @NotBlank(message = "닉네임 파라미터 값이 존재하지 않습니다.")
             String nickname
+    );
+
+    @Operation(
+            summary = "리뷰 순 회원 목록 조회",
+            description = """
+                    리뷰가 많은 순으로 회원 목록을 페이지 조회합니다.
+                                        
+                    단, 리뷰를 작성하지 않은 회원은 조회되지 않습니다.
+                                        
+                    page, size 파라미터를 입력하지 않으면 기본으로 0, 20이 적용됩니다.
+                                        
+                    size는 1~20까지만 가능합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "리뷰 순 회원 목록 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.조회페이지가 0보다 작은 경우
+                                                        
+                            2.조회 크기가 1보다 작은 경우
+                                                        
+                            3.조회 크기가 20보다 큰 경우
+                            """
+            )
+    })
+    ResponseEntity<MemberSearchResponses> getMembersSortByReviewCounts(
+            @Parameter(description = "조회 페이지", example = "0")
+            @RequestParam(defaultValue = "0")
+            @PositiveOrZero(message = "조회 페이지는 0이상만 가능합니다.")
+            int page,
+
+            @Parameter(description = "조회 크기", example = "20")
+            @RequestParam(defaultValue = "20")
+            @Positive(message = "조회 크기는 1이상만 가능합니다.")
+            @Max(value = 20, message = "최대 20개까지 조회가능합니다.")
+            int size,
+
+            LoginMember loginMember
     );
 
     @Operation(summary = "프로필 정보 수정", description = "닉네임, 한 줄 소개를 수정한다.")

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
@@ -98,7 +98,7 @@ public class StoreCustomRepository {
                 )
                 .where(
                         review.member.id.eq(memberId)
-                                        .or(follow.follower.id.eq(memberId)),
+                                .or(follow.follower.id.eq(memberId)),
                         containsPolygon(mapCoordinateBoundDto)
                 )
                 .fetch();

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberCustomServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/application/MemberCustomServiceTest.java
@@ -1,5 +1,6 @@
 package org.dinosaur.foodbowl.domain.member.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.List;
@@ -28,5 +29,22 @@ class MemberCustomServiceTest extends IntegrationTest {
             softly.assertThat(members).containsExactly(memberA, memberC, memberB);
             softly.assertThat(members).doesNotContain(memberD);
         });
+    }
+
+    @Test
+    void 리뷰_많은_순으로_회원_목록을_페이지_조회한다() {
+        Member memberA = memberTestPersister.builder().save();
+        Member memberB = memberTestPersister.builder().save();
+        Member memberC = memberTestPersister.builder().save();
+        reviewTestPersister.builder().member(memberA).save();
+        reviewTestPersister.builder().member(memberB).save();
+        reviewTestPersister.builder().member(memberB).save();
+        reviewTestPersister.builder().member(memberB).save();
+        reviewTestPersister.builder().member(memberC).save();
+        reviewTestPersister.builder().member(memberC).save();
+
+        List<Member> members = memberCustomService.getMembersSortByReviewCounts(0, 3);
+
+        assertThat(members).containsExactly(memberB, memberC, memberA);
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/persistence/MemberCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/persistence/MemberCustomRepositoryTest.java
@@ -1,10 +1,12 @@
 package org.dinosaur.foodbowl.domain.member.persistence;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.List;
 import org.dinosaur.foodbowl.domain.member.domain.Member;
 import org.dinosaur.foodbowl.test.PersistenceTest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -30,5 +32,69 @@ class MemberCustomRepositoryTest extends PersistenceTest {
             softly.assertThat(members).containsExactly(memberD, memberA, memberE, memberC);
             softly.assertThat(members).doesNotContain(memberB, memberF);
         });
+    }
+
+    @Nested
+    class 리뷰_개수_많은_순_회원_목록_페이지_조회_시 {
+
+        @Test
+        void 리뷰_개수가_많은_순으로_정렬되어_조회한다() {
+            Member memberA = memberTestPersister.builder().save();
+            Member memberB = memberTestPersister.builder().save();
+            Member memberC = memberTestPersister.builder().save();
+            reviewTestPersister.builder().member(memberA).save();
+            reviewTestPersister.builder().member(memberB).save();
+            reviewTestPersister.builder().member(memberB).save();
+            reviewTestPersister.builder().member(memberB).save();
+            reviewTestPersister.builder().member(memberC).save();
+            reviewTestPersister.builder().member(memberC).save();
+
+            List<Member> members = memberCustomRepository.getMembersSortByReviewCounts(0, 3);
+
+            assertThat(members).containsExactly(memberB, memberC, memberA);
+        }
+
+        @Test
+        void 페이지_번호에_해당하는_리뷰_목록을_조회한다() {
+            Member memberA = memberTestPersister.builder().save();
+            Member memberB = memberTestPersister.builder().save();
+            Member memberC = memberTestPersister.builder().save();
+            reviewTestPersister.builder().member(memberA).save();
+            reviewTestPersister.builder().member(memberB).save();
+            reviewTestPersister.builder().member(memberB).save();
+            reviewTestPersister.builder().member(memberB).save();
+            reviewTestPersister.builder().member(memberC).save();
+            reviewTestPersister.builder().member(memberC).save();
+
+            List<Member> members = memberCustomRepository.getMembersSortByReviewCounts(1, 2);
+
+            assertThat(members).containsExactly(memberA);
+        }
+
+        @Test
+        void 페이지_개수만큼_리뷰_목록을_조회한다() {
+            Member memberA = memberTestPersister.builder().save();
+            Member memberB = memberTestPersister.builder().save();
+            Member memberC = memberTestPersister.builder().save();
+            reviewTestPersister.builder().member(memberA).save();
+            reviewTestPersister.builder().member(memberB).save();
+            reviewTestPersister.builder().member(memberB).save();
+            reviewTestPersister.builder().member(memberB).save();
+            reviewTestPersister.builder().member(memberC).save();
+            reviewTestPersister.builder().member(memberC).save();
+
+            List<Member> members = memberCustomRepository.getMembersSortByReviewCounts(0, 2);
+
+            assertThat(members).containsExactly(memberB, memberC);
+        }
+
+        @Test
+        void 리뷰를_작성하지_않은_회원은_조회되지_않는다() {
+            Member member = memberTestPersister.builder().save();
+
+            List<Member> members = memberCustomRepository.getMembersSortByReviewCounts(0, 2);
+
+            assertThat(members).isEmpty();
+        }
     }
 }

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
@@ -319,8 +319,8 @@ class MemberControllerTest extends PresentationTest {
                     .andExpect(jsonPath("message").value(containsString("조회 페이지는 0이상만 가능합니다.")));
         }
 
-        @ValueSource(ints = {-1, -0})
         @ParameterizedTest
+        @ValueSource(ints = {-1, -0})
         void 페이지_크기가_1보다_작으면_400_응답을_반환한다(int size) throws Exception {
             mockingAuthMemberInResolver();
 

--- a/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/member/presentation/MemberControllerTest.java
@@ -280,6 +280,76 @@ class MemberControllerTest extends PresentationTest {
     }
 
     @Nested
+    class 리뷰_많은_순으로_회원_목록_페이지_조회_시 {
+
+        private final String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);
+
+        @Test
+        void 회원_목록_조회에_성공하면_200_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+            MemberSearchResponses response = new MemberSearchResponses(
+                    List.of(new MemberSearchResponse(1L, "gray", "https://image.com", 10, true, false))
+            );
+            given(memberService.getMembersSortByReviewCounts(anyInt(), anyInt(), any(LoginMember.class)))
+                    .willReturn(response);
+
+            MvcResult mvcResult = mockMvc.perform(get("/v1/members/by-reviews")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .characterEncoding(StandardCharsets.UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+            String jsonResponse = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+            MemberSearchResponses result = objectMapper.readValue(jsonResponse, MemberSearchResponses.class);
+
+            assertThat(result).usingRecursiveComparison().isEqualTo(response);
+        }
+
+        @Test
+        void 페이지_번호가_0보다_작으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/members/by-reviews")
+                            .param("page", "-1")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .characterEncoding(StandardCharsets.UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("message").value(containsString("조회 페이지는 0이상만 가능합니다.")));
+        }
+
+        @ValueSource(ints = {-1, -0})
+        @ParameterizedTest
+        void 페이지_크기가_1보다_작으면_400_응답을_반환한다(int size) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/members/by-reviews")
+                            .param("size", String.valueOf(size))
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .characterEncoding(StandardCharsets.UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("message").value(containsString("조회 크기는 1이상만 가능합니다.")));
+        }
+
+        @Test
+        void 페이지_크기가_20보다_크면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/members/by-reviews")
+                            .param("size", "21")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .characterEncoding(StandardCharsets.UTF_8))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("message").value(containsString("최대 20개까지 조회가능합니다.")));
+        }
+    }
+
+    @Nested
     class 프로필_정보_수정_시 {
 
         private final String accessToken = jwtTokenProvider.createAccessToken(1L, RoleType.ROLE_회원);

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -376,7 +376,6 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
                     10
             );
 
-
             assertThat(reviews).containsExactly(reviewB, reviewA);
         }
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #213

## 📝 작업 요약

리뷰 많은 순으로 회원 목록을 페이지 조회하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

전체 리뷰에 회원을 **조인**하여 회원을 기준으로 **그룹화** 시킨뒤 개수로 **정렬**하여 `offset` 기반 페이지 조회하는 기능입니다.
현재는 리뷰 개수가 반정규화 되어있지 않은 상태이기에 위와 같은 방법을 사용했는데, 혹시 더 좋은 방법이 있을까요?
팔로잉, 팔로워, 리뷰 수는 조만간 반정규화가 필요한 부분이라고 생각이 듭니다 😳

또한 offset 기반으로 동작하기에 no offset 기반으로 바꿀 수 없을까라는 고민을 해보았는데 당장 떠오르지 않았습니다.
offset을 하지 않고 해당 기능을 구현할 방법에 대해서도 리뷰 부탁드립니다!

추가로 적당한 URL이 떠오르지 않아서 현재는 `/v1/members/by-reviews`로 임의로 지정해두었는데,
이와 관련하여 의견 있다면 리뷰로 남겨주시면 감사합니다 :)

## 🌟 리뷰 요구 사항

> 15분
