### PR TITLE
Feature/#215 위도, 경도 범위에 해당하는 리뷰를 조회한다.

### DIFF
--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomService.java
@@ -31,6 +31,15 @@ public class ReviewCustomService {
     }
 
     @Transactional(readOnly = true)
+    public List<Review> getReviewsInMapBounds(
+            Long lastReviewId,
+            MapCoordinateBoundDto mapCoordinateBoundDto,
+            int pageSize
+    ) {
+        return reviewCustomRepository.findPaginationReviewsInMapBound(lastReviewId, mapCoordinateBoundDto, pageSize);
+    }
+
+    @Transactional(readOnly = true)
     public List<Review> getReviewsByMemberInMapBounds(
             Long memberId,
             Long lastReviewId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/application/ReviewService.java
@@ -117,6 +117,26 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
+    public ReviewPageResponse getReviewsInMapBounds(
+            Long lastReviewId,
+            MapCoordinateRequest mapCoordinateRequest,
+            DeviceCoordinateRequest deviceCoordinateRequest,
+            int pageSize,
+            LoginMember loginMember
+    ) {
+        Member viewer = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+
+        MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
+        List<Review> reviews = reviewCustomService.getReviewsInMapBounds(
+                lastReviewId,
+                mapCoordinateBoundDto,
+                pageSize
+        );
+        return convertToReviewPageResponse(viewer, reviews, deviceCoordinateRequest);
+    }
+
+    @Transactional(readOnly = true)
     public ReviewPageResponse getReviewsByMemberInMapBounds(
             Long memberId,
             Long lastReviewId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -32,7 +32,7 @@ public class ReviewCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public List<Review> findPaginationReviewsInMapBound (
+    public List<Review> findPaginationReviewsInMapBound(
             Long lastReviewId,
             MapCoordinateBoundDto mapCoordinateBoundDto,
             int pageSize

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepository.java
@@ -32,6 +32,25 @@ public class ReviewCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    public List<Review> findPaginationReviewsInMapBound (
+            Long lastReviewId,
+            MapCoordinateBoundDto mapCoordinateBoundDto,
+            int pageSize
+    ) {
+        return jpaQueryFactory.selectDistinct(review)
+                .from(review)
+                .innerJoin(review.store, store).fetchJoin()
+                .innerJoin(review.member, member).fetchJoin()
+                .innerJoin(store.category, category).fetchJoin()
+                .where(
+                        ltLastReviewId(lastReviewId),
+                        containsPolygon(mapCoordinateBoundDto)
+                )
+                .orderBy(review.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
     public List<Review> findPaginationReviewsHavingPhoto(Long lastReviewId, int pageSize) {
         return jpaQueryFactory.selectDistinct(review)
                 .from(review)

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewController.java
@@ -41,6 +41,30 @@ public class ReviewController implements ReviewControllerDocs {
 
     private final ReviewService reviewService;
 
+    @GetMapping("/bounds")
+    public ResponseEntity<ReviewPageResponse> getReviewsInMapBounds(
+            @RequestParam(name = "lastReviewId", required = false) @Positive(message = "리뷰 ID는 양수만 가능합니다.") Long lastReviewId,
+            @RequestParam(name = "x") BigDecimal x,
+            @RequestParam(name = "y") BigDecimal y,
+            @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
+            @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
+            @RequestParam(name = "deviceX") BigDecimal deviceX,
+            @RequestParam(name = "deviceY") BigDecimal deviceY,
+            @RequestParam(name = "pageSize", defaultValue = "10") @Positive(message = "페이지 크기는 양수만 가능합니다.") int pageSize,
+            @Auth LoginMember loginMember
+    ) {
+        MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
+        DeviceCoordinateRequest deviceCoordinateRequest = new DeviceCoordinateRequest(deviceX, deviceY);
+        ReviewPageResponse reviewPageResponse = reviewService.getReviewsInMapBounds(
+                lastReviewId,
+                mapCoordinateRequest,
+                deviceCoordinateRequest,
+                pageSize,
+                loginMember
+        );
+        return ResponseEntity.ok(reviewPageResponse);
+    }
+
     @GetMapping("/members")
     public ResponseEntity<ReviewPageResponse> getReviewsByMemberInMapBounds(
             @RequestParam(name = "memberId") @Positive(message = "멤버 ID는 양수만 가능합니다.") Long memberId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -76,6 +76,89 @@ public interface ReviewControllerDocs {
     );
 
     @Operation(
+            summary = "범위 기반 리뷰 목록 페이징 조회",
+            description = """
+                    지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
+                                        
+                    해당 범위에 속한 가게에 작성된 리뷰 목록을 조회하는 기능입니다.
+                                        
+                    디바이스 경도(deviceX), 디바이스 위도(deviceY)를 통해 디바이스와 가게 사이의 거리를 계산합니다.
+                                        
+                    조회 성능을 높이기 위해 NO OFFSET 페이징으로 구현하였기에 페이지 번호 대신 마지막 리뷰 ID를 요청값으로 받습니다.
+                                        
+                    첫 페이지 조회 시에는 마지막 리뷰 ID를 파라미터에 담지 않고 요청을 보내면 됩니다.
+                                        
+                    두번째 페이지 조회 부터는 이전 조회 응답에 담겨 있는 마지막 리뷰 ID를 파라미터로 넘겨주면
+                                        
+                    해당 리뷰 ID보다 작은, 다시 말해서 요청으로 보낸 리뷰 이전에 작성된 리뷰부터 조회하게 됩니다.
+                                        
+                    페이지 크기(응답할 리뷰 개수)는 파라미터로 보내지 않으면 기본적으로 10개로 동작하게 되어있습니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "리뷰 목록 범위 기반 페이징 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.리뷰 ID가 양수가 아닌 경우
+                                                        
+                            2.지도 중심 경도가 존재하지 않은 경우
+                                                        
+                            3.지도 중심 위도가 존재하지 않은 경우
+                                                        
+                            4.지도 경도 증가값이 존재하지 않은 경우
+                                                        
+                            5.지도 위도 증가값이 존재하지 않은 경우
+                                                        
+                            6.지도 경도 증가값이 0이상 양수가 아닌 경우
+                                                        
+                            7.지도 위도 증가값이 0이상 양수가 아닌 경우
+                                                        
+                            8.디바이스 경도가 존재하지 않은 경우
+                                                        
+                            9.디바이스 위도가 존재하지 않은 경우
+                                                        
+                            10.페이지 크기가 양수가 아닌 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<ReviewPageResponse> getReviewsInMapBounds(
+            @Parameter(description = "이전 조회의 마지막 리뷰 ID(첫 조회 시에는 파라미터 요청 X)", example = "1")
+            @Positive(message = "리뷰 ID는 양수만 가능합니다.")
+            Long lastReviewId,
+
+            @Parameter(description = "지도 중심 경도", example = "123.3636")
+            BigDecimal x,
+
+            @Parameter(description = "지도 중심 위도", example = "32.3636")
+            BigDecimal y,
+
+            @Parameter(description = "지도 경도 증가값", example = "3.1212")
+            @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaX,
+
+            @Parameter(description = "지도 위도 증가값", example = "3.1212")
+            @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaY,
+
+            @Parameter(description = "사용자 경도", example = "123.3636")
+            BigDecimal deviceX,
+
+            @Parameter(description = "사용자 위도", example = "32.3636")
+            BigDecimal deviceY,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @Positive(message = "페이지 크기는 양수만 가능합니다.")
+            int pageSize,
+
+            LoginMember loginMember
+    );
+
+    @Operation(
             summary = "리뷰 피드 조회",
             description = """
                     리뷰를 피드를 조회합니다.

--- a/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/review/presentation/ReviewControllerDocs.java
@@ -76,7 +76,7 @@ public interface ReviewControllerDocs {
     );
 
     @Operation(
-            summary = "범위 기반 리뷰 목록 페이징 조회",
+            summary = "위도, 경도 범위 기반 리뷰 목록 페이징 조회",
             description = """
                     지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
                                         

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomService.java
@@ -15,6 +15,11 @@ public class StoreCustomService {
     private final StoreCustomRepository storeCustomRepository;
 
     @Transactional(readOnly = true)
+    public List<Store> getStoresInMapBounds(MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return storeCustomRepository.findStoresByInMapBounds(mapCoordinateBoundDto);
+    }
+
+    @Transactional(readOnly = true)
     public List<Store> getStoresByMemberInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
         return storeCustomRepository.findStoresByMemberInMapBounds(memberId, mapCoordinateBoundDto);
     }

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/application/StoreService.java
@@ -85,6 +85,20 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
+    public StoreMapBoundResponses getStoresInMapBounds(
+            MapCoordinateRequest mapCoordinateRequest,
+            LoginMember loginMember
+    ) {
+        Member viewer = memberRepository.findById(loginMember.id())
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NOT_FOUND));
+
+        MapCoordinateBoundDto mapCoordinateBoundDto = convertToMapCoordinateBound(mapCoordinateRequest);
+        List<Store> stores = storeCustomService.getStoresInMapBounds(mapCoordinateBoundDto);
+
+        return convertToStoreMapBoundResponses(stores, viewer);
+    }
+
+    @Transactional(readOnly = true)
     public StoreMapBoundResponses getStoresByMemberInMapBounds(
             Long memberId,
             MapCoordinateRequest mapCoordinateRequest,

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepository.java
@@ -63,6 +63,17 @@ public class StoreCustomRepository {
         );
     }
 
+    public List<Store> findStoresByInMapBounds(MapCoordinateBoundDto mapCoordinateBoundDto) {
+        return jpaQueryFactory.selectDistinct(store)
+                .from(store)
+                .innerJoin(store.category, category).fetchJoin()
+                .innerJoin(review).on(
+                        review.store.eq(store)
+                )
+                .where(containsPolygon(mapCoordinateBoundDto))
+                .fetch();
+    }
+
     public List<Store> findStoresByMemberInMapBounds(Long memberId, MapCoordinateBoundDto mapCoordinateBoundDto) {
         return jpaQueryFactory.selectDistinct(store)
                 .from(store)

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreController.java
@@ -46,6 +46,20 @@ public class StoreController implements StoreControllerDocs {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/bounds")
+    public ResponseEntity<StoreMapBoundResponses> getStoresInMapBounds(
+            @RequestParam(name = "x") BigDecimal x,
+            @RequestParam(name = "y") BigDecimal y,
+            @RequestParam(name = "deltaX") @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaX,
+            @RequestParam(name = "deltaY") @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.") BigDecimal deltaY,
+            @Auth LoginMember loginMember
+    ) {
+        MapCoordinateRequest mapCoordinateRequest = new MapCoordinateRequest(x, y, deltaX, deltaY);
+        StoreMapBoundResponses storeMapBoundResponses =
+                storeService.getStoresInMapBounds(mapCoordinateRequest, loginMember);
+        return ResponseEntity.ok(storeMapBoundResponses);
+    }
+
     @GetMapping("/members")
     public ResponseEntity<StoreMapBoundResponses> getStoresByMemberInMapBounds(
             @RequestParam(name = "memberId") @Positive(message = "멤버 ID는 양수만 가능합니다.") Long memberId,

--- a/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
+++ b/src/main/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerDocs.java
@@ -86,6 +86,61 @@ public interface StoreControllerDocs {
     );
 
     @Operation(
+            summary = "위도, 경도 범위 내 존재하는 가게 목록 범위 조회",
+            description = """
+                    지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여
+                                        
+                    해당 범위에 속한 리뷰가 존재하는 가게 목록을 조회하는 기능입니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "리뷰가 존재하는 가게 목록 범위 기반 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            1.지도 중심 경도가 존재하지 않은 경우
+                                                        
+                            2.지도 중심 위도가 존재하지 않은 경우
+                                                        
+                            3.지도 경도 증가값이 존재하지 않은 경우
+                                                        
+                            4.지도 경도 증가값이 양수가 아닌 경우
+                                                        
+                            5.지도 위도 증가값이 존재하지 않은 경우
+                                                        
+                            6.지도 위도 증가값이 양수가 아닌 경우
+                            """,
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않은 사용자인 경우",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    ResponseEntity<StoreMapBoundResponses> getStoresInMapBounds(
+            @Parameter(description = "지도 중심 경도", example = "123.3636")
+            BigDecimal x,
+
+            @Parameter(description = "지도 중심 위도", example = "32.3636")
+            BigDecimal y,
+
+            @Parameter(description = "지도 경도 증가값", example = "3.1212")
+            @Positive(message = "경도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaX,
+
+            @Parameter(description = "지도 위도 증가값", example = "3.1212")
+            @Positive(message = "위도 증가값은 0이상의 양수만 가능합니다.")
+            BigDecimal deltaY,
+
+            LoginMember loginMember
+    );
+
+
+    @Operation(
             summary = "멤버 리뷰가 존재하는 가게 목록 범위 기반 조회",
             description = """
                     지도 중심의 경도(x), 위도(y)와 경도 증가값(deltaX), 위도 증가값(deltaY)을 통해 사각형 범위를 생성하여

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/application/ReviewCustomServiceTest.java
@@ -44,6 +44,29 @@ class ReviewCustomServiceTest extends IntegrationTest {
     }
 
     @Test
+    void 모든_리뷰_목록을_범위를_통해_조회한다() {
+        Member writerA = memberTestPersister.builder().save();
+        Member writerB = memberTestPersister.builder().save();
+        Store store = storeTestPersister.builder().save();
+        Review reviewA = reviewTestPersister.builder().member(writerA).store(store).save();
+        Review reviewB = reviewTestPersister.builder().member(writerB).store(store).save();
+        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                BigDecimal.valueOf(3),
+                BigDecimal.valueOf(3)
+        );
+
+        List<Review> result = reviewCustomService.getReviewsInMapBounds(
+                null,
+                mapCoordinateBoundDto,
+                10
+        );
+
+        assertThat(result).containsExactly(reviewB, reviewA);
+    }
+
+    @Test
     void 멤버_리뷰_목록을_범위를_통해_조회한다() {
         Member writer = memberTestPersister.builder().save();
         Store store = storeTestPersister.builder().save();

--- a/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/review/persistence/ReviewCustomRepositoryTest.java
@@ -52,6 +52,130 @@ class ReviewCustomRepositoryTest extends PersistenceTest {
     }
 
     @Nested
+    class 폴리곤_범위_내_모든_리뷰_조회_시 {
+
+        @Test
+        void 폴리곤_영역에_경도와_위도가_속한_가게의_리뷰를_조회한다() {
+            Member writerA = memberTestPersister.builder().save();
+            Member writerB = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().store(store).member(writerA).save();
+            Review reviewB = reviewTestPersister.builder().store(store).member(writerB).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 0.9),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 0.9),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsInMapBound(
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).containsExactly(reviewB, reviewA);
+        }
+
+        @Test
+        void 폴리곤_영역에_경도와_위도가_속하지_않는_가게의_리뷰는_조회하지_않는다() {
+            Member writer = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().store(store).member(writer).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsInMapBound(
+                    null,
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 마지막_리뷰ID가_NULL이_아닐때_마지막_리뷰ID보다_작은_리뷰는_조회한다() {
+            Member writerA = memberTestPersister.builder().save();
+            Member writerB = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().store(store).member(writerA).save();
+            Review reviewB = reviewTestPersister.builder().store(store).member(writerB).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 0.9),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 0.9),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsInMapBound(
+                    reviewB.getId(),
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertSoftly(softly -> {
+                softly.assertThat(result).doesNotContain(reviewB);
+                softly.assertThat(result).containsExactly(reviewA);
+            });
+        }
+
+        @Test
+        void 마지막_리뷰ID가_NULL이_아닐때_마지막_리뷰ID보다_큰_리뷰는_조회하지_않는다() {
+            Member writerA = memberTestPersister.builder().save();
+            Member writerB = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().store(store).member(writerA).save();
+            Review reviewB = reviewTestPersister.builder().store(store).member(writerB).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 0.9),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 0.9),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsInMapBound(
+                    reviewA.getId(),
+                    mapCoordinateBoundDto,
+                    10
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 페이지_크기만큼_조회한다() {
+            Member writerA = memberTestPersister.builder().save();
+            Member writerB = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            Review reviewA = reviewTestPersister.builder().store(store).member(writerA).save();
+            Review reviewB = reviewTestPersister.builder().store(store).member(writerB).save();
+            Review reviewC = reviewTestPersister.builder().store(store).member(writerB).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 0.9),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 0.9),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Review> result = reviewCustomRepository.findPaginationReviewsInMapBound(
+                    null,
+                    mapCoordinateBoundDto,
+                    2
+            );
+
+            assertSoftly(sofly -> {
+                sofly.assertThat(result).doesNotContain(reviewA);
+                sofly.assertThat(result).containsExactly(reviewC, reviewB);
+            });
+        }
+    }
+
+    @Nested
     class 사진이_포함된_리뷰_조회_시 {
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomServiceTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/application/StoreCustomServiceTest.java
@@ -19,6 +19,22 @@ class StoreCustomServiceTest extends IntegrationTest {
     private StoreCustomService storeCustomService;
 
     @Test
+    void 위도_경도와_폴리곤_영역에_해당하는_가게_목록을_조회한다() {
+        Store store = storeTestPersister.builder().save();
+        reviewTestPersister.builder().store(store).save();
+        MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getX()),
+                BigDecimal.valueOf(store.getAddress().getCoordinate().getY()),
+                BigDecimal.valueOf(1),
+                BigDecimal.valueOf(1)
+        );
+
+        List<Store> stores = storeCustomService.getStoresInMapBounds(mapCoordinateBoundDto);
+
+        assertThat(stores).containsExactly(store);
+    }
+
+    @Test
     void 멤버가_작성한_리뷰가_존재하는_가게_목록을_범위를_통해_조회한다() {
         Member member = memberTestPersister.builder().save();
         Store store = storeTestPersister.builder().save();

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/persistence/StoreCustomRepositoryTest.java
@@ -68,6 +68,48 @@ class StoreCustomRepositoryTest extends PersistenceTest {
     }
 
     @Nested
+    class 위도_경도와_폴리곤_영역에_해당하는_가게_목록_범위_조회_시 {
+
+        @Test
+        void 영역에_포함된_가게는_조회한다() {
+            Member member = memberTestPersister.builder().save();
+            Store storeA = storeTestPersister.builder().save();
+            Store storeB = storeTestPersister.builder().address(storeA.getAddress()).save();
+            reviewTestPersister.builder().member(member).store(storeA).save();
+            reviewTestPersister.builder().member(member).store(storeB).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(storeA.getAddress().getCoordinate().getX() + 0.5),
+                    BigDecimal.valueOf(storeA.getAddress().getCoordinate().getY() + 0.5),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByInMapBounds(mapCoordinateBoundDto);
+
+            assertThat(result).containsExactly(storeA, storeB);
+        }
+
+        @Test
+        void 영역에_포함되지_않는_가게는_조회되지_않는다() {
+            Member member = memberTestPersister.builder().save();
+            Store store = storeTestPersister.builder().save();
+            reviewTestPersister.builder().member(member).store(store).save();
+            MapCoordinateBoundDto mapCoordinateBoundDto = MapCoordinateBoundDto.of(
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getX() + 10),
+                    BigDecimal.valueOf(store.getAddress().getCoordinate().getY() + 10),
+                    BigDecimal.valueOf(1),
+                    BigDecimal.valueOf(1)
+            );
+
+            List<Store> result =
+                    storeCustomRepository.findStoresByInMapBounds(mapCoordinateBoundDto);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
     class 멤버의_리뷰가_작성된_가게_목록_범위_조회_시 {
 
         @Test

--- a/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
+++ b/src/test/java/org/dinosaur/foodbowl/domain/store/presentation/StoreControllerTest.java
@@ -217,6 +217,122 @@ class StoreControllerTest extends PresentationTest {
     }
 
     @Nested
+    class 위도_경도와_폴리곤_범위에_해당하는_가게_조회_시 {
+
+        private final String accessToken = jwtTokenProvider.createAccessToken(1L, ROLE_회원);
+
+        @Test
+        void 정상적인_요청이라면_200_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+            StoreMapBoundResponses response = mockStoreMapBoundResponses();
+            given(storeService.getStoresInMapBounds(
+                    any(MapCoordinateRequest.class),
+                    any(LoginMember.class))
+            ).willReturn(response);
+
+            MvcResult mvcResult = mockMvc.perform(get("/v1/stores/bounds")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.1212")
+                            .param("deltaY", "3.1212"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            String jsonResponse = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+            StoreMapBoundResponses result = objectMapper.readValue(jsonResponse, StoreMapBoundResponses.class);
+            assertThat(result).usingRecursiveComparison().isEqualTo(response);
+        }
+
+        @Test
+        void 경도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/bounds")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 위도가_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/bounds")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 경도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/bounds")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaY", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 위도_증가값이_존재하지_않으면_400_응답을_반환한다() throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/bounds")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 경도_증가값이_0이상의_양수가_아니라면_400_응답을_반환한다(String deltaX) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/bounds")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", deltaX)
+                            .param("deltaY", "3.12"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("경도 증가값은 0이상의 양수만 가능합니다.")));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-1", "0"})
+        void 위도_증가값이_0이상의_양수가_아니라면_400_응답을_반환한다(String deltaY) throws Exception {
+            mockingAuthMemberInResolver();
+
+            mockMvc.perform(get("/v1/stores/bounds")
+                            .header(AUTHORIZATION, BEARER + accessToken)
+                            .param("x", "123.3636")
+                            .param("y", "32.3636")
+                            .param("deltaX", "3.12")
+                            .param("deltaY", deltaY))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("errorCode").value("CLIENT-101"))
+                    .andExpect(jsonPath("$.message").value(containsString("위도 증가값은 0이상의 양수만 가능합니다.")));
+        }
+    }
+
+    @Nested
     class 멤버의_리뷰가_존재하는_가게_목록_조회_시 {
 
         private final String accessToken = jwtTokenProvider.createAccessToken(1L, ROLE_회원);


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #215 

## 📝 작업 요약

위도, 경도 범위 내에 해당하는 모든 사용자의 리뷰 및 가게 목록을 조회합니다.

## 🔎 작업 상세 설명

기존의 리뷰, 가게 조회 로직에서 (작성자 or 팔로워) 조건 문만 삭제되었다고 생각하시면 됩니다 !

## 🌟 리뷰 요구 사항
기존 기능과 거의 동일하므로 크게 어려운 사항은 없는 것 같아요 :D

> 10분
